### PR TITLE
feat(indicators): 125-indicator calc library (WS-EXTRA-IND)

### DIFF
--- a/docs/extra-indicators/INDICATOR-SCHOOLS-INVENTORY.md
+++ b/docs/extra-indicators/INDICATOR-SCHOOLS-INVENTORY.md
@@ -1,0 +1,380 @@
+# Technical-Analysis Schools & World Indicator Inventory
+
+**Purpose:** exhaustive prior-art catalog of the *schools* of technical stock/futures trading and the *indicators / tools* each school uses. This is the scoping anchor for the `extra-indicators` workstream. Next steps (which to implement, parametrize, backtest) will be decided on top of this.
+
+**Legend:** `[calc]` = computed indicator (formula, implementable). `[method]` = pattern/discretionary method (not a single formula). `[data]` = external data feed needed. Overlaps noted with → .
+
+---
+
+## 1. Trend-Following / Moving-Average school
+The oldest quant school: smooth price, trade in the direction of the smoothed line.
+
+**Moving averages (smoothers):**
+- Simple MA (SMA) `[calc]`
+- Exponential MA (EMA) `[calc]`
+- Weighted MA (WMA) `[calc]`
+- Wilder's Smoothing / Smoothed MA (RMA / SMMA) `[calc]`
+- Double EMA (DEMA) `[calc]`
+- Triple EMA (TEMA) `[calc]`
+- Triangular MA (TMA) `[calc]`
+- Hull MA (HMA) `[calc]`
+- Kaufman Adaptive MA (KAMA) `[calc]`
+- MESA Adaptive MA (MAMA/FAMA, Ehlers) `[calc]`
+- Fractal Adaptive MA (FRAMA, Ehlers) `[calc]`
+- Variable Index Dynamic Average (VIDYA, Chande) `[calc]`
+- Arnaud Legoux MA (ALMA) `[calc]`
+- Zero-Lag EMA (ZLEMA) `[calc]`
+- Least-Squares / Linear-Regression MA (LSMA) `[calc]`
+- Jurik MA (JMA) `[calc]`
+- T3 (Tillson) `[calc]`
+- McGinley Dynamic `[calc]`
+- Sine-Weighted MA `[calc]`
+- Volume-Weighted MA (VWMA) `[calc]` → Volume
+- Elastic Volume-Weighted MA (eVWMA) `[calc]` → Volume
+- Guppy Multiple MA (GMMA, ribbon of 12) `[calc]`
+- MA Ribbon / MA Envelopes / Displaced MA `[calc]`
+- Ehlers filters: SuperSmoother, Roofing, Bandpass, Butterworth `[calc]` → Cycles
+
+**Trend / directional indicators:**
+- MACD + MACD Histogram `[calc]`
+- Percentage Price Oscillator (PPO) `[calc]`
+- Absolute Price Oscillator / Price Oscillator `[calc]`
+- ADX / DMI (+DI, −DI, ADXR; Wilder) `[calc]`
+- Aroon + Aroon Oscillator `[calc]`
+- Parabolic SAR (Wilder) `[calc]`
+- Vortex Indicator (VI+ / VI−) `[calc]`
+- Supertrend `[calc]`
+- TRIX (triple-smoothed ROC) `[calc]`
+- Know Sure Thing (KST, Pring) `[calc]`
+- Coppock Curve `[calc]`
+- Schaff Trend Cycle `[calc]` → Cycles
+- Detrended Price Oscillator (DPO) `[calc]`
+- Trend Intensity Index `[calc]`
+- Linear Regression Slope / Curve / Channel `[calc]` → Stat
+- Chande Kroll Stop / Chandelier Exit (ATR trailing) `[calc]`
+- QQE (Quantitative Qualitative Estimation) `[calc]`
+- Gann HiLo Activator `[calc]` → Gann
+- Elder Ray (Bull/Bear Power), Elder Impulse System `[calc]`
+- Accumulation Swing Index (ASI) + Swing Index (Wilder) `[calc]`
+- EXPMA / DMA / BBI (Asian-retail trend set) `[calc]`
+
+---
+
+## 2. Momentum / Oscillator school
+Measure speed & overbought/oversold, hunt divergences.
+
+- Relative Strength Index (RSI, Wilder) `[calc]`
+- Cutler's RSI, Connors RSI, Laguerre RSI (Ehlers) `[calc]`
+- Stochastic Oscillator (fast / slow / full; Lane) `[calc]`
+- Stochastic RSI `[calc]`
+- KDJ (Asian stochastic variant) `[calc]`
+- Williams %R `[calc]`
+- Commodity Channel Index (CCI, Lambert) `[calc]`
+- Momentum (n-period price change) `[calc]`
+- Rate of Change (ROC / Price ROC) `[calc]`
+- Chande Momentum Oscillator (CMO) `[calc]`
+- Ultimate Oscillator (Williams) `[calc]`
+- True Strength Index (TSI) `[calc]`
+- Relative Vigor Index (RVI/RVGI) `[calc]`
+- Stochastic Momentum Index (SMI, Blau) `[calc]`
+- Relative Momentum Index (RMI) `[calc]`
+- Dynamic Momentum Index (DMI, Chande) `[calc]`
+- Fisher Transform (Ehlers) `[calc]`
+- Derivative Oscillator, Ergodic Oscillator `[calc]`
+- Wave Trend Oscillator (LazyBear) `[calc]`
+- Disparity Index `[calc]`
+- Balance of Power `[calc]`
+- Pretty Good Oscillator `[calc]`
+- Awesome / Accelerator Oscillator (Bill Williams) `[calc]` → Bill Williams
+- Psychological Line (PSY), BIAS (Asian-retail momentum) `[calc]`
+
+---
+
+## 3. Volatility school
+Trade the width of the range / bands.
+
+- Bollinger Bands + %B + BandWidth (Bollinger) `[calc]`
+- Average True Range (ATR) + Normalized ATR (Wilder) `[calc]`
+- Keltner Channels `[calc]`
+- Donchian Channels `[calc]` → Breakout
+- STARC Bands, Acceleration Bands, Projection Bands `[calc]`
+- Standard Deviation / rolling variance `[calc]` → Stat
+- Historical (close-to-close) Volatility `[calc]`
+- Parkinson / Garman-Klass / Rogers-Satchell / Yang-Zhang range estimators `[calc]` → Quant
+- Chaikin Volatility `[calc]`
+- Relative Volatility Index (Dorsey) `[calc]`
+- Mass Index (Dorsey) `[calc]`
+- Ulcer Index `[calc]`
+- Choppiness Index `[calc]`
+- Volatility Ratio / Volatility Stop `[calc]`
+- TTM Squeeze / Bollinger-in-Keltner squeeze (Carter) `[calc]`
+- GARCH / EWMA conditional volatility `[calc]` → Quant
+- VIX, VVIX, SKEW, term structure `[data]` → Sentiment
+
+---
+
+## 4. Volume / Money-Flow school
+Confirm price with participation.
+
+- On-Balance Volume (OBV, Granville) `[calc]`
+- Accumulation/Distribution Line (Williams/Chaikin) `[calc]`
+- Chaikin Money Flow (CMF) `[calc]`
+- Chaikin Oscillator `[calc]`
+- Money Flow Index (MFI) `[calc]` → Momentum
+- Price Volume Trend (PVT) `[calc]`
+- Volume Price Trend / Trade Volume Index (TVI) `[calc]`
+- Negative & Positive Volume Index (NVI / PVI) `[calc]`
+- Ease of Movement (EOM/EMV, Arms) `[calc]`
+- Force Index (Elder) `[calc]`
+- Klinger Volume Oscillator `[calc]`
+- Volume Oscillator / Volume ROC `[calc]`
+- Volume Zone Oscillator (VZO) `[calc]`
+- Demand Index (Sibbet) `[calc]`
+- Twiggs Money Flow `[calc]`
+- Williams Variable Accumulation/Distribution (WVAD) `[calc]`
+- Market Facilitation Index (BW MFI, Bill Williams) `[calc]`
+- Better Volume `[calc]`
+- Volume-Weighted Average Price (VWAP) + Anchored VWAP + VWAP bands `[calc]`
+- Volume Profile / Volume-by-Price (VPOC, HVN/LVN) `[method]` → Market Profile
+- Volume Ratio (VR, Asian-retail) `[calc]`
+
+---
+
+## 5. Ichimoku Kinko Hyo school (Japanese)
+A single self-contained system.
+- Tenkan-sen (conversion line) `[calc]`
+- Kijun-sen (base line) `[calc]`
+- Senkou Span A & B → Kumo (cloud) `[calc]`
+- Chikou Span (lagging span) `[calc]`
+- Cloud thickness / twist / flat-Kijun magnets `[method]`
+
+---
+
+## 6. Candlestick / Japanese price-action school
+Single- & multi-bar reversal/continuation shapes.
+- Single: Doji (+ dragonfly/gravestone/long-legged), Hammer, Hanging Man, Shooting Star, Inverted Hammer, Marubozu, Spinning Top `[method]`
+- Two-bar: Bullish/Bearish Engulfing, Harami (+ cross), Piercing, Dark Cloud Cover, Tweezer top/bottom, Kicker `[method]`
+- Three-bar: Morning/Evening Star, Three White Soldiers, Three Black Crows, Three Inside/Outside, Abandoned Baby `[method]`
+- Continuation: Rising/Falling Three Methods, Tasuki, Windows (gaps) `[method]`
+- Derived charts: Heikin-Ashi `[calc]`, Candle Volume `[calc]`
+
+---
+
+## 7. Classical charting / Dow Theory school (Edwards & Magee)
+- Dow Theory tenets (trend confirmation, phases) `[method]`
+- Support / Resistance, Trendlines, Channels `[method]`
+- Reversals: Head & Shoulders (+ inverse), Double/Triple Top & Bottom, Rounding, Diamond `[method]`
+- Continuation: Triangles (asc/desc/symmetrical), Flags, Pennants, Wedges, Rectangles, Cup & Handle, Broadening `[method]`
+- Gaps: common / breakaway / runaway / exhaustion / island `[method]`
+
+---
+
+## 8. Pivot / Level-calculation school
+Formula-derived intraday support/resistance.
+- Floor (Classic) Pivots: PP, R1–R3, S1–S3 `[calc]`
+- Woodie's Pivots `[calc]`
+- Camarilla Pivots `[calc]`
+- Fibonacci Pivots `[calc]`
+- DeMark Pivots `[calc]` → DeMark
+- Central Pivot Range (CPR) `[calc]`
+
+---
+
+## 9. Fibonacci / Harmonic-pattern school
+- Fibonacci retracements / extensions / projections `[calc]`
+- Fibonacci fans / arcs / time zones / channels / spiral `[calc]`
+- Fibonacci clusters / confluence `[method]`
+- Harmonic patterns: ABCD, Gartley, Butterfly, Bat (+ Alt Bat), Crab (+ Deep Crab), Cypher, Shark, Three Drives, 5-0 `[method]`
+
+---
+
+## 10. Elliott Wave school
+- Impulse (1-2-3-4-5) & corrective (A-B-C) counts `[method]`
+- Diagonals, triangles, WXY/WXYXZ combinations `[method]`
+- Wave-degree labeling; Fibonacci ratio targets within waves `[method]`
+- Elliott Wave Oscillator (5/34 momentum proxy) `[calc]`
+
+---
+
+## 11. Gann school (W.D. Gann)
+- Gann Angles (1×1, 2×1, 1×2, …) & Gann Fan `[calc]`
+- Square of 9 / Square of 144 / Hexagon chart `[calc]`
+- Gann Box, Gann retracements (1/8 & 1/3 divisions) `[calc]`
+- Time cycles / anniversary & "natural" dates `[method]`
+- Gann HiLo Activator `[calc]` → Trend
+
+---
+
+## 12. Cycle / Spectral / Ehlers DSP school (Hurst, Ehlers)
+Treat price as signal, extract dominant cycle.
+- Hurst nominal cycle model / cyclic RSI `[method]`
+- Fourier / spectral analysis, MESA (max-entropy) `[calc]`
+- Hilbert Transform: dominant cycle period, phase, trend mode (Ehlers) `[calc]`
+- Sine Wave & Even Better Sinewave (Ehlers) `[calc]`
+- Cyber Cycle, Center-of-Gravity Oscillator (Ehlers) `[calc]`
+- Instantaneous Trendline, Cycle Period (Ehlers) `[calc]`
+- Bandpass / Roofing / SuperSmoother filters (Ehlers) `[calc]`
+- Schaff Trend Cycle `[calc]`
+- Empirical Mode Decomposition (EMD) `[calc]`
+- Hurst exponent (R/S analysis), DFA — persistence/mean-reversion measure `[calc]` → Quant
+
+---
+
+## 13. Wyckoff school
+Supply/demand via "Composite Man" logic.
+- Accumulation / Distribution schematics & phases (A–E) `[method]`
+- Events: Selling/Buying Climax, Automatic Rally, Secondary Test, Spring, Upthrust (UTAD), SOS/SOW `[method]`
+- Effort vs Result (price/volume) `[method]`
+- Wyckoff Wave, Optimism-Pessimism (O-P) Index, Force Index `[calc]`
+- Relative Strength (vs market), Point & Figure counts `[method]` → P&F
+
+---
+
+## 14. Market Profile / Auction-Market-Theory school (Steidlmayer)
+- TPO (Time-Price-Opportunity) profile `[method]`
+- Point of Control (POC) / Naked POC `[calc]`
+- Value Area (VAH / VAL, ~70%) `[calc]`
+- Initial Balance (IB) `[calc]`
+- Profile shapes (b / P / D / balanced) `[method]`
+- Single prints, excess, poor highs/lows `[method]`
+- Composite / merged profiles `[method]`
+- Volume Profile (VPOC, HVN/LVN) `[calc]` → Volume
+
+---
+
+## 15. Order-Flow / Market-Microstructure school
+Sub-bar, needs tick/DOM data.
+- Depth of Market (DOM) / order-book ladder `[data]`
+- Footprint / bid-ask cluster charts `[data]`
+- Cumulative Volume Delta (CVD) + delta divergence `[calc]`
+- Volume Delta per bar `[calc]`
+- Time & Sales (tape reading), speed of tape `[data]`
+- Absorption / Exhaustion / Iceberg detection `[method]`
+- Order-Flow Imbalance, Trade Imbalance `[calc]`
+- Liquidity heatmaps `[data]`
+- VPIN (Volume-synchronized Prob. of Informed Trading) `[calc]` → Quant
+
+---
+
+## 16. DeMark school (Tom DeMark)
+- TD Sequential (Setup 1-9 + Countdown 1-13) `[calc]`
+- TD Combo `[calc]`
+- TD Lines (auto trendlines) `[calc]`
+- TD Range Expansion Index (REI) `[calc]`
+- TD DeMarker I / II `[calc]`
+- TDST support/resistance levels `[calc]`
+- TD Pressure, TD Differential, TD Camouflage `[calc]`
+
+---
+
+## 17. Point & Figure school
+- P&F chart (X/O columns), box size & reversal `[calc]`
+- Patterns: double/triple top & bottom breakouts, bullish/bearish signal, catapult `[method]`
+- Price objectives: horizontal & vertical counts `[calc]`
+- Bullish Percent Index (P&F breadth) `[calc]` → Breadth
+
+---
+
+## 18. Alternative-charting school (price/volume/time re-bucketing)
+- Renko `[calc]`
+- Kagi `[calc]`
+- Three-Line Break `[calc]`
+- Range bars / Tick charts / Volume bars `[calc]`
+- Heikin-Ashi `[calc]` → Candlestick
+
+---
+
+## 19. Bill Williams / Chaos-Theory school
+- Alligator (3 displaced smoothed MAs) `[calc]`
+- Fractals (5-bar) `[calc]`
+- Awesome Oscillator (AO) `[calc]`
+- Accelerator/Decelerator Oscillator (AC) `[calc]`
+- Gator Oscillator `[calc]`
+- Market Facilitation Index `[calc]` → Volume
+- "Zone" & "Wiseman" trade logic `[method]`
+
+---
+
+## 20. Breadth / Market-Internals school
+Index-level, needs constituent data.
+- Advance/Decline Line & Ratio `[data]`
+- McClellan Oscillator & Summation Index `[data]`
+- TRIN / Arms Index `[data]`
+- TICK, TIKI `[data]`
+- New Highs − New Lows / High-Low Index `[data]`
+- % of stocks above 50/200-day MA `[data]`
+- Bullish Percent Index `[data]`
+- Up/Down Volume & Volume ratio `[data]`
+- Absolute Breadth Index, Hindenburg Omen, Zweig Breadth Thrust `[data]`
+
+---
+
+## 21. Sentiment / Contrarian & Positioning school
+- Put/Call Ratio `[data]`
+- VIX / VVIX / SKEW / term structure `[data]` → Volatility
+- Commitments of Traders (COT) positioning `[data]`
+- AAII survey, Investors Intelligence Bull/Bear, NAAIM Exposure `[data]`
+- CNN Fear & Greed Index `[data]`
+- Short interest / short ratio, margin debt, insider transactions, fund flows `[data]`
+
+---
+
+## 22. Intermarket / Relative-Strength / Rotation school (Murphy)
+- Comparative Relative Strength (ratio charts, e.g. SPX/Gold) `[calc]`
+- Mansfield RS, Dorsey Relative Strength `[calc]`
+- Relative Rotation Graphs (RRG: RS-Ratio & RS-Momentum) `[calc]`
+- Sector-rotation / business-cycle models `[method]`
+- Cross-asset correlation matrices; yield-curve & spread signals `[calc]` `[data]`
+- IBD/Minervini RS Rating (percentile rank) `[calc]`
+- Alpha / Beta vs benchmark `[calc]` → Quant
+
+---
+
+## 23. Statistical / Quant / Mean-Reversion school
+- Z-score / rolling standardization `[calc]`
+- Linear regression, regression channels (Raff), slope/R² `[calc]`
+- Kalman filter (adaptive trend) `[calc]`
+- Cointegration & pairs spread, ADF stationarity test `[calc]`
+- Ornstein-Uhlenbeck fit, half-life of mean reversion `[calc]`
+- Autocorrelation / partial autocorrelation `[calc]`
+- Hurst exponent / fractal dimension `[calc]` → Cycles
+- Principal Component Analysis, factor exposures `[calc]`
+- Rolling correlation / beta `[calc]`
+- Performance stats used as filters: Sharpe, Sortino, Calmar `[calc]`
+- ML feature families (lagged returns, rolling moments, entropy, wavelets) `[calc]`
+
+---
+
+## 24. Median-Line / Andrews school
+- Andrews Pitchfork (median line + parallels) `[calc]`
+- Schiff & Modified Schiff Pitchforks `[calc]`
+- Reaction/warning lines, sliding parallels `[calc]`
+
+---
+
+## 25. Smart-Money-Concepts / ICT school (modern price-action)
+- Market Structure: Break of Structure (BOS), Change of Character (CHoCH) `[method]`
+- Order Blocks (+ Breaker & Mitigation blocks) `[method]`
+- Fair Value Gaps (FVG) / Imbalances `[calc]`  ← *(note: you already have a gold-FVG result on file)*
+- Liquidity pools & sweeps (buy-side/sell-side), stop hunts, inducement `[method]`
+- Premium/Discount zones, Optimal Trade Entry (OTE, Fib-based) `[method]`
+- Displacement, Killzones (session-timing) `[method]`
+
+---
+
+## 26. Seasonality / Calendar-effect school
+- Monthly & day-of-week seasonality, turn-of-month `[calc]`
+- "Sell in May", Santa Claus rally, January effect `[method]`
+- Presidential / 4-year & decennial cycles `[method]`
+- Holiday & options-expiration (OPEX) effects `[method]`
+
+---
+
+## Cross-cutting notes
+- **Asian-retail TA bundle** (very common on Chinese/Korean platforms) reuses many above under local names: KDJ, MACD, BOLL, BIAS, PSY, VR, WR, CCI, DMA, TRIX, EXPMA, BBI, DMI, WVAD, ASI, BRAR, CR, OBOS.
+- **"Indicator" vs "method":** roughly half of these schools trade *patterns/structure* (`[method]`) not formulas — implementable only as heuristic detectors, not one-line calcs.
+- **Data-gated:** breadth, sentiment, intermarket, and order-flow schools need feeds beyond OHLCV (`[data]`) — relevant to what we can realistically add to the current engine.
+
+---
+
+*Compiled as the prior-art pass for `extra-indicators`. Awaiting direction on which schools/indicators to prioritize, parametrize, and backtest.*

--- a/docs/superpowers/plans/2026-07-25-calc-indicators-library.md
+++ b/docs/superpowers/plans/2026-07-25-calc-indicators-library.md
@@ -1,0 +1,629 @@
+# Calc-Indicator Library Expansion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ~125 faithful, single-OHLCV "calc" technical indicators as confirm/veto votes, auto-wired into backtester, dashboard, and optimizer.
+
+**Architecture:** Each indicator = a vectorized numpy primitive + a thin `Indicator`/`StanceIndicator` subclass producing per-bar confirm/veto directions + one `REGISTRY`/`SCHEMA` entry. Because `fast_engine` and `engine.py` both consume the shared folded vote mask, and the optimizer loops the whole `REGISTRY`, an indicator written once auto-propagates to all three surfaces with structural parity.
+
+**Tech Stack:** Python 3, numpy, pandas (fixtures/oracle only), pytest. TA-Lib + pandas-ta are **dev/test-only** oracles — never imported at runtime.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-calc-indicators-library-design.md`
+
+## Global Constraints
+
+- **Working dir:** `subprojects/Parametric-Indicators/` (the project root for this work). All paths below are relative to it unless noted.
+- **No silent defaults.** Never `params.get(k, default)` to substitute a *strategy* value silently; missing required params raise `IndicatorParamError`. (Convenience defaults matching the SCHEMA default are allowed for optional tuning params, mirroring existing classes.)
+- **No runtime TA-Lib.** TA-Lib / pandas-ta appear only in `requirements-dev.txt` and `tests/`/`scripts/`. A runtime `import talib` is a plan violation.
+- **Parity is mandatory.** After any batch, `optimize/test_indicator_parity.py` must pass for every registered key.
+- **Causal only.** No indicator may read `x[i+1]` for bar `i`. Warm-up bars vote NEUTRAL (handled by `base.Indicator.vote`).
+- **One class + one key per named indicator** (families NOT collapsed) — approved 2026-07-25.
+- **Branch cadence:** one feature branch per school phase (`feat/extra-ind-<school>`) → tests + parity green → merge to `dev`. Commit after every task.
+- **Vote-rule conventions** (defined in Task F2, used throughout):
+  - *Stance* indicator → `votes.stance_directions(stance)` where `stance ∈ {+1,-1,0}`.
+  - *Zone* indicator → `votes.band_directions(v, lower, upper, mid)` (mean-reversion zones around `mid`).
+  - *Magnitude veto* (unbounded vol/quant) → `votes.magnitude_veto(value, ref, threshold)`: veto BOTH sides where `value/ref < threshold` (low-activity chop veto; the box strategy is vol-seeking).
+  - *Bounded veto* (e.g. choppiness, ADX) → veto BOTH sides on the indicator's natural threshold.
+
+---
+
+## PHASE F — Framework (do first; blocks all school phases)
+
+### Task F1: Per-school registry aggregation
+
+Refactor `library.py` so schools live in their own modules and merge into `REGISTRY`/`SCHEMA`. This keeps `library.py` from ballooning to 125 classes.
+
+**Files:**
+- Create: `indicators/calc/__init__.py` (empty package marker)
+- Create: `indicators/lib_ma.py`, `indicators/lib_trend.py`, `indicators/lib_osc.py`, `indicators/lib_vol.py`, `indicators/lib_volume.py`, `indicators/lib_levels.py`, `indicators/lib_bw.py`, `indicators/lib_quant.py` — each starts as: `CLASSES = ()` and `SCHEMA = {}`.
+- Modify: `indicators/library.py` (REGISTRY/SCHEMA construction, ~314-378)
+- Test: `indicators/test_registry_merge.py`
+
+**Interfaces:**
+- Produces: each `lib_<school>` module exports `CLASSES: tuple[type[Indicator], ...]` and `SCHEMA: dict[str, dict]`. `library.REGISTRY` and `library.SCHEMA` include every school module's contributions plus the existing built-ins.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# indicators/test_registry_merge.py
+import sys; from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from indicators import library
+
+def test_every_registry_key_has_schema_and_vice_versa():
+    assert set(library.REGISTRY) == set(library.SCHEMA), (
+        set(library.REGISTRY) ^ set(library.SCHEMA))
+
+def test_school_modules_merge_in():
+    # built-ins still present after refactor
+    for k in ("ema_trend", "rsi", "adx"):
+        assert k in library.REGISTRY and k in library.SCHEMA
+```
+
+- [ ] **Step 2: Run to verify current state**
+
+Run: `pytest indicators/test_registry_merge.py -v`
+Expected: PASS for built-ins (guards the refactor doesn't drop them).
+
+- [ ] **Step 3: Refactor `library.py` REGISTRY/SCHEMA to merge school modules**
+
+```python
+# library.py — replace the REGISTRY = {...} and after SCHEMA = {...} literal blocks
+from . import lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant
+_SCHOOLS = (lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant)
+
+_BUILTINS = (EMATrend, SMATrend, MACD, VWAPTrend, KeltnerTrend, OBVTrend, CCIBreakout,
+             RSIZone, StochasticZone, MFIZone, BollingerVeto, ADXVeto,
+             StructureTrend, OrderBlock, FVGConfirm, IFVGConfirm, BreakerBlock, CISDConfirm)
+REGISTRY = {c.key: c for c in (*_BUILTINS, *(c for m in _SCHOOLS for c in m.CLASSES))}
+# SCHEMA literal for built-ins stays; then merge school schemas:
+for _m in _SCHOOLS:
+    for _k, _v in _m.SCHEMA.items():
+        if _k in SCHEMA:
+            raise KeyError(f"duplicate indicator key {_k!r}")
+        SCHEMA[_k] = _v
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `pytest indicators/test_registry_merge.py indicators/test_runner_confirm_count.py -v`
+Expected: PASS (built-ins intact, empty school modules merge as no-ops).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add indicators/calc/__init__.py indicators/lib_*.py indicators/library.py indicators/test_registry_merge.py
+git commit -m "refactor(indicators): per-school registry aggregation scaffolding"
+```
+
+### Task F2: Vote-rule helpers (band + magnitude-veto)
+
+**Files:**
+- Modify: `indicators/votes.py`
+- Test: `indicators/test_votes_helpers.py`
+
+**Interfaces:**
+- Produces:
+  - `band_directions(v, lower, upper, mid) -> (cdir, vdir)` — generalizes `rsi_directions`; `rsi_directions(r,lo,up)` becomes `band_directions(r,lo,up,50.0)`.
+  - `magnitude_veto(value, ref, threshold) -> (cdir, vdir)` — `cdir=0`; `vdir=BOTH` where `value/ref < threshold` (and both finite), else 0.
+  - `both_veto(mask) -> (cdir, vdir)` — `vdir=BOTH` where `mask`, else 0; `cdir=0`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# indicators/test_votes_helpers.py
+import sys; from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import numpy as np
+from indicators import votes
+from indicators.base import BOTH
+
+def test_band_directions_matches_rsi_at_mid_50():
+    r = np.array([np.nan, 25.0, 45.0, 50.0, 55.0, 80.0])
+    c1, v1 = votes.band_directions(r, 30, 70, 50.0)
+    c2, v2 = votes.rsi_directions(r, 30, 70)
+    assert np.array_equal(c1, c2) and np.array_equal(v1, v2)
+
+def test_magnitude_veto_flags_low_ratio_both_sides():
+    val = np.array([1.0, 1.0, 1.0]); ref = np.array([2.0, 1.0, np.nan])
+    c, v = votes.magnitude_veto(val, ref, threshold=0.8)  # 0.5<0.8 → veto; 1.0 no; nan no
+    assert v[0] == BOTH and v[1] == 0 and v[2] == 0 and not c.any()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest indicators/test_votes_helpers.py -v`
+Expected: FAIL (`band_directions`/`magnitude_veto` undefined).
+
+- [ ] **Step 3: Implement helpers in `votes.py`**
+
+```python
+from .base import BOTH  # add import
+
+def band_directions(v, lower, upper, mid=50.0):
+    x = np.asarray(v, dtype=float)
+    cdir = np.zeros(len(x), dtype=np.int8); vdir = np.zeros(len(x), dtype=np.int8)
+    valid = ~np.isnan(x)
+    over = valid & (x >= upper); under = valid & (x <= lower)
+    bull = valid & ~over & ~under & (x > mid); bear = valid & ~over & ~under & (x < mid)
+    long_z = under | bull; short_z = over | bear
+    cdir[long_z] = 1; vdir[long_z] = -1; cdir[short_z] = -1; vdir[short_z] = 1
+    return cdir, vdir
+
+def rsi_directions(rsi_vals, lower=30.0, upper=70.0):   # keep name; delegate
+    return band_directions(rsi_vals, lower, upper, 50.0)
+
+def magnitude_veto(value, ref, threshold):
+    a = np.asarray(value, dtype=float); b = np.asarray(ref, dtype=float)
+    cdir = np.zeros(len(a), dtype=np.int8); vdir = np.zeros(len(a), dtype=np.int8)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        ratio = a / b
+    veto = np.isfinite(ratio) & (ratio < float(threshold))
+    vdir[veto] = BOTH
+    return cdir, vdir
+
+def both_veto(mask):
+    m = np.asarray(mask, dtype=bool)
+    cdir = np.zeros(len(m), dtype=np.int8); vdir = np.zeros(len(m), dtype=np.int8)
+    vdir[m] = BOTH
+    return cdir, vdir
+```
+
+- [ ] **Step 4: Run tests (helpers + existing RSI users)**
+
+Run: `pytest indicators/test_votes_helpers.py indicators/test_runner_confirm_count.py -v`
+Expected: PASS (RSI behavior byte-identical via delegation).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add indicators/votes.py indicators/test_votes_helpers.py
+git commit -m "feat(indicators): generalized band + magnitude-veto vote helpers"
+```
+
+### Task F3: Offline oracle harness + dev deps + shared fixture
+
+**Files:**
+- Create: `requirements-dev.txt`
+- Create: `tests/oracle/__init__.py`, `tests/oracle/fixture.py`, `scripts/gen_oracle.py`
+- Test: `tests/oracle/test_fixture_deterministic.py`
+
+**Interfaces:**
+- Produces: `tests.oracle.fixture.ohlcv(n=300)` → deterministic dict of numpy arrays `{open,high,low,close,volume}` (fixed seed, no `Date.now`). Used by every indicator reference test.
+- `scripts/gen_oracle.py` prints TA-Lib/pandas-ta reference values for a named indicator on the fixture, for pasting into tests when a bespoke assertion is easier than importing the oracle in-test.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/oracle/test_fixture_deterministic.py
+import sys; from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+from tests.oracle.fixture import ohlcv
+
+def test_fixture_is_deterministic_and_valid():
+    a, b = ohlcv(300), ohlcv(300)
+    for k in ("open", "high", "low", "close", "volume"):
+        assert np.array_equal(a[k], b[k])
+    assert np.all(a["high"] >= a["low"])
+    assert np.all(a["high"] >= a["close"]) and np.all(a["close"] >= a["low"])
+    assert np.all(a["volume"] > 0)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/oracle/test_fixture_deterministic.py -v`
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement fixture + dev deps + oracle script**
+
+```python
+# tests/oracle/fixture.py
+import numpy as np
+def ohlcv(n=300):
+    rng = np.random.default_rng(20260725)          # fixed seed → deterministic
+    ret = rng.normal(0, 0.01, n)
+    close = 100.0 * np.exp(np.cumsum(ret))
+    spread = np.abs(rng.normal(0, 0.4, n)) + 0.1
+    high = close + spread; low = close - spread
+    openp = np.concatenate([[close[0]], close[:-1]])
+    high = np.maximum.reduce([high, openp, close]); low = np.minimum.reduce([low, openp, close])
+    volume = rng.integers(500, 5000, n).astype(float)
+    return {"open": openp, "high": high, "low": low, "close": close, "volume": volume}
+```
+
+```text
+# requirements-dev.txt
+-r requirements.txt
+pandas-ta==0.3.14b0
+TA-Lib==0.4.28   ; platform_system != "Windows"
+```
+
+```python
+# scripts/gen_oracle.py — usage: python scripts/gen_oracle.py rsi 14
+import sys, numpy as np, pandas_ta as ta, pandas as pd
+sys.path.insert(0, ".")
+from tests.oracle.fixture import ohlcv
+d = ohlcv(300); name = sys.argv[1]; args = [int(a) for a in sys.argv[2:]]
+s = pd.DataFrame(d)
+print(getattr(ta, name)(**{"close": s.close, "high": s.high, "low": s.low, "volume": s.volume},
+                        length=args[0] if args else None).tail(10).to_string())
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest tests/oracle/test_fixture_deterministic.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add requirements-dev.txt tests/oracle scripts/gen_oracle.py
+git commit -m "test(indicators): deterministic OHLCV fixture + offline oracle harness"
+```
+
+### Task F4: Parity auto-sweep over the whole registry
+
+**Files:**
+- Modify: `optimize/test_indicator_parity.py`
+
+**Interfaces:**
+- Consumes: `library.REGISTRY`, `library.SCHEMA` (each key's default params).
+- Produces: a parametrized test asserting fast_engine == engine.py for each registered key enabled alone at its SCHEMA defaults.
+
+- [ ] **Step 1: Add the parametrized sweep test**
+
+```python
+import pytest
+from indicators import library
+
+@pytest.mark.parametrize("key", sorted(library.REGISTRY))
+def test_single_indicator_parity(key):
+    meta = library.SCHEMA[key]
+    params = {p["name"]: p["default"] for p in meta["params"]}
+    spec = [{"key": key, "enabled": True, "mode": meta["mode"], "params": params}]
+    # existing helper in this file that runs both engines on the same data with `spec`
+    fast, slow = run_both_engines(spec)          # reuse the file's existing harness
+    assert fast == slow, f"parity broke for {key}"
+```
+
+- [ ] **Step 2: Run (built-ins only for now)**
+
+Run: `pytest optimize/test_indicator_parity.py -v`
+Expected: PASS for the 18 built-ins (empty schools add nothing yet). If `run_both_engines` differs in name, adapt to the file's existing harness function.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add optimize/test_indicator_parity.py
+git commit -m "test(indicators): parity auto-sweep over full registry"
+```
+
+### Task F5: Optimizer K-cap knob (`--max-enabled`)
+
+**Files:**
+- Modify: `optimize/optimizer.py` (`_suggest_indicators` ~56-73; `search_dims` ~194-201; CLI arg parsing)
+- Test: `optimize/test_max_enabled_cap.py`
+
+**Interfaces:**
+- Consumes: trial + `max_enabled: int | None`.
+- Produces: `_suggest_indicators(trial, ..., max_enabled=None)` — when set, at most `max_enabled` keys may be `enabled=True`; excess enables (lowest trial-param order) are forced False (repair, keeps NSGA rectangular).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# optimize/test_max_enabled_cap.py
+import sys; from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import optuna
+from optimize import optimizer
+
+def test_max_enabled_caps_active_indicators():
+    def obj(trial):
+        specs = optimizer._suggest_indicators(trial, max_enabled=3)
+        n_on = sum(1 for s in specs if s["enabled"])
+        trial.set_user_attr("n_on", n_on)
+        return float(n_on)
+    st = optuna.create_study(sampler=optuna.samplers.RandomSampler(seed=0))
+    st.optimize(obj, n_trials=50)
+    assert max(t.user_attrs["n_on"] for t in st.trials) <= 3
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest optimize/test_max_enabled_cap.py -v`
+Expected: FAIL (`max_enabled` kwarg unsupported / cap not enforced).
+
+- [ ] **Step 3: Implement the cap (repair after suggestion)**
+
+```python
+def _suggest_indicators(trial, exclude=(), only=(), prefix="", max_enabled=None):
+    specs = []
+    for key in library.REGISTRY:
+        # ... existing per-key enable/param suggestion unchanged ...
+        specs.append(spec)
+    if max_enabled is not None:
+        on = [s for s in specs if s.get("enabled")]
+        for s in on[int(max_enabled):]:      # deterministic order = REGISTRY order
+            s["enabled"] = False
+    return specs
+```
+
+Wire `--max-enabled` into the CLI and pass through to `_suggest_indicators`; add it to `search_dims`' docstring note (does not change dim count, only feasible region).
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pytest optimize/test_max_enabled_cap.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add optimize/optimizer.py optimize/test_max_enabled_cap.py
+git commit -m "feat(optimizer): --max-enabled cap on simultaneously-active indicators"
+```
+
+---
+
+## EXEMPLARS — the exact TDD cycle each indicator follows
+
+Every school-phase indicator is one task following the matching exemplar below. A task = (1) write primitive + oracle test → fail → implement → pass; (2) write the `Indicator` subclass + append its `CLASSES`/`SCHEMA` entry; (3) run the parity sweep for that key; (4) commit. The manifest rows give the deltas (formula, params, warmup, vote rule).
+
+### EXEMPLAR-S (Stance) — `wma`
+
+- [ ] **Primitive test** (`indicators/calc/ma.py` ← `wma`):
+
+```python
+# tests/oracle/test_ma_wma.py
+import sys; from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np, pandas as pd
+from indicators.calc.ma import wma
+from tests.oracle.fixture import ohlcv
+
+def test_wma_matches_pandas_oracle():
+    x = ohlcv(300)["close"]; n = 10
+    w = np.arange(1, n + 1)
+    oracle = pd.Series(x).rolling(n).apply(lambda s: np.dot(s, w) / w.sum(), raw=True).to_numpy()
+    got = wma(x, n)
+    m = ~np.isnan(oracle)
+    assert np.allclose(got[m], oracle[m], atol=1e-9)
+    assert np.isnan(got[:n - 1]).all()   # causal warm-up
+```
+
+- [ ] **Primitive** (`indicators/calc/ma.py`):
+
+```python
+import numpy as np
+def wma(x, n):
+    x = np.asarray(x, dtype=float); w = np.arange(1, n + 1, dtype=float)
+    out = np.full(len(x), np.nan)
+    denom = w.sum()
+    for i in range(n - 1, len(x)):
+        out[i] = np.dot(x[i - n + 1:i + 1], w) / denom
+    return out
+```
+*(vectorize later via `np.convolve` if profiling flags it; correctness first.)*
+
+- [ ] **Class + registry** (`indicators/lib_ma.py`):
+
+```python
+import numpy as np
+from .base import Indicator, MarketContext
+from .library import StanceIndicator   # or import StanceIndicator from where defined
+from . import calc, votes
+
+class WMATrend(StanceIndicator):
+    key = "wma"
+    def stance(self, ctx):
+        p = self.config.params
+        f = calc.ma.wma(ctx.close, int(p.get("fast", 20)))
+        s = calc.ma.wma(ctx.close, int(p.get("slow", 50)))
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[(ctx.close > f) & (f > s)] = 1
+        st[(ctx.close < f) & (f < s)] = -1
+        return st
+    def warmup_bars(self):
+        p = self.config.params
+        return max(int(p.get("fast", 20)), int(p.get("slow", 50)))
+
+CLASSES = (WMATrend,)
+SCHEMA = {"wma": {"label": "WMA trend", "mode": "confirm",
+                  "params": [{"name": "fast", "default": 20, "min": 2, "max": 400, "step": 1},
+                             {"name": "slow", "default": 50, "min": 2, "max": 400, "step": 1}]}}
+```
+
+- [ ] **Parity + commit:** `pytest optimize/test_indicator_parity.py -k wma -v` → PASS; commit.
+
+### EXEMPLAR-Z (Zone) — `williams_r`
+
+Primitive `williams_r(high,low,close,n) = -100*(HHₙ-close)/(HHₙ-LLₙ)` (range −100..0). Oracle: `pandas_ta.willr`. Class extends `Indicator`, `directions` = `votes.band_directions(wr, lower=-80, upper=-20, mid=-50.0)`. SCHEMA params: `n(14,2..100,1)`, `lower(-80,-99..-51,1)`, `upper(-20,-49..-1,1)`, mode `both`, warmup `n`.
+
+### EXEMPLAR-V (Veto) — `choppiness`
+
+Primitive `choppiness(high,low,close,n) = 100*log10(Σ(TR,n)/(maxHighₙ-minLowₙ))/log10(n)` (0..100). Class extends `Indicator`; `directions` = `votes.both_veto(chop >= threshold)` (high chop = no-trend → veto both). SCHEMA: `n(14,2..100,1)`, `threshold(61.8,30..80,0.1)`, mode `veto`, warmup `n`. Oracle: `pandas_ta.chop`.
+
+---
+
+## PHASE 1 — Moving averages (`lib_ma.py`, 19) — pattern S
+
+Each row: primitive in `calc/ma.py`, class `<Name>Trend(StanceIndicator)` with fast/slow cross (like `wma`) unless noted. Default params `fast(20,2..400,1) slow(50,2..400,1)` unless noted; warmup `max(fast,slow)`; mode `confirm`. Oracle in parens.
+
+| key | primitive formula | param notes (oracle) |
+|---|---|---|
+| `wma` | see EXEMPLAR-S | (pandas rolling) |
+| `rma` | already in classic (`classic.rma`) — reuse | (Wilder) |
+| `dema` | `2*ema(x,n) - ema(ema(x,n),n)` | single `n(20)` (ta.dema) |
+| `tema` | `3e - 3*ema(e,n) + ema(ema(e,n),n)`, `e=ema(x,n)` | single `n` (ta.tema) |
+| `tma` | `sma(sma(x, ⌈n/2⌉), ⌊n/2⌋+1)` | single `n` (ta.trima) |
+| `hma` | `wma(2*wma(x,n/2) - wma(x,n), √n)` | single `n` (ta.hma) |
+| `kama` | Kaufman adaptive: ER=|Δn|/Σ|Δ1|; sc=(ER*(2/3−2/31)+2/31)²; recursive | `n(10) fast(2) slow(30)` (ta.kama) |
+| `vidya` | CMO-scaled EMA: `α=2/(n+1)*|CMO|`; recursive | `n(14)` (ta.vidya-equiv) |
+| `alma` | Gaussian-weighted: `w_k=exp(-(k-m)²/(2s²))`, `m=offset*(n-1)`, `s=n/sigma` | `n(9) offset(0.85,0..1,0.05) sigma(6,1..12,0.5)` (ta.alma) |
+| `zlema` | `ema(x + (x - x[lag]), n)`, `lag=(n-1)//2` | single `n` (ta.zlma) |
+| `lsma` | rolling linear-reg endpoint value, window `n` | single `n(14)` (ta.linreg) |
+| `t3` | Tillson: 6 cascaded EMAs w/ volume-factor `v` | `n(10) v(0.7,0..1,0.05)` (ta.t3) |
+| `mcginley` | `md = md + (x-md)/(k*n*(x/md)⁴)`, `k=0.6`; recursive | single `n(14)` (ta.-) |
+| `sine_wma` | weights `sin(π*(k+1)/(n+1))` normalized | single `n(20)` |
+| `vwma` | `Σ(x*vol,n)/Σ(vol,n)` | single `n(20)` (ta.vwma) |
+| `evwma` | elastic VWMA: `e = e*(V-vol)/V + x*vol/V`, `V=Σ(vol,n)`; recursive | single `n(20)` |
+| `gmma` | ribbon: short group `{3,5,8,10,12,15}` all above long `{30,35,40,45,50,60}` EMAs → +1; all below → −1 | no params; warmup 60 |
+| `ma_envelope` | stance = sign(close − sma(close,n)); veto when |close/sma−1|>pct | `n(20) pct(2.5%,0.1..10,0.1)` mode both |
+| `ma_displaced` | sign(close − sma(close,n) shifted `d` bars forward-in-past) | `n(20) d(5,1..50,1)` |
+
+## PHASE 2 — Trend / directional (`lib_trend.py`, 24)
+
+Primitives in `calc/trend.py`. Pattern letter in col.
+
+| key | pat | primitive / vote rule | params (oracle) |
+|---|---|---|---|
+| `ppo` | S | `100*(ema_f-ema_s)/ema_s`; stance=sign(ppo − ema(ppo,signal)) | `fast(12) slow(26) signal(9)` (ta.ppo) |
+| `apo` | S | `ema_f-ema_s`; stance=sign | `fast(12) slow(26)` (ta.apo) |
+| `di_cross` | S | +DI/−DI from `classic.adx` internals; stance=sign(+DI − −DI) | `n(14)` (ta.plus/minus_di) |
+| `aroon` | S | up=100*(n−sinceHigh)/n, dn=100*(n−sinceLow)/n; sign(up−dn) | `n(25,2..200,1)` (ta.aroon) |
+| `aroon_osc` | S | `up−dn`; stance=sign | `n(25)` (ta.aroon) |
+| `psar` | S | Wilder Parabolic SAR recursion; stance=sign(close − sar) | `step(0.02,0.01..0.2,0.01) max(0.2,0.05..0.5,0.01)` (ta.psar) |
+| `vortex` | S | VI+=Σ|H−L_prev|/ΣTR, VI−=Σ|L−H_prev|/ΣTR; sign(VI+−VI−) | `n(14,2..100,1)` (ta.vortex) |
+| `supertrend` | S | ATR bands w/ trend flip recursion; stance=trend dir | `n(10,2..100,1) m(3.0,1..8,0.5)` (ta.supertrend) |
+| `trix` | S | `roc1(ema(ema(ema(log?close,n),n),n))*1e4`; sign(trix−signal) | `n(15) signal(9)` (ta.trix) |
+| `kst` | S | weighted sum of 4 smoothed ROCs; sign(kst−signal) | fixed roc/sma windows; `signal(9)` (ta.kst) |
+| `coppock` | S | `wma(roc(c,11)+roc(c,14), 10)`; stance=sign | fixed (ta.coppock) |
+| `dpo` | S | `close − sma(close,n) shifted (n/2+1)`; stance=sign | `n(20,2..200,1)` (ta.dpo) |
+| `trend_intensity` | S | `TII = 100*Σ(dev>0)/Σ|dev|` around sma(n); band vs 50 | `n(60)` band both |
+| `linreg_slope` | S | rolling OLS slope over `n`; stance=sign(slope) | `n(14,2..200,1)` (ta.linreg slope) |
+| `linreg_channel` | V | veto both when |close−reg|>k*σ over `n` (extended) | `n(100) k(2.0)` both |
+| `chandelier` | V | long-stop=HHₙ−m*ATR, short-stop=LLₙ+m*ATR; veto side broken | `n(22) m(3.0)` veto |
+| `chande_kroll` | V | Chande-Kroll stop bands; veto broken side | `n(10) m(1.0) p(9)` veto |
+| `qqe` | S | smoothed-RSI + ATR-of-RSI trailing; stance=RSI vs trail | `n(14) sf(5) f(4.236)` (ta.qqe) |
+| `elder_ray` | S | bull=H−ema(n), bear=L−ema(n); +1 bull>0&rising, −1 bear<0&falling | `n(13,2..100,1)` |
+| `elder_impulse` | S | ema slope AND macd-hist slope agree → that side | `n(13) macd(12,26,9)` |
+| `asi` | S | Wilder Accumulation Swing Index cumulative; stance=sign(ΔASI) | `limit(3.0,0.5..10,0.5)` |
+| `expma` | S | dual EMA cross (China EXPMA); sign(ema_f−ema_s) | `fast(12) slow(50)` |
+| `dma` | S | `ddd=sma(c,f)−sma(c,s)`, `ama=sma(ddd,m)`; sign(ddd−ama) | `f(10) s(50) m(10)` |
+| `bbi` | S | `(sma3+sma6+sma12+sma24)/4`; stance=sign(close−bbi) | no params; warmup 24 |
+
+## PHASE 3 — Momentum / oscillator (`lib_osc.py`, 23)
+
+Primitives in `calc/osc.py`. Zone (Z) → `votes.band_directions`; S → sign stance.
+
+| key | pat | primitive / rule | params (oracle) |
+|---|---|---|---|
+| `rsi_cutler` | Z | RSI with SMA (not Wilder) smoothing | `n(14) lower(30) upper(70)` |
+| `rsi_connors` | Z | `(RSI(3)+RSI(streak,2)+PctRank(roc1,100))/3` | `lower(20) upper(80)` (ta.-) |
+| `stoch_rsi` | Z | stochastic of RSI(n) over `k`, %K/%D | `n(14) k(14) d(3) lower(20) upper(80)` (ta.stochrsi) |
+| `kdj` | Z | stochastic K,D + J=3K−2D; band on K | `n(9) lower(20) upper(80)` |
+| `williams_r` | Z | EXEMPLAR-Z | `n(14) lower(-80) upper(-20)` |
+| `momentum` | S | `close − close[n]`; sign | `n(10,1..200,1)` |
+| `roc` | S | `100*(close/close[n]−1)`; sign | `n(9,1..200,1)` (ta.roc) |
+| `cmo` | Z | `100*(Σup−Σdn)/(Σup+Σdn)` over n; band mid 0 | `n(14) lower(-50) upper(50)` (ta.cmo) |
+| `ultimate_osc` | Z | Williams UO weighted 7/14/28 | `lower(30) upper(70)` (ta.uo) |
+| `tsi` | S | `100*ema(ema(Δc,r),s)/ema(ema(|Δc|,r),s)`; sign(tsi−signal) | `r(25) s(13) signal(13)` (ta.tsi) |
+| `rvgi` | S | `(c−o)/(h−l)` smoothed / range smoothed; sign(rvi−signal) | `n(14) signal(4)` (ta.rvgi) |
+| `smi` | Z | Blau stochastic momentum index; band mid 0 | `n(14) smooth(3) lower(-40) upper(40)` |
+| `rmi` | Z | RSI-like with momentum lag `m` | `n(14) m(5) lower(30) upper(70)` |
+| `cmo_chande_dmi` | Z | dynamic-period RSI (period scaled by vol) | `n(14) lower(30) upper(70)` |
+| `fisher` | S | Fisher transform of normalized price; sign(fish−fish[1]) | `n(9,2..100,1)` (ta.fisher) |
+| `derivative_osc` | S | `ema(ema(rsi,5? )..)` DiNapoli; sign vs signal | `rsi_n(14) s1(5) s2(3) signal(9)` |
+| `ergodic_osc` | S | TSI variant (Blau ergodic); sign(erg−signal) | `r(32) s(5) signal(5)` |
+| `wavetrend` | Z | LazyBear WT: ema of (ap−esa)/(0.015*d); band mid 0 | `n1(10) n2(21) lower(-60) upper(60)` |
+| `disparity` | S | `100*(close/sma(close,n)−1)`; sign | `n(14,2..200,1)` |
+| `balance_of_power` | S | `(close−open)/(high−low)` smoothed; sign | `n(14)` (ta.bop) |
+| `pgo` | Z | Pretty Good Osc `(close−sma)/ema(TR,n)`; band mid 0 | `n(14) lower(-3) upper(3)` |
+| `psy` | Z | psychological line `100*Σ(up,n)/n`; band vs 50 | `n(12) lower(25) upper(75)` |
+| `bias` | S | `100*(close−sma(close,n))/sma(close,n)`; sign | `n(6,2..200,1)` |
+
+## PHASE 4 — Volatility (`lib_vol.py`, 18)
+
+Primitives in `calc/vol.py`. Magnitude-veto (MV) → `votes.magnitude_veto(value, ref=ema(value,m), threshold)`; bounded veto (BV) → `votes.both_veto`.
+
+| key | pat | primitive / rule | params |
+|---|---|---|---|
+| `atr_norm` | MV | `atr(n)/close`; veto low-vol via magnitude_veto | `n(14) m(50) threshold(0.8,0.2..1.5,0.05)` |
+| `donchian` | S | mid=(HHₙ+LLₙ)/2; stance=sign(close−mid) | `n(20,2..200,1)` |
+| `starc` | V | STARC bands sma±m*ATR; veto broken side | `n(15) m(2.0)` |
+| `accel_bands` | V | Price Headley accel bands; veto broken side | `n(20) f(4.0)` |
+| `proj_bands` | V | Mickey Jordan projection bands (slope-projected H/L) | `n(14)` |
+| `stddev` | MV | rolling std(close,n) (ddof=0); magnitude_veto | `n(20) m(50) threshold(0.8)` |
+| `hist_vol` | MV | annualized std of log-returns over n; magnitude_veto | `n(20) m(50) threshold(0.8)` |
+| `parkinson` | MV | `√(Σ(ln(H/L)²)/(4n·ln2))`; magnitude_veto | `n(20) m(50) threshold(0.8)` |
+| `garman_klass` | MV | GK range estimator; magnitude_veto | `n(20) m(50) threshold(0.8)` |
+| `rogers_satchell` | MV | RS estimator; magnitude_veto | `n(20) m(50) threshold(0.8)` |
+| `yang_zhang` | MV | YZ overnight+open-close estimator; magnitude_veto | `n(20) m(50) threshold(0.8)` |
+| `chaikin_vol` | MV | `roc(ema(H−L,n), roc_n)`; magnitude_veto vs 0-centered → use both_veto when < −thr | `n(10) roc_n(10) threshold(-10)` |
+| `rvi_dorsey` | Z | Relative Volatility Index (RSI of stddev); band | `n(14) lower(30) upper(70)` |
+| `mass_index` | BV | `Σ(ema(H−L,9)/ema(ema(H−L,9),9), n)`; veto both when >27 (reversal bulge) | `n(25) threshold(27,20..35,0.5)` |
+| `ulcer` | MV | ulcer index (RMS drawdown, n); magnitude_veto low | `n(14) m(50) threshold(0.8)` |
+| `choppiness` | BV | EXEMPLAR-V | `n(14) threshold(61.8)` |
+| `vol_ratio` | MV | `atr(n_fast)/atr(n_slow)`; magnitude_veto | `n_fast(5) n_slow(20) threshold(0.8)` |
+| `ttm_squeeze` | BV | veto both when Bollinger(n,2) inside Keltner(n,1.5) (squeeze on) | `n(20)` |
+
+## PHASE 5 — Volume (`lib_volume.py`, 18)
+
+Primitives in `calc/volume.py`. Mostly Stance = sign of the flow line vs its own smoothing.
+
+| key | pat | primitive / rule | params |
+|---|---|---|---|
+| `ad_line` | S | cumulative `((c−l)−(h−c))/(h−l)*vol`; sign(ad − sma(ad,n)) | `n(20)` (ta.ad) |
+| `cmf` | S | `Σ(mfv,n)/Σ(vol,n)`; sign | `n(20,2..200,1)` (ta.cmf) |
+| `chaikin_osc` | S | `ema(ad,3)−ema(ad,10)`; sign | `fast(3) slow(10)` (ta.adosc) |
+| `pvt` | S | cumulative `roc1*vol`; sign(pvt − sma(pvt,n)) | `n(20)` (ta.pvt) |
+| `tvi` | S | Trade Volume Index (tick-rule proxy on close Δ) | `min_tick(0.01) n(20)` |
+| `nvi` | S | Negative Volume Index; sign(nvi − ema(nvi,255)) | `n(255)` (ta.nvi) |
+| `pvi` | S | Positive Volume Index; sign(pvi − ema(pvi,255)) | `n(255)` (ta.pvi) |
+| `eom` | S | Arms Ease of Movement smoothed; sign | `n(14,2..200,1)` (ta.eom) |
+| `force_index` | S | `ema(Δc*vol, n)`; sign | `n(13,2..200,1)` (ta.efi) |
+| `klinger` | S | Klinger VO (ema34−ema55 of volume-force); sign(kvo−signal) | `fast(34) slow(55) signal(13)` (ta.kvo) |
+| `vol_osc` | S | `100*(ema(vol,f)−ema(vol,s))/ema(vol,s)`; sign | `fast(5) slow(20)` |
+| `vzo` | Z | `100*ema(sign(Δc)*vol,n)/ema(vol,n)`; band mid 0 | `n(14) lower(-40) upper(40)` |
+| `demand_index` | S | Sibbet demand index; sign | `n(20)` |
+| `twiggs_mf` | S | Twiggs money flow (Wilder-smoothed AD/vol); sign | `n(21)` |
+| `wvad` | S | `Σ((c−o)/(h−l)*vol, n)`; sign | `n(20)` |
+| `bw_mfi` | S | `(h−l)/vol` regime → green/fade/fake/squat stance | no params; warmup 1 |
+| `anchored_vwap` | S | VWAP anchored at each session start (reuse `classic.vwap`); sign(close−avwap) | uses `ctx.session_id`; no params |
+| `volume_ratio_asia` | Z | China VR `100*Σ(up-vol)/Σ(dn-vol)` over n; band vs 100 | `n(26) lower(70) upper(150)` |
+
+## PHASE 6 — Ichimoku / pivots / Bill Williams (`lib_levels.py` + `lib_bw.py`, 15)
+
+Primitives: `calc/levels.py`. Pivots computed on prior-session OHLC (needs `ctx.session_id`; if absent, prior-day via a rolling daily group — reuse the project's session mapping).
+
+| key | pat | primitive / rule | params |
+|---|---|---|---|
+| `ichimoku_tk_cross` | S | sign(Tenkan − Kijun), Tenkan=(HH9+LL9)/2, Kijun=(HH26+LL26)/2 | `t(9) k(26)` |
+| `ichimoku_cloud` | S | +1 close>max(spanA,spanB), −1 close<min; spans shifted +26 (causal read of past span) | `t(9) k(26) b(52)` |
+| `ichimoku_chikou` | S | sign(close − close[26]) (Chikou vs price) | `lag(26)` |
+| `pivot_floor` | S | PP=(H+L+C)/3 prior session; stance=sign(close−PP) | no params |
+| `pivot_woodie` | S | PP=(H+L+2C)/4; sign(close−PP) | no params |
+| `pivot_camarilla` | S | R/S=C±range*1.1/k; stance vs C-pivot | no params |
+| `pivot_fib` | S | PP + fib(0.382/0.618) of range; sign(close−PP) | no params |
+| `pivot_demark` | S | DeMark X-based pivot per close vs open rule; sign(close−PP) | no params |
+| `cpr` | S | central pivot range (PP, BC, TC); +1 above TC, −1 below BC | no params |
+| `alligator` | S | 3 smoothed displaced MAs (13/8/5 shift 8/5/3); aligned → that side | fixed; warmup 21 |
+| `fractals` | S | Williams 5-bar fractal; +1 after up-fractal broken, −1 down | `n(2,1..10,1)` |
+| `awesome_osc` | S | `sma(median,5)−sma(median,34)`; sign | fixed (ta.ao) |
+| `accel_osc` | S | `AO − sma(AO,5)`; sign | fixed |
+| `gator` | S | |jaw−teeth| & |teeth−lips| expanding → trend side | fixed |
+| `elliott_wave_osc` | S | `sma(median,5)−sma(median,34)`; sign (EWO) | fixed |
+
+## PHASE 7 — Cycles / DeMark / quant Tier-1 (`lib_quant.py`, 8)
+
+Primitives: `calc/quant.py`.
+
+| key | pat | primitive / rule | params |
+|---|---|---|---|
+| `zscore` | Z | `(close−sma(close,n))/std(close,n)`; band mid 0 | `n(20) lower(-2) upper(2)` |
+| `hurst_exp` | BV | rolling R/S Hurst over n; veto both when H<0.5 (mean-reverting = chop) | `n(100) threshold(0.5,0.3..0.7,0.01)` |
+| `dfa` | BV | detrended fluctuation α over n; veto both when α<0.5 | `n(100) threshold(0.5)` |
+| `autocorr` | BV | lag-1 autocorrelation over n; veto both when |ρ|<threshold (no structure) | `n(50) threshold(0.1,0..0.5,0.01)` |
+| `demarker` | Z | DeMark DeMarker (DeMax/DeMin) over n; band | `n(14) lower(0.3) upper(0.7)` |
+| `td_rei` | Z | TD Range Expansion Index over 5; band mid 0 | `lower(-40) upper(40)` |
+| `linreg_r2` | BV | rolling R² of OLS(close~t,n); veto both when R²<threshold (no trend) | `n(20) threshold(0.2,0..0.9,0.01)` |
+| `efficiency_ratio` | S | Kaufman ER `|Δn|/Σ|Δ1|` signed by Δn; +1 if ER>thr & up, −1 if ER>thr & down | `n(10) threshold(0.3,0..1,0.05)` |
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** §2 architecture → Phase F. §3 modules → F1. §4 build manifest → Phases 1–7 (19+24+23+18+18+15+8 = 125). §6 K-cap → F5; masks/MAP-Elites already exist (reuse, no task); adopt-gate is a runtime research discipline enforced when a study is *evaluated*, not a code task. §7 verification → F3 (oracle), F4 (parity sweep), per-task parity `-k <key>`. §5 Tier-2 → out of scope (documented in spec).
+- **Placeholder scan:** every task has real code or an exact formula + oracle. Manifest rows carry the precise formula, params (default/min/max/step), warmup, and vote rule — a skilled dev implements each by cloning the matching exemplar and swapping the formula.
+- **Type consistency:** all classes are `StanceIndicator` (needs `stance()`) or `Indicator` (needs `directions()`); every module exports `CLASSES`/`SCHEMA` merged by F1; vote helpers `band_directions`/`magnitude_veto`/`both_veto` defined in F2 and referenced by name thereafter.
+- **Known follow-ups during execution:** confirm the exact name of `test_indicator_parity.py`'s existing two-engine harness fn (Task F4 Step 2) and adapt; profile-vectorize the O(n·window) primitive loops only if the optimizer flags them (recurrence notes in `optimize/RESEARCH_indicator_recurrence_relations.md`).

--- a/docs/superpowers/specs/2026-07-25-calc-indicators-library-design.md
+++ b/docs/superpowers/specs/2026-07-25-calc-indicators-library-design.md
@@ -1,0 +1,173 @@
+# Design: Calc-Indicator Library Expansion (WS-EXTRA-IND)
+
+**Date:** 2026-07-25
+**Branch / worktree:** `extra-indicators`
+**Status:** Approved design → implementation planning
+**Author:** Mulham Fetna (see `/home/mulham-fetna/.claude/CLAUDE.md` for attribution links)
+
+---
+
+## 1. Goal
+
+Expand the system's technical-indicator library from the current ~18 to a comprehensive set of
+**faithful, single-OHLCV computable indicators** ("calc" indicators from
+`docs/extra-indicators/INDICATOR-SCHOOLS-INVENTORY.md`), fully wired into all three surfaces —
+**backtester, dashboard, and optimizer** — with each indicator entering as a **confirm/veto vote**
+on the primary box signal (the existing WS-I paradigm).
+
+Approved scope decisions (2026-07-25):
+1. **Role:** confirm/veto votes only — indicators never originate an entry.
+2. **Granularity:** one class + one registry key per named indicator (families NOT collapsed).
+3. **Optimizer:** all indicators enter the global auto-search (already automatic via the registry loop).
+4. **Tiering:** build **Tier-1 (~125, faithful pure-numpy) now**; **defer Tier-2 (~22, hard/approximate/extra-input)**.
+5. **K-cap guardrail:** add a "max simultaneously-enabled indicators" knob to the optimizer. **Approved.**
+6. **TA-Lib as a test-only oracle** (dev dependency, never a runtime import). **Approved.**
+
+## 2. Architecture (verified, parity-free)
+
+Every indicator is **written once** and auto-propagates. Verified against the current code:
+
+| Surface | Mechanism | File evidence |
+|---|---|---|
+| Backtester (both engines) | Votes computed in the shared `indicators/` layer, folded into `entry_gate`; **`fast_engine` consumes precomputed masks, does NOT re-implement** | `engine.py:258`, `optimize/fast_engine.py` (mask args only) |
+| Dashboard | Panel built dynamically from `library.schema()` — no hardcoding | `indicators/library.py:383` |
+| Optimizer | `_suggest_indicators()` loops **the whole `REGISTRY`** — new keys auto-enter the search; `search_dims` counts `len(REGISTRY)` | `optimize/optimizer.py:56,201` |
+
+Consequence: **no per-indicator edits to engine, dashboard, or optimizer wiring.** Parity is
+structural because both engines read the same folded vote mask, and `optimize/test_indicator_parity.py`
+already guards it.
+
+### 2.1 Per-indicator work unit (the repeated pattern)
+
+```
+1. primitive  → vectorized numpy function (indicators/calc/<school>.py)
+2. class      → StanceIndicator (trend/breakout → sign stance) OR Indicator (zone/veto via votes.py)
+                + warmup_bars()  (mandatory, no default guessing)
+3. registry   → one REGISTRY entry + one SCHEMA entry {label, default mode, params[{default,min,max,step}]}
+4. test       → one reference-value unit test (values from TA-Lib/pandas-ta offline, hardcoded)
+```
+
+Both base patterns already exist (`StanceIndicator`, `Indicator`) — **no new abstraction is added.**
+
+## 3. Module layout (keeps files focused)
+
+`classic.py` and `library.py` would balloon; split instead:
+
+```
+indicators/
+  calc/                      # pure vectorized primitives, no framework imports
+    ma.py  trend.py  osc.py  vol.py  volume.py  levels.py
+  lib_ma.py  lib_trend.py  lib_osc.py  lib_vol.py  lib_volume.py  lib_levels.py  lib_bw.py  lib_quant.py
+  library.py                 # imports each lib_* module; aggregates REGISTRY + SCHEMA
+```
+
+Each `lib_<school>.py` contributes its own `{key: class}` sub-registry and `{key: schema}` sub-schema;
+`library.py` merges them. Adding a school = add a module + one import/merge line.
+
+## 4. Tier-1 build manifest (~125 indicators)
+
+Base pattern: **S** = StanceIndicator, **Z** = zone/oscillator `Indicator`, **V** = veto-only `Indicator`.
+Default mode shown; all remain optimizer-tunable.
+
+### 4.1 Moving-average trends — `lib_ma.py` (19) — pattern S, mode confirm
+`wma`, `rma` (Wilder/SMMA), `dema`, `tema`, `tma` (triangular), `hma` (Hull), `kama` (Kaufman),
+`vidya` (Chande), `alma`, `zlema`, `lsma` (linear-reg MA), `t3` (Tillson), `mcginley`, `sine_wma`,
+`vwma`, `evwma`, `gmma` (Guppy ribbon alignment), `ma_envelope`, `ma_displaced`.
+*Params: fast/slow (or n) + variant-specific (e.g. kama fast/slow/er-period, alma offset/sigma).*
+
+### 4.2 Trend / directional — `lib_trend.py` (24)
+`ppo` (S), `apo` (S), `di_cross` (±DI, S), `aroon` (S), `aroon_osc` (S), `psar` (S), `vortex` (S),
+`supertrend` (S), `trix` (S), `kst` (S), `coppock` (S), `dpo` (S), `trend_intensity` (S),
+`linreg_slope` (S), `linreg_channel` (S/V), `chandelier` (V), `chande_kroll` (V), `qqe` (S),
+`elder_ray` (S), `elder_impulse` (S), `asi` (S, accumulation swing), `expma` (S), `dma` (S), `bbi` (S).
+
+### 4.3 Momentum / oscillator — `lib_osc.py` (23)
+`rsi_cutler` (Z), `rsi_connors` (Z), `stoch_rsi` (Z), `kdj` (Z), `williams_r` (Z), `momentum` (S),
+`roc` (S), `cmo` (Z), `ultimate_osc` (Z), `tsi` (S), `rvgi` (S), `smi` (Z), `rmi` (Z),
+`cmo_chande_dmi` (Z), `fisher` (S), `derivative_osc` (S), `ergodic_osc` (S), `wavetrend` (Z),
+`disparity` (S), `balance_of_power` (S), `pgo` (Z), `psy` (Z), `bias` (S).
+
+### 4.4 Volatility — `lib_vol.py` (18)
+`atr_norm` (V), `donchian` (S), `starc` (V), `accel_bands` (V), `proj_bands` (V), `stddev` (V),
+`hist_vol` (V), `parkinson` (V), `garman_klass` (V), `rogers_satchell` (V), `yang_zhang` (V),
+`chaikin_vol` (V), `rvi_dorsey` (Z), `mass_index` (V), `ulcer` (V), `choppiness` (V),
+`vol_ratio` (V), `ttm_squeeze` (V).
+
+### 4.5 Volume — `lib_volume.py` (18)
+`ad_line` (S), `cmf` (S), `chaikin_osc` (S), `pvt` (S), `tvi` (S), `nvi` (S), `pvi` (S),
+`eom` (S), `force_index` (S), `klinger` (S), `vol_osc` (S), `vzo` (Z), `demand_index` (S),
+`twiggs_mf` (S), `wvad` (S), `bw_mfi` (S), `anchored_vwap` (S), `volume_ratio_asia` (Z).
+
+### 4.6 Ichimoku / pivots / Bill Williams — `lib_levels.py` + `lib_bw.py` (15)
+Ichimoku: `ichimoku_tk_cross` (S), `ichimoku_cloud` (S), `ichimoku_chikou` (S).
+Pivots (price-vs-level stance): `pivot_floor` (S), `pivot_woodie` (S), `pivot_camarilla` (S),
+`pivot_fib` (S), `pivot_demark` (S), `cpr` (S).
+Bill Williams: `alligator` (S), `fractals` (S), `awesome_osc` (S), `accel_osc` (S), `gator` (S),
+plus `elliott_wave_osc` (S, 5/34).
+
+### 4.7 Cycles / DeMark / quant (Tier-1 subset) — `lib_quant.py` (8)
+`zscore` (Z), `hurst_exp` (V, persistence gate), `dfa` (V), `autocorr` (V), `demarker` (Z),
+`td_rei` (Z), `linreg_r2` (V), `efficiency_ratio` (S).
+
+**Tier-1 total ≈ 125** (19 + 24 + 23 + 18 + 18 + 15 + 8).
+
+## 5. Tier-2 — deferred (~22), documented not built
+
+Reason each is deferred (faithfulness / statefulness / extra input):
+
+- **MA/DSP:** `mama_fama`, `frama`, `jma` (proprietary), Ehlers `super_smoother`, `roofing`, `bandpass`.
+- **Trend/momentum:** `schaff_trend_cycle`, `laguerre_rsi`.
+- **Volatility:** `garch_ewma`.
+- **Cycles/Ehlers DSP:** `hilbert_cycle`, `sinewave`, `cyber_cycle`, `center_of_gravity`, `emd`.
+- **DeMark (stateful):** `td_sequential`, `td_combo`.
+- **Quant:** `kalman`.
+- **Cross-series (needs 2nd instrument in `MarketContext`):** `cointegration`, `rolling_corr`,
+  `rolling_beta`, `pca_factor`, `ou_halflife`.
+
+Deferral rationale: each either cannot be made faithful in pure numpy without silent approximation
+(violates the no-silent-defaults rule), is stateful enough to threaten engine parity, or requires a
+`MarketContext` extension to carry a second series. Follow-up spec will pick these up.
+
+## 6. Optimizer-at-scale guardrails (⚠️ required by process memory)
+
+150 enable-flags in one search is a combinatorial + multiple-comparisons hazard. Machinery mostly
+already exists; this section is **wiring + one small knob**, not new algorithms.
+
+1. **K-cap on simultaneous enables** — new optimizer knob bounding how many indicators a trial may
+   enable (e.g. `--max-enabled K`). Small change in `_suggest_indicators` (reject/repair trials over
+   the cap). Keeps the search sparse and interpretable.
+2. **School-group masks** — reuse existing `only=()/exclude=()` args + `contributor_masks` so a study
+   can optionally scope to one school without removing the global option.
+3. **MAP-Elites + two-stage sampler** — already COMPLETE in the optimizer; reuse as the large-space tool.
+4. **Speed** — vectorize every primitive; reuse existing memoization (candidate-L1 cache) and the
+   recurrence relations in `optimize/RESEARCH_indicator_recurrence_relations.md` for O(1) rolling updates.
+5. **Mandatory adopt-gate** — **no indicator/champion is adopted** without: power analysis + noise
+   check + dumb control + OOS verification. Non-negotiable (multiple-comparisons trap over 125 candidates).
+
+## 7. Rollout & verification
+
+- **Batches by school** (build/merge cadence — all still land in the one global registry):
+  `feat/extra-ind-<school>` → tests + parity green → merge to `dev`. Order: MA → oscillators →
+  trend → volatility → volume → levels/BW → quant.
+- **TDD, one reference-value test per indicator.** Oracle = TA-Lib / pandas-ta computed **offline**;
+  expected values hardcoded into the test. **TA-Lib is `requirements-dev` only — never a runtime import.**
+  This is the exact guard against the class of bug that flipped NG's sign (`round(x,4)` precision).
+- **Extend `optimize/test_indicator_parity.py`** to auto-sweep every new registry key (fast==engine).
+- **Dashboard smoke:** after each batch, verify the new indicators render in the panel from `schema()`
+  and toggle correctly (per the UI-verification memory: browser, not API; `--ind-1min`).
+
+## 8. Out of scope
+
+- Tier-2 indicators (§5) — separate follow-up.
+- The frozen vendored copy `shareable/wsh6cold_4h_backtester/indicators/` — left pinned.
+- Standalone-signal or L2-feature roles (explicitly rejected in Q1).
+- Any change to the box signal, exit logic, or sizing.
+
+## 9. Success criteria
+
+1. ~125 Tier-1 indicators registered; each appears in `schema()` and is optimizer-searchable.
+2. Every indicator has a passing reference-value test vs an offline TA-Lib/pandas-ta oracle.
+3. `test_indicator_parity.py` green across all new keys (fast_engine == engine.py).
+4. Optimizer runs with the K-cap knob; a scoped study over any school completes.
+5. No runtime dependency on TA-Lib; no silent defaults introduced.
+6. Dashboard renders and toggles the new panel entries (browser-verified, `--ind-1min`).

--- a/subprojects/Parametric-Indicators/indicators/calc/bw.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/bw.py
@@ -1,0 +1,58 @@
+"""Bill Williams + Elliott-wave-oscillator primitives (pure, causal)."""
+from __future__ import annotations
+
+import numpy as np
+
+from ..classic import rma as _rma
+from ..classic import sma as _sma
+from .osc import _shift, nan_sma
+
+
+def _median(high, low):
+    return (np.asarray(high, float) + np.asarray(low, float)) / 2.0
+
+
+def alligator(high, low):
+    """Displaced smoothed MAs of the median price: jaw(13,+8), teeth(8,+5), lips(5,+3).
+    Returned already displaced into the past (causal read of the future-plotted lines)."""
+    med = _median(high, low)
+    jaw = _shift(_rma(med, 13), 8)
+    teeth = _shift(_rma(med, 8), 5)
+    lips = _shift(_rma(med, 5), 3)
+    return jaw, teeth, lips
+
+
+def awesome(price):
+    """AO = SMA(median,5) − SMA(median,34) (pass median price)."""
+    return _sma(price, 5) - _sma(price, 34)
+
+
+def accel(price):
+    """Accelerator = AO − SMA(AO,5). nan_sma so AO's warm-up NaNs don't poison the SMA."""
+    ao = awesome(price)
+    return ao - nan_sma(ao, 5)
+
+
+def ewo(close):
+    """Elliott Wave Oscillator = SMA(close,5) − SMA(close,34) (uses CLOSE, unlike AO's median)."""
+    c = np.asarray(close, float)
+    return _sma(c, 5) - _sma(c, 34)
+
+
+def fractal_levels(high, low):
+    """Last CONFIRMED Williams 5-bar fractal high/low available at each bar (centre confirmed +2 bars)."""
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    N = len(h)
+    up = np.full(N, np.nan)
+    dn = np.full(N, np.nan)
+    last_up = np.nan
+    last_dn = np.nan
+    for i in range(N):
+        if i >= 4:
+            j = i - 2
+            if h[j] > h[j - 1] and h[j] > h[j - 2] and h[j] > h[j + 1] and h[j] > h[j + 2]:
+                last_up = h[j]
+            if l[j] < l[j - 1] and l[j] < l[j - 2] and l[j] < l[j + 1] and l[j] < l[j + 2]:
+                last_dn = l[j]
+        up[i], dn[i] = last_up, last_dn
+    return up, dn

--- a/subprojects/Parametric-Indicators/indicators/calc/levels.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/levels.py
@@ -1,0 +1,79 @@
+"""Ichimoku + session-pivot primitives (pure, causal).
+
+Pivots use the PRIOR completed session's OHLC (from session_id), so they are constant within a session
+and never peek into the current one. Ichimoku spans are read at their displaced (past) position."""
+from __future__ import annotations
+
+import numpy as np
+
+from ..classic import _roll_max, _roll_min
+from .osc import _shift
+
+
+def _mid(high, low, n):
+    return (_roll_max(high, n) + _roll_min(low, n)) / 2.0
+
+
+def ichimoku_lines(high, low, t, k, b):
+    tenkan = _mid(high, low, t)
+    kijun = _mid(high, low, k)
+    span_a = (tenkan + kijun) / 2.0
+    span_b = _mid(high, low, b)
+    return tenkan, kijun, span_a, span_b
+
+
+def cloud_past(high, low, t, k, b, shift=26):
+    """Leading spans read at the current bar = spans computed `shift` bars ago (causal Kumo)."""
+    _, _, span_a, span_b = ichimoku_lines(high, low, t, k, b)
+    return _shift(span_a, shift), _shift(span_b, shift)
+
+
+def prior_session_ohlc(openp, high, low, close, session_id):
+    """Per-bar (O,H,L,C) of the most recent COMPLETED session before this bar (NaN until one exists)."""
+    o, h, l, c = map(lambda a: np.asarray(a, float), (openp, high, low, close))
+    sid = np.asarray(session_id)
+    N = len(c)
+    pO = np.full(N, np.nan); pH = np.full(N, np.nan); pL = np.full(N, np.nan); pC = np.full(N, np.nan)
+    prev = (np.nan, np.nan, np.nan, np.nan)
+    cur_sid = None
+    co = ch = cl = cc = np.nan
+    for i in range(N):
+        if cur_sid is None or sid[i] != cur_sid:
+            if cur_sid is not None:
+                prev = (co, ch, cl, cc)
+            cur_sid, co, ch, cl, cc = sid[i], o[i], h[i], l[i], c[i]
+        else:
+            ch, cl, cc = max(ch, h[i]), min(cl, l[i]), c[i]
+        pO[i], pH[i], pL[i], pC[i] = prev
+    return pO, pH, pL, pC
+
+
+def floor_pp(pH, pL, pC):
+    return (pH + pL + pC) / 3.0
+
+
+def woodie_pp(pH, pL, pC):
+    return (pH + pL + 2.0 * pC) / 4.0
+
+
+def demark_pp(pO, pH, pL, pC):
+    x = np.where(pC < pO, pH + 2.0 * pL + pC, np.where(pC > pO, 2.0 * pH + pL + pC, pH + pL + 2.0 * pC))
+    return x / 4.0
+
+
+def camarilla_bands(pH, pL, pC):
+    rng = pH - pL
+    return pC + rng * 1.1 / 4.0, pC - rng * 1.1 / 4.0     # R3, S3
+
+
+def fib_levels(pH, pL, pC):
+    pp = floor_pp(pH, pL, pC)
+    rng = pH - pL
+    return pp + 0.382 * rng, pp - 0.382 * rng             # R1(fib), S1(fib)
+
+
+def cpr_levels(pH, pL, pC):
+    pp = floor_pp(pH, pL, pC)
+    bc = (pH + pL) / 2.0
+    tc = 2.0 * pp - bc
+    return np.maximum(tc, bc), np.minimum(tc, bc)         # top, bottom of central range

--- a/subprojects/Parametric-Indicators/indicators/calc/ma.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/ma.py
@@ -1,9 +1,23 @@
-"""Moving-average primitives (pure, vectorized, causal). Each returns a float array the length of the
-input with NaN during warm-up. No framework imports — unit-testable in isolation against an
-independent pandas/numpy oracle (see tests/oracle/)."""
+"""Moving-average primitives (pure, vectorized/recursive, causal). Each returns a float array the
+length of the input; NaN (or a soft seed) during warm-up. Depends only on numpy + the leaf
+primitives in indicators/classic.py (ema/sma) — unit-testable against independent oracles."""
 from __future__ import annotations
 
 import numpy as np
+
+from ..classic import ema as _ema
+
+
+def _rolling_sum(x: np.ndarray, n: int) -> np.ndarray:
+    """Sum of the last n values; NaN for the first n-1 bars."""
+    x = np.asarray(x, dtype=float)
+    out = np.full(len(x), np.nan)
+    if n <= 0 or len(x) < n:
+        return out
+    c = np.cumsum(x)
+    out[n - 1] = c[n - 1]
+    out[n:] = c[n:] - c[:-n]
+    return out
 
 
 def wma(x: np.ndarray, n: int) -> np.ndarray:
@@ -14,4 +28,194 @@ def wma(x: np.ndarray, n: int) -> np.ndarray:
     out = np.full(len(x), np.nan)
     for i in range(n - 1, len(x)):
         out[i] = np.dot(x[i - n + 1:i + 1], w) / denom
+    return out
+
+
+def dema(x: np.ndarray, n: int) -> np.ndarray:
+    """Double EMA: 2·EMA − EMA(EMA)."""
+    e = _ema(x, n)
+    return 2.0 * e - _ema(e, n)
+
+
+def tema(x: np.ndarray, n: int) -> np.ndarray:
+    """Triple EMA: 3e − 3·EMA(e) + EMA(EMA(e)), e=EMA(x)."""
+    e = _ema(x, n)
+    e2 = _ema(e, n)
+    e3 = _ema(e2, n)
+    return 3.0 * e - 3.0 * e2 + e3
+
+
+def tma(x: np.ndarray, n: int) -> np.ndarray:
+    """Triangular MA = SMA(⌈n/2⌉)∘SMA(⌊n/2⌋+1) (TA-Lib TRIMA convention). Implemented as the
+    equivalent single triangular-kernel windowed average — SMA∘SMA via classic.sma would poison on
+    the inner SMA's leading NaNs (cumsum). Kernel = boxcar(h)⊛boxcar(k), length h+k-1."""
+    import math
+    h = math.ceil(n / 2)
+    k = n // 2 + 1
+    w = np.convolve(np.ones(h), np.ones(k)) / (h * k)   # symmetric triangular weights
+    L = len(w)
+    x = np.asarray(x, dtype=float)
+    out = np.full(len(x), np.nan)
+    for i in range(L - 1, len(x)):
+        out[i] = np.dot(x[i - L + 1:i + 1], w)
+    return out
+
+
+def hma(x: np.ndarray, n: int) -> np.ndarray:
+    """Hull MA: WMA(2·WMA(n/2) − WMA(n), √n). Very low lag."""
+    half = int(n // 2)
+    sq = int(np.sqrt(n))
+    return wma(2.0 * wma(x, half) - wma(x, n), sq)
+
+
+def zlema(x: np.ndarray, n: int) -> np.ndarray:
+    """Zero-lag EMA: EMA of the de-lagged series d[i]=2x[i]−x[i−lag], lag=(n−1)//2."""
+    x = np.asarray(x, dtype=float)
+    lag = (n - 1) // 2
+    d = x.copy()
+    if lag > 0:
+        d[lag:] = 2.0 * x[lag:] - x[:-lag]
+    return _ema(d, n)
+
+
+def sine_wma(x: np.ndarray, n: int) -> np.ndarray:
+    """Sine-weighted MA: weights sin(π(k+1)/(n+1)), k=0..n−1 (symmetric bell)."""
+    x = np.asarray(x, dtype=float)
+    k = np.arange(n)
+    w = np.sin(np.pi * (k + 1) / (n + 1))
+    w /= w.sum()
+    out = np.full(len(x), np.nan)
+    for i in range(n - 1, len(x)):
+        out[i] = np.dot(x[i - n + 1:i + 1], w)
+    return out
+
+
+def vwma(x: np.ndarray, vol: np.ndarray, n: int) -> np.ndarray:
+    """Volume-weighted MA: Σ(x·vol,n)/Σ(vol,n)."""
+    x = np.asarray(x, dtype=float)
+    v = np.asarray(vol, dtype=float)
+    num = _rolling_sum(x * v, n)
+    den = _rolling_sum(v, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return num / den
+
+
+def lsma(x: np.ndarray, n: int) -> np.ndarray:
+    """Least-squares MA: value of the OLS line (y~t) at the window's last point."""
+    x = np.asarray(x, dtype=float)
+    t = np.arange(n, dtype=float)
+    tm = t.mean()
+    ss = ((t - tm) ** 2).sum()
+    out = np.full(len(x), np.nan)
+    for i in range(n - 1, len(x)):
+        y = x[i - n + 1:i + 1]
+        ym = y.mean()
+        b = ((t - tm) * (y - ym)).sum() / ss
+        a = ym - b * tm
+        out[i] = a + b * (n - 1)
+    return out
+
+
+def kama(x: np.ndarray, n: int, fast: int, slow: int) -> np.ndarray:
+    """Kaufman Adaptive MA. ER=|Δn|/Σ|Δ1|; smoothing sc=(ER·(fsc−ssc)+ssc)²; seeded at bar n."""
+    x = np.asarray(x, dtype=float)
+    N = len(x)
+    out = np.full(N, np.nan)
+    if N <= n:
+        return out
+    fsc = 2.0 / (fast + 1.0)
+    ssc = 2.0 / (slow + 1.0)
+    absd = np.abs(np.diff(x))                       # |Δ1|, length N-1
+    out[n] = x[n]
+    for i in range(n + 1, N):
+        change = abs(x[i] - x[i - n])
+        vol = absd[i - n:i].sum()
+        er = change / vol if vol > 0 else 0.0
+        sc = (er * (fsc - ssc) + ssc) ** 2
+        out[i] = out[i - 1] + sc * (x[i] - out[i - 1])
+    return out
+
+
+def vidya(x: np.ndarray, n: int) -> np.ndarray:
+    """Variable Index Dynamic Average (Chande): EMA whose gain scales with |CMO(n)|."""
+    x = np.asarray(x, dtype=float)
+    N = len(x)
+    out = np.full(N, np.nan)
+    if N <= n:
+        return out
+    d = np.diff(x)
+    up = np.where(d > 0, d, 0.0)
+    dn = np.where(d < 0, -d, 0.0)
+    alpha = 2.0 / (n + 1.0)
+    out[n] = x[n]
+    for i in range(n + 1, N):
+        su = up[i - n:i].sum()
+        sd = dn[i - n:i].sum()
+        k = abs(su - sd) / (su + sd) if (su + sd) > 0 else 0.0
+        out[i] = alpha * k * x[i] + (1.0 - alpha * k) * out[i - 1]
+    return out
+
+
+def alma(x: np.ndarray, n: int, offset: float, sigma: float) -> np.ndarray:
+    """Arnaud Legoux MA: Gaussian window centred at offset·(n−1), width n/sigma."""
+    x = np.asarray(x, dtype=float)
+    m = offset * (n - 1)
+    s = n / sigma
+    k = np.arange(n)
+    w = np.exp(-((k - m) ** 2) / (2.0 * s * s))
+    w /= w.sum()
+    out = np.full(len(x), np.nan)
+    for i in range(n - 1, len(x)):
+        out[i] = np.dot(x[i - n + 1:i + 1], w)
+    return out
+
+
+def t3(x: np.ndarray, n: int, v: float) -> np.ndarray:
+    """Tillson T3: six cascaded EMAs blended with volume-factor v."""
+    e1 = _ema(x, n)
+    e2 = _ema(e1, n)
+    e3 = _ema(e2, n)
+    e4 = _ema(e3, n)
+    e5 = _ema(e4, n)
+    e6 = _ema(e5, n)
+    c1 = -v ** 3
+    c2 = 3.0 * v ** 2 + 3.0 * v ** 3
+    c3 = -6.0 * v ** 2 - 3.0 * v - 3.0 * v ** 3
+    c4 = 1.0 + 3.0 * v + v ** 3 + 3.0 * v ** 2
+    return c1 * e6 + c2 * e5 + c3 * e4 + c4 * e3
+
+
+def mcginley(x: np.ndarray, n: int) -> np.ndarray:
+    """McGinley Dynamic: self-adjusting MA, md += (x−md)/(0.6·n·(x/md)^4). Seeded at bar 0."""
+    x = np.asarray(x, dtype=float)
+    N = len(x)
+    out = np.full(N, np.nan)
+    if N == 0:
+        return out
+    out[0] = x[0]
+    for i in range(1, N):
+        prev = out[i - 1]
+        if prev == 0 or np.isnan(prev):
+            out[i] = x[i]
+            continue
+        out[i] = prev + (x[i] - prev) / (0.6 * n * (x[i] / prev) ** 4)
+    return out
+
+
+def evwma(x: np.ndarray, vol: np.ndarray, n: int) -> np.ndarray:
+    """Elastic Volume-Weighted MA: e = e·(V−vol)/V + x·vol/V, V=Σ(vol,n). Seeded at bar n−1."""
+    x = np.asarray(x, dtype=float)
+    vv = np.asarray(vol, dtype=float)
+    N = len(x)
+    out = np.full(N, np.nan)
+    V = _rolling_sum(vv, n)
+    if N < n:
+        return out
+    out[n - 1] = x[n - 1]
+    for i in range(n, N):
+        Vi = V[i]
+        if Vi <= 0 or np.isnan(Vi):
+            out[i] = out[i - 1]
+            continue
+        out[i] = out[i - 1] * (Vi - vv[i]) / Vi + x[i] * vv[i] / Vi
     return out

--- a/subprojects/Parametric-Indicators/indicators/calc/ma.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/ma.py
@@ -1,0 +1,17 @@
+"""Moving-average primitives (pure, vectorized, causal). Each returns a float array the length of the
+input with NaN during warm-up. No framework imports — unit-testable in isolation against an
+independent pandas/numpy oracle (see tests/oracle/)."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def wma(x: np.ndarray, n: int) -> np.ndarray:
+    """Linearly-weighted MA: weights 1..n (most recent = n). NaN for the first n-1 bars."""
+    x = np.asarray(x, dtype=float)
+    w = np.arange(1, n + 1, dtype=float)
+    denom = w.sum()
+    out = np.full(len(x), np.nan)
+    for i in range(n - 1, len(x)):
+        out[i] = np.dot(x[i - n + 1:i + 1], w) / denom
+    return out

--- a/subprojects/Parametric-Indicators/indicators/calc/osc.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/osc.py
@@ -1,0 +1,350 @@
+"""Momentum / oscillator primitives (pure, causal). Return float arrays; NaN during warm-up.
+
+Depends on numpy + leaf primitives in indicators/classic.py. `nan_ema` seeds at the first finite
+value (classic.ema seeds at bar 0 and would poison a NaN-warmup input such as RSI)."""
+from __future__ import annotations
+
+import numpy as np
+
+from ..classic import _roll_max, _roll_min
+from ..classic import ema as _ema
+from ..classic import rma as _rma
+from ..classic import rsi as _rsi
+from ..classic import sma as _sma
+from ..classic import true_range as _tr
+from .ma import _rolling_sum
+
+
+def nan_ema(x: np.ndarray, n: int) -> np.ndarray:
+    """EMA (alpha=2/(n+1)) that seeds at the first finite value and holds through interior NaNs.
+    Use when the input carries a NaN warm-up (RSI, stochastic) — classic.ema would go all-NaN."""
+    x = np.asarray(x, dtype=float)
+    out = np.full(len(x), np.nan)
+    fin = np.where(~np.isnan(x))[0]
+    if len(fin) == 0:
+        return out
+    a = 2.0 / (n + 1.0)
+    s = int(fin[0])
+    out[s] = x[s]
+    for t in range(s + 1, len(x)):
+        out[t] = out[t - 1] if np.isnan(x[t]) else a * x[t] + (1.0 - a) * out[t - 1]
+    return out
+
+
+def roll_sum_safe(x: np.ndarray, n: int) -> np.ndarray:
+    """Rolling sum tolerant of LEADING NaN (warm-up): result is NaN until the full window is finite,
+    then the true sum. Avoids the cumsum-poisoning of classic.sma / calc.ma._rolling_sum."""
+    x = np.asarray(x, dtype=float)
+    N = len(x)
+    s = np.full(N, np.nan)
+    if N < n or n <= 0:
+        return s
+    xf = np.where(np.isnan(x), 0.0, x)
+    c = np.cumsum(xf)
+    s[n - 1] = c[n - 1]
+    s[n:] = c[n:] - c[:-n]
+    valid = (~np.isnan(x)).astype(float)
+    vc = np.cumsum(valid)
+    w = np.full(N, 0.0)
+    w[n - 1] = vc[n - 1]
+    w[n:] = vc[n:] - vc[:-n]
+    s[w < n] = np.nan
+    return s
+
+
+def nan_sma(x: np.ndarray, n: int) -> np.ndarray:
+    """SMA tolerant of leading NaN (see roll_sum_safe)."""
+    return roll_sum_safe(x, n) / n
+
+
+def _shift(x: np.ndarray, k: int) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    out = np.full(len(x), np.nan)
+    if 0 < k < len(x):
+        out[k:] = x[:-k]
+    elif k == 0:
+        out[:] = x
+    return out
+
+
+# --- simple momentum ---
+def momentum(close, n):
+    c = np.asarray(close, dtype=float)
+    return c - _shift(c, n)
+
+
+def roc(close, n):
+    c = np.asarray(close, dtype=float)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * (c / _shift(c, n) - 1.0)
+
+
+def disparity(close, n):
+    c = np.asarray(close, dtype=float)
+    m = _sma(c, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * (c / m - 1.0)
+
+
+def bias(close, n):
+    c = np.asarray(close, dtype=float)
+    m = _sma(c, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * (c - m) / m
+
+
+def williams_r(high, low, close, n):
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    hh, ll = _roll_max(h, n), _roll_min(l, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return -100.0 * (hh - c) / (hh - ll)
+
+
+def cmo(close, n):
+    c = np.asarray(close, dtype=float)
+    d = np.diff(c)
+    up = np.where(d > 0, d, 0.0)
+    dn = np.where(d < 0, -d, 0.0)
+    su, sd = _rolling_sum(up, n), _rolling_sum(dn, n)
+    out = np.full(len(c), np.nan)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        out[1:] = 100.0 * (su - sd) / (su + sd)
+    return out
+
+
+def psy(close, n):
+    c = np.asarray(close, dtype=float)
+    up = (np.diff(c) > 0).astype(float)
+    out = np.full(len(c), np.nan)
+    out[1:] = 100.0 * _rolling_sum(up, n) / n
+    return out
+
+
+def balance_of_power(openp, high, low, close, n):
+    o, h, l, c = map(lambda a: np.asarray(a, float), (openp, high, low, close))
+    with np.errstate(invalid="ignore", divide="ignore"):
+        bop = (c - o) / (h - l)
+    return _sma(bop, n)
+
+
+# --- RSI variants ---
+def rsi_cutler(close, n):
+    """Cutler's RSI — SMA smoothing of gains/losses (vs Wilder's RMA)."""
+    c = np.asarray(close, dtype=float)
+    d = np.diff(c)
+    up = np.where(d > 0, d, 0.0)
+    dn = np.where(d < 0, -d, 0.0)
+    ag, al = _rolling_sum(up, n) / n, _rolling_sum(dn, n) / n
+    out = np.full(len(c), np.nan)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        rs = ag / al
+        out[1:] = 100.0 - 100.0 / (1.0 + rs)
+        out[1:][al == 0] = 100.0
+    return out
+
+
+def connors_rsi(close, rsi_n=3, streak_n=2, rank_n=100):
+    """Connors RSI = mean(RSI(close,rsi_n), RSI(streak,streak_n), PercentRank(ROC1,rank_n))."""
+    c = np.asarray(close, dtype=float)
+    N = len(c)
+    r1 = _rsi(c, rsi_n)
+    # streak: consecutive up/down count
+    streak = np.zeros(N)
+    for i in range(1, N):
+        if c[i] > c[i - 1]:
+            streak[i] = streak[i - 1] + 1 if streak[i - 1] > 0 else 1
+        elif c[i] < c[i - 1]:
+            streak[i] = streak[i - 1] - 1 if streak[i - 1] < 0 else -1
+        else:
+            streak[i] = 0
+    r2 = _rsi(streak, streak_n)
+    roc1 = np.full(N, np.nan)
+    roc1[1:] = (c[1:] / c[:-1] - 1.0) * 100.0
+    pr = np.full(N, np.nan)
+    for i in range(rank_n, N):
+        win = roc1[i - rank_n:i]
+        pr[i] = 100.0 * np.mean(win < roc1[i])
+    return (r1 + r2 + pr) / 3.0
+
+
+def rmi(close, n, m):
+    """Relative Momentum Index — RSI of the m-bar momentum, Wilder-smoothed over n."""
+    c = np.asarray(close, dtype=float)
+    N = len(c)
+    mom = np.full(N, np.nan)
+    mom[m:] = c[m:] - c[:-m]
+    up = np.where(mom > 0, mom, 0.0)
+    dn = np.where(mom < 0, -mom, 0.0)
+    au, ad = _rma(up, n), _rma(dn, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 - 100.0 / (1.0 + au / ad)
+
+
+def dynamic_dmi(close, n):
+    """Chande Dynamic Momentum Index — RSI whose period shrinks when volatility rises.
+    td = n / (std5 / SMA10(std5)), clamped to [3, 2n]; then Wilder RSI over td (per-bar period)."""
+    c = np.asarray(close, dtype=float)
+    N = len(c)
+    std5 = np.full(N, np.nan)
+    for i in range(4, N):
+        std5[i] = c[i - 4:i + 1].std()
+    vi = std5 / nan_sma(std5, 10)
+    out = np.full(N, np.nan)
+    d = np.diff(c)
+    up = np.where(d > 0, d, 0.0)
+    dn = np.where(d < 0, -d, 0.0)
+    for i in range(1, N):
+        if np.isnan(vi[i]) or vi[i] <= 0:
+            continue
+        td = int(round(n / vi[i]))
+        td = max(3, min(td, 2 * n))
+        if i < td:
+            continue
+        au = up[i - td:i].mean()
+        ad = dn[i - td:i].mean()
+        out[i] = 100.0 if ad == 0 else 100.0 - 100.0 / (1.0 + au / ad)
+    return out
+
+
+# --- stochastic family ---
+def stoch_rsi(close, n, k, d):
+    """Stochastic of RSI(n) over k, %D = SMA(%K, d). Returns %K (0..100)."""
+    r = _rsi(close, n)
+    hh, ll = _roll_max(r, k), _roll_min(r, k)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        kk = 100.0 * (r - ll) / (hh - ll)
+    return kk
+
+
+def kdj_k(high, low, close, n):
+    """KDJ %K line: K = (2/3)K_prev + (1/3)RSV, RSV = 100·(close−LLn)/(HHn−LLn)."""
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    hh, ll = _roll_max(h, n), _roll_min(l, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        rsv = 100.0 * (c - ll) / (hh - ll)
+    out = np.full(len(c), np.nan)
+    fin = np.where(~np.isnan(rsv))[0]
+    if len(fin) == 0:
+        return out
+    s = int(fin[0])
+    out[s] = rsv[s]
+    for i in range(s + 1, len(c)):
+        out[i] = (2.0 / 3.0) * out[i - 1] + (1.0 / 3.0) * (rsv[i] if not np.isnan(rsv[i]) else out[i - 1])
+    return out
+
+
+def smi(high, low, close, n, smooth):
+    """Blau Stochastic Momentum Index (−100..100): double-EMA of (close − midpoint) over range/2."""
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    hh, ll = _roll_max(h, n), _roll_min(l, n)
+    mid = (hh + ll) / 2.0
+    diff = c - mid
+    rng = hh - ll
+    ds = nan_ema(nan_ema(diff, smooth), smooth)
+    rs = nan_ema(nan_ema(rng, smooth), smooth)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * ds / (0.5 * rs)
+
+
+# --- double-smoothed momentum ---
+def tsi(close, r, s):
+    """True Strength Index (−100..100): 100·EMA_s(EMA_r(Δc)) / EMA_s(EMA_r(|Δc|))."""
+    c = np.asarray(close, dtype=float)
+    pc = np.zeros(len(c))
+    pc[1:] = np.diff(c)
+    num = _ema(_ema(pc, r), s)
+    den = _ema(_ema(np.abs(pc), r), s)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        out = 100.0 * num / den
+    out[0] = np.nan
+    return out
+
+
+def rvgi(openp, high, low, close, n):
+    """Relative Vigor Index: SWMA(close−open) / SWMA(high−low), summed over n. Weights (1,2,2,1)/6."""
+    o, h, l, c = map(lambda a: np.asarray(a, float), (openp, high, low, close))
+    def swma(x):
+        out = np.full(len(x), np.nan)
+        for i in range(3, len(x)):
+            out[i] = (x[i] + 2 * x[i - 1] + 2 * x[i - 2] + x[i - 3]) / 6.0
+        return out
+    num = roll_sum_safe(swma(c - o), n)
+    den = roll_sum_safe(swma(h - l), n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return num / den
+
+
+def rvgi_signal(rvi):
+    """4-period symmetric-weighted signal of the RVI line."""
+    out = np.full(len(rvi), np.nan)
+    for i in range(3, len(rvi)):
+        seg = rvi[i - 3:i + 1]
+        if np.isnan(seg).any():
+            continue
+        out[i] = (seg[3] + 2 * seg[2] + 2 * seg[1] + seg[0]) / 6.0
+    return out
+
+
+def ultimate_osc(high, low, close, s1=7, s2=14, s3=28):
+    """Williams Ultimate Oscillator (0..100), weighted 4/2/1 across three look-backs."""
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    pc = _shift(c, 1)
+    bp = c - np.minimum(l, pc)
+    tr = np.maximum(h, pc) - np.minimum(l, pc)
+    def avg(k):
+        return roll_sum_safe(bp, k) / roll_sum_safe(tr, k)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * (4 * avg(s1) + 2 * avg(s2) + avg(s3)) / 7.0
+
+
+def wavetrend(high, low, close, n1, n2):
+    """LazyBear WaveTrend line wt1 = EMA(ci, n2), ci = (ap−esa)/(0.015·d)."""
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    ap = (h + l + c) / 3.0
+    esa = _ema(ap, n1)
+    d = _ema(np.abs(ap - esa), n1)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        ci = np.where(d > 0, (ap - esa) / (0.015 * d), 0.0)
+    return nan_ema(ci, n2)
+
+
+def fisher(high, low, n):
+    """Ehlers Fisher Transform of the normalized median price. Returns the fisher line."""
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    mp = (h + l) / 2.0
+    hh, ll = _roll_max(mp, n), _roll_min(mp, n)
+    N = len(mp)
+    val = np.zeros(N)
+    fish = np.full(N, np.nan)
+    prev_v, prev_f = 0.0, 0.0
+    for i in range(N):
+        if np.isnan(hh[i]) or hh[i] == ll[i]:
+            continue
+        raw = 2.0 * (mp[i] - ll[i]) / (hh[i] - ll[i]) - 1.0
+        v = 0.33 * raw + 0.67 * prev_v
+        v = min(max(v, -0.999), 0.999)
+        f = 0.5 * np.log((1 + v) / (1 - v)) + 0.5 * prev_f
+        fish[i] = f
+        prev_v, prev_f = v, f
+    return fish
+
+
+def derivative_osc(close, rsi_n, s1, s2, signal):
+    """DiNapoli Derivative Oscillator: double-smoothed RSI minus its SMA signal."""
+    r = _rsi(close, rsi_n)
+    smoothed = nan_ema(nan_ema(r, s1), s2)
+    return smoothed - nan_sma(smoothed, signal)
+
+
+def ergodic(close, r, s, signal):
+    """Blau Ergodic = TSI line minus its EMA signal."""
+    t = tsi(close, r, s)
+    return t - nan_ema(t, signal)
+
+
+def pgo(high, low, close, n):
+    """Pretty Good Oscillator: (close − SMA(close,n)) / EMA(TR, n)."""
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    tr = _tr(h, l, c)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return (c - _sma(c, n)) / _ema(tr, n)

--- a/subprojects/Parametric-Indicators/indicators/calc/quant.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/quant.py
@@ -1,0 +1,127 @@
+"""Statistical / quant primitives (pure, causal). Hurst & DFA are computed on the RETURN series so a
+random walk gives ~0.5 (persistence >0.5 = trending, <0.5 = mean-reverting/chop)."""
+from __future__ import annotations
+
+import numpy as np
+
+from ..classic import sma as _sma
+from .osc import _shift, roll_sum_safe
+from .vol import rolling_std
+
+
+def zscore(close, n):
+    c = np.asarray(close, float)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return (c - _sma(c, n)) / rolling_std(c, n)
+
+
+def hurst_exp(close, n):
+    """Rolling R/S Hurst of the window's returns. H≈0.5 random, >0.5 persistent, <0.5 mean-reverting."""
+    c = np.asarray(close, float)
+    N = len(c)
+    out = np.full(N, np.nan)
+    for i in range(n - 1, N):
+        r = np.diff(c[i - n + 1:i + 1])
+        s = r.std()
+        if s <= 0:
+            continue
+        y = np.cumsum(r - r.mean())
+        rng = y.max() - y.min()
+        if rng > 0:
+            out[i] = np.log(rng / s) / np.log(len(r))
+    return out
+
+
+def dfa(close, n):
+    """Rolling detrended-fluctuation exponent alpha of the window's returns (few log-spaced scales)."""
+    c = np.asarray(close, float)
+    N = len(c)
+    out = np.full(N, np.nan)
+    scales = sorted({s for s in (4, n // 8, n // 4, n // 2) if 4 <= s <= (n - 1) // 2})
+    if len(scales) < 2:
+        return out
+    for i in range(n - 1, N):
+        r = np.diff(c[i - n + 1:i + 1])
+        y = np.cumsum(r - r.mean())
+        fs, ls = [], []
+        for s in scales:
+            nb = len(y) // s
+            if nb < 1:
+                continue
+            f2 = []
+            t = np.arange(s)
+            for b in range(nb):
+                seg = y[b * s:(b + 1) * s]
+                coef = np.polyfit(t, seg, 1)
+                f2.append(np.mean((seg - np.polyval(coef, t)) ** 2))
+            fs.append(np.sqrt(np.mean(f2)))
+            ls.append(s)
+        fs = np.asarray(fs)
+        if len(fs) >= 2 and np.all(fs > 0):
+            out[i] = np.polyfit(np.log(ls), np.log(fs), 1)[0]
+    return out
+
+
+def autocorr(close, n, lag=1):
+    """Lag-`lag` autocorrelation of returns over the last n returns."""
+    c = np.asarray(close, float)
+    r = np.diff(c)
+    N = len(c)
+    out = np.full(N, np.nan)
+    for i in range(n + 1, N):
+        w = r[i - n:i]
+        a, b = w[lag:], w[:-lag]
+        if a.std() > 0 and b.std() > 0:
+            out[i] = np.corrcoef(a, b)[0, 1]
+    return out
+
+
+def demarker(high, low, n):
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    dh = h - _shift(h, 1)
+    dl = _shift(l, 1) - l
+    demax = np.where(dh > 0, dh, 0.0)
+    demin = np.where(dl > 0, dl, 0.0)
+    demax[~np.isfinite(demax)] = 0.0
+    demin[~np.isfinite(demin)] = 0.0
+    smax, smin = _sma(demax, n), _sma(demin, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return smax / (smax + smin)
+
+
+def td_rei(high, low, n=5):
+    """Simplified TD Range Expansion Index (−100..100): 2-bar high/low expansion, summed over n."""
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    dh = h - _shift(h, 2)
+    dl = l - _shift(l, 2)
+    num = roll_sum_safe(dh + dl, n)
+    den = roll_sum_safe(np.abs(dh) + np.abs(dl), n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * num / den
+
+
+def linreg_r2(close, n):
+    c = np.asarray(close, float)
+    t = np.arange(n, dtype=float)
+    tm = t.mean()
+    tss = ((t - tm) ** 2).sum()
+    out = np.full(len(c), np.nan)
+    for i in range(n - 1, len(c)):
+        y = c[i - n + 1:i + 1]
+        ym = y.mean()
+        b = ((t - tm) * (y - ym)).sum() / tss
+        pred = (ym - b * tm) + b * t
+        sst = ((y - ym) ** 2).sum()
+        out[i] = 1.0 - ((y - pred) ** 2).sum() / sst if sst > 0 else 0.0
+    return out
+
+
+def efficiency_ratio(close, n):
+    """Kaufman efficiency ratio (0..1): |net change| / sum(|bar changes|) over n."""
+    c = np.asarray(close, float)
+    absd = np.abs(np.diff(c))
+    out = np.full(len(c), np.nan)
+    for i in range(n, len(c)):
+        vol = absd[i - n:i].sum()
+        out[i] = abs(c[i] - c[i - n]) / vol if vol > 0 else 0.0
+    return out

--- a/subprojects/Parametric-Indicators/indicators/calc/trend.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/trend.py
@@ -1,0 +1,259 @@
+"""Trend / directional primitives (pure, causal). Return float arrays (or tuples); NaN during warm-up.
+
+Reuses classic.py leaves + the NaN-safe helpers in calc/osc.py."""
+from __future__ import annotations
+
+import numpy as np
+
+from ..classic import _roll_max, _roll_min
+from ..classic import atr as _atr
+from ..classic import ema as _ema
+from ..classic import rma as _rma
+from ..classic import rsi as _rsi
+from ..classic import sma as _sma
+from ..classic import true_range as _tr
+from .ma import wma as _wma
+from .osc import _shift, nan_ema, nan_sma, roc as _roc, roll_sum_safe
+
+
+def ppo(close, fast, slow):
+    ef, es = _ema(close, fast), _ema(close, slow)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * (ef - es) / es
+
+
+def apo(close, fast, slow):
+    return _ema(close, fast) - _ema(close, slow)
+
+
+def plus_minus_di(high, low, close, n):
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    N = len(c)
+    up = np.zeros(N)
+    dn = np.zeros(N)
+    up[1:] = h[1:] - h[:-1]
+    dn[1:] = l[:-1] - l[1:]
+    pdm = np.where((up > dn) & (up > 0), up, 0.0)
+    mdm = np.where((dn > up) & (dn > 0), dn, 0.0)
+    tr = _tr(h, l, c)
+    atr = _rma(tr, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * _rma(pdm, n) / atr, 100.0 * _rma(mdm, n) / atr
+
+
+def aroon(high, low, n):
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    N = len(h)
+    up = np.full(N, np.nan)
+    dn = np.full(N, np.nan)
+    for i in range(n, N):
+        wh, wl = h[i - n:i + 1], l[i - n:i + 1]
+        since_high = n - int(np.argmax(wh))    # bars since highest high (0 = current bar)
+        since_low = n - int(np.argmin(wl))
+        up[i] = 100.0 * (n - since_high) / n
+        dn[i] = 100.0 * (n - since_low) / n
+    return up, dn
+
+
+def psar(high, low, step, maxstep):
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    N = len(h)
+    sar = np.full(N, np.nan)
+    if N < 2:
+        return sar
+    trend = 1
+    af = step
+    ep = h[0]
+    sar[0] = l[0]
+    for i in range(1, N):
+        prev = sar[i - 1]
+        if trend == 1:
+            cur = prev + af * (ep - prev)
+            cur = min(cur, l[i - 1], l[i - 2] if i >= 2 else l[i - 1])
+            if l[i] < cur:
+                trend, cur, ep, af = -1, ep, l[i], step
+            elif h[i] > ep:
+                ep, af = h[i], min(af + step, maxstep)
+        else:
+            cur = prev + af * (ep - prev)
+            cur = max(cur, h[i - 1], h[i - 2] if i >= 2 else h[i - 1])
+            if h[i] > cur:
+                trend, cur, ep, af = 1, ep, h[i], step
+            elif l[i] < ep:
+                ep, af = l[i], min(af + step, maxstep)
+        sar[i] = cur
+    return sar
+
+
+def vortex(high, low, close, n):
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    tr = _tr(h, l, c)
+    vmp = np.abs(h - _shift(l, 1))
+    vmm = np.abs(l - _shift(h, 1))
+    str_ = roll_sum_safe(tr, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return roll_sum_safe(vmp, n) / str_, roll_sum_safe(vmm, n) / str_
+
+
+def supertrend(high, low, close, n, m):
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    atr = _atr(h, l, c, n)
+    hl2 = (h + l) / 2.0
+    upper, lower = hl2 + m * atr, hl2 - m * atr
+    N = len(c)
+    fu = np.full(N, np.nan)
+    fl = np.full(N, np.nan)
+    dirn = np.full(N, np.nan)
+    fin = np.where(~np.isnan(atr))[0]
+    if len(fin) == 0:
+        return dirn
+    s = int(fin[0])
+    fu[s], fl[s], dirn[s] = upper[s], lower[s], 1.0
+    for i in range(s + 1, N):
+        fu[i] = upper[i] if (upper[i] < fu[i - 1] or c[i - 1] > fu[i - 1]) else fu[i - 1]
+        fl[i] = lower[i] if (lower[i] > fl[i - 1] or c[i - 1] < fl[i - 1]) else fl[i - 1]
+        if c[i] > fu[i - 1]:
+            dirn[i] = 1.0
+        elif c[i] < fl[i - 1]:
+            dirn[i] = -1.0
+        else:
+            dirn[i] = dirn[i - 1]
+    return dirn
+
+
+def trix(close, n):
+    e = _ema(_ema(_ema(close, n), n), n)
+    out = np.full(len(e), np.nan)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        out[1:] = (e[1:] / e[:-1] - 1.0) * 10000.0
+    return out
+
+
+def kst(close):
+    k = (nan_sma(_roc(close, 10), 10) * 1 + nan_sma(_roc(close, 15), 10) * 2
+         + nan_sma(_roc(close, 20), 10) * 3 + nan_sma(_roc(close, 30), 15) * 4)
+    return k
+
+
+def coppock(close):
+    return _wma(_roc(close, 11) + _roc(close, 14), 10)
+
+
+def dpo(close, n):
+    c = np.asarray(close, float)
+    return c - _shift(_sma(c, n), n // 2 + 1)
+
+
+def trend_intensity(close, n):
+    c = np.asarray(close, float)
+    dev = c - _sma(c, n)
+    half = max(1, n // 2)
+    sp = roll_sum_safe(np.where(dev > 0, dev, 0.0), half)
+    sn = roll_sum_safe(np.where(dev < 0, -dev, 0.0), half)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * sp / (sp + sn)
+
+
+def linreg_slope(close, n):
+    c = np.asarray(close, float)
+    t = np.arange(n, dtype=float)
+    tm = t.mean()
+    ss = ((t - tm) ** 2).sum()
+    out = np.full(len(c), np.nan)
+    for i in range(n - 1, len(c)):
+        y = c[i - n + 1:i + 1]
+        out[i] = ((t - tm) * (y - y.mean())).sum() / ss
+    return out
+
+
+def linreg_dev(close, n):
+    """(close − regression endpoint, rolling std of that residual over n) — for the channel veto."""
+    c = np.asarray(close, float)
+    t = np.arange(n, dtype=float)
+    tm = t.mean()
+    ss = ((t - tm) ** 2).sum()
+    reg = np.full(len(c), np.nan)
+    resid_std = np.full(len(c), np.nan)
+    for i in range(n - 1, len(c)):
+        y = c[i - n + 1:i + 1]
+        b = ((t - tm) * (y - y.mean())).sum() / ss
+        a = y.mean() - b * tm
+        line = a + b * t
+        reg[i] = line[-1]
+        resid_std[i] = np.sqrt(np.mean((y - line) ** 2))
+    return c - reg, resid_std
+
+
+def chandelier(high, low, close, n, m):
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    atr = _atr(h, l, c, n)
+    return _roll_max(h, n) - m * atr, _roll_min(l, n) + m * atr
+
+
+def chande_kroll(high, low, close, n, m, p):
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    atr = _atr(h, l, c, n)
+    first_hs = _roll_max(h, n) - m * atr
+    first_ls = _roll_min(l, n) + m * atr
+    return _roll_max(first_hs, p), _roll_min(first_ls, p)
+
+
+def qqe(close, n, sf, f):
+    """QQE trend line ∈ {+1,-1}: smoothed-RSI vs its ATR-of-RSI trailing bands."""
+    rsi_ma = nan_ema(_rsi(close, n), sf)
+    wilder = 2 * n - 1
+    delta = np.abs(rsi_ma - _shift(rsi_ma, 1))
+    dar = nan_ema(nan_ema(delta, wilder), wilder) * f
+    N = len(rsi_ma)
+    longb = np.full(N, np.nan)
+    shortb = np.full(N, np.nan)
+    trend = np.full(N, np.nan)
+    fin = np.where(~np.isnan(rsi_ma) & ~np.isnan(dar))[0]
+    if len(fin) == 0:
+        return trend
+    s = int(fin[0])
+    longb[s], shortb[s], trend[s] = rsi_ma[s] - dar[s], rsi_ma[s] + dar[s], 1.0
+    for i in range(s + 1, N):
+        nl, ns = rsi_ma[i] - dar[i], rsi_ma[i] + dar[i]
+        longb[i] = max(longb[i - 1], nl) if rsi_ma[i - 1] > longb[i - 1] else nl
+        shortb[i] = min(shortb[i - 1], ns) if rsi_ma[i - 1] < shortb[i - 1] else ns
+        if rsi_ma[i] > shortb[i - 1]:
+            trend[i] = 1.0
+        elif rsi_ma[i] < longb[i - 1]:
+            trend[i] = -1.0
+        else:
+            trend[i] = trend[i - 1]
+    return trend
+
+
+def elder_ray(high, low, close, n):
+    e = _ema(close, n)
+    return np.asarray(high, float) - e, np.asarray(low, float) - e
+
+
+def asi(openp, high, low, close, limit):
+    o, h, l, c = map(lambda a: np.asarray(a, float), (openp, high, low, close))
+    N = len(c)
+    si = np.zeros(N)
+    for i in range(1, N):
+        cy, oy = c[i - 1], o[i - 1]
+        k = max(abs(h[i] - cy), abs(l[i] - cy))
+        a1, a2, a3 = abs(h[i] - cy), abs(l[i] - cy), abs(h[i] - l[i])
+        if a1 >= a2 and a1 >= a3:
+            r = a1 - 0.5 * a2 + 0.25 * abs(cy - oy)
+        elif a2 >= a3:
+            r = a2 - 0.5 * a1 + 0.25 * abs(cy - oy)
+        else:
+            r = a3 + 0.25 * abs(cy - oy)
+        if r != 0 and limit != 0:
+            si[i] = 50.0 * ((c[i] - cy) + 0.5 * (c[i] - o[i]) + 0.25 * (cy - oy)) / r * (k / limit)
+    return np.cumsum(si)
+
+
+def dma(close, f, s, m):
+    ddd = _sma(close, f) - _sma(close, s)
+    return ddd, nan_sma(ddd, m)
+
+
+def bbi(close):
+    return (_sma(close, 3) + _sma(close, 6) + _sma(close, 12) + _sma(close, 24)) / 4.0

--- a/subprojects/Parametric-Indicators/indicators/calc/vol.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/vol.py
@@ -1,0 +1,174 @@
+"""Volatility primitives (pure, causal). Return float arrays; NaN during warm-up.
+
+Most feed the magnitude-veto convention (value vs its own EMA); a few are bounded (choppiness, mass
+index) or band-based (STARC/accel/projection)."""
+from __future__ import annotations
+
+import numpy as np
+
+from .. import classic
+from ..classic import _roll_max, _roll_min
+from ..classic import atr as _atr
+from ..classic import ema as _ema
+from ..classic import sma as _sma
+from ..classic import true_range as _tr
+from .osc import roc as _roc, roll_sum_safe
+
+
+def rolling_std(x, n):
+    """Population rolling std (ddof=0); NaN for windows with any NaN (matches classic.bollinger)."""
+    x = np.asarray(x, dtype=float)
+    out = np.full(len(x), np.nan)
+    if len(x) >= n:
+        win = np.lib.stride_tricks.sliding_window_view(x, n)
+        out[n - 1:] = win.std(axis=1)
+    return out
+
+
+def _rolling_var(x, n, ddof=1):
+    x = np.asarray(x, dtype=float)
+    out = np.full(len(x), np.nan)
+    if len(x) >= n:
+        win = np.lib.stride_tricks.sliding_window_view(x, n)
+        out[n - 1:] = win.var(axis=1, ddof=ddof)
+    return out
+
+
+# --- positive-magnitude vols (magnitude-veto) ---
+def atr_norm(high, low, close, n):
+    return _atr(high, low, close, n) / np.asarray(close, float)
+
+
+def stddev(close, n):
+    return rolling_std(np.asarray(close, float), n)
+
+
+def hist_vol(close, n, annual=252.0):
+    c = np.asarray(close, float)
+    lr = np.full(len(c), np.nan)
+    lr[1:] = np.log(c[1:] / c[:-1])
+    return rolling_std(lr, n) * np.sqrt(annual)
+
+
+def parkinson(high, low, n):
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    lr2 = np.log(h / l) ** 2
+    return np.sqrt(roll_sum_safe(lr2, n) / (4.0 * n * np.log(2.0)))
+
+
+def garman_klass(openp, high, low, close, n):
+    o, h, l, c = map(lambda a: np.asarray(a, float), (openp, high, low, close))
+    term = 0.5 * np.log(h / l) ** 2 - (2.0 * np.log(2.0) - 1.0) * np.log(c / o) ** 2
+    return np.sqrt(np.maximum(roll_sum_safe(term, n) / n, 0.0))
+
+
+def rogers_satchell(openp, high, low, close, n):
+    o, h, l, c = map(lambda a: np.asarray(a, float), (openp, high, low, close))
+    term = np.log(h / c) * np.log(h / o) + np.log(l / c) * np.log(l / o)
+    return np.sqrt(np.maximum(roll_sum_safe(term, n) / n, 0.0))
+
+
+def yang_zhang(openp, high, low, close, n):
+    o, h, l, c = map(lambda a: np.asarray(a, float), (openp, high, low, close))
+    N = len(c)
+    oc = np.log(c / o)
+    on = np.full(N, np.nan)
+    on[1:] = np.log(o[1:] / c[:-1])
+    vo = _rolling_var(on, n)
+    vc = _rolling_var(oc, n)
+    rs_term = np.log(h / c) * np.log(h / o) + np.log(l / c) * np.log(l / o)
+    vrs = roll_sum_safe(rs_term, n) / n
+    k = 0.34 / (1.34 + (n + 1) / (n - 1))
+    return np.sqrt(np.maximum(vo + k * vc + (1.0 - k) * vrs, 0.0))
+
+
+def ulcer(close, n):
+    c = np.asarray(close, float)
+    out = np.full(len(c), np.nan)
+    for i in range(n - 1, len(c)):
+        w = c[i - n + 1:i + 1]
+        peak = np.maximum.accumulate(w)
+        dd = 100.0 * (w - peak) / peak
+        out[i] = np.sqrt(np.mean(dd ** 2))
+    return out
+
+
+def vol_ratio(high, low, close, n_fast, n_slow):
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return _atr(high, low, close, n_fast) / _atr(high, low, close, n_slow)
+
+
+# --- 0-centred / bounded vols ---
+def chaikin_vol(high, low, n, roc_n):
+    e = _ema(np.asarray(high, float) - np.asarray(low, float), n)
+    return _roc(e, roc_n)
+
+
+def rvi_dorsey(close, n, stdlen=10):
+    """Relative Volatility Index (Dorsey): RSI logic on rolling std, up-days vs down-days."""
+    c = np.asarray(close, float)
+    s = rolling_std(c, stdlen)
+    d = np.full(len(c), np.nan)
+    d[1:] = np.diff(c)
+    u = np.where(d > 0, s, 0.0)
+    dn = np.where(d < 0, s, 0.0)
+    au, ad = classic.rma(u, n), classic.rma(dn, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * au / (au + ad)
+
+
+def mass_index(high, low, n):
+    rng = np.asarray(high, float) - np.asarray(low, float)
+    e1 = _ema(rng, 9)
+    e2 = _ema(e1, 9)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        ratio = e1 / e2
+    return roll_sum_safe(ratio, n)
+
+
+def choppiness(high, low, close, n):
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    s = roll_sum_safe(_tr(h, l, c), n)
+    rng = _roll_max(h, n) - _roll_min(l, n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * np.log10(s / rng) / np.log10(n)
+
+
+def ttm_squeeze(high, low, close, n):
+    """1.0 when Bollinger(n,2) sits INSIDE Keltner(n,1.5) (squeeze on), else 0.0."""
+    _, bu, bl = classic.bollinger(np.asarray(close, float), n, 2.0)
+    _, ku, kl = classic.keltner(high, low, close, n, 1.5)
+    on = (bl > kl) & (bu < ku)
+    return on.astype(float)
+
+
+# --- bands (band-veto) ---
+def starc(high, low, close, n, m):
+    mid = _sma(np.asarray(close, float), n)
+    a = _atr(high, low, close, n)
+    return mid + m * a, mid - m * a
+
+
+def accel_bands(high, low, close, n, f):
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    hl = (h - l) / (h + l)
+    return _sma(h * (1.0 + f * hl), n), _sma(l * (1.0 - f * hl), n)
+
+
+def proj_bands(high, low, n):
+    """Mickey Jordan projection bands: each bar's high/low extended by its window regression slope."""
+    h, l = np.asarray(high, float), np.asarray(low, float)
+    N = len(h)
+    upper = np.full(N, np.nan)
+    lower = np.full(N, np.nan)
+    t = np.arange(n, dtype=float)
+    tm = t.mean()
+    ss = ((t - tm) ** 2).sum()
+    for i in range(n - 1, N):
+        wh, wl = h[i - n + 1:i + 1], l[i - n + 1:i + 1]
+        sh = ((t - tm) * (wh - wh.mean())).sum() / ss
+        sl = ((t - tm) * (wl - wl.mean())).sum() / ss
+        fwd = n - 1 - t                                # bars forward to the current bar
+        upper[i] = np.max(wh + sh * fwd)
+        lower[i] = np.min(wl + sl * fwd)
+    return upper, lower

--- a/subprojects/Parametric-Indicators/indicators/calc/volume.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/volume.py
@@ -1,0 +1,176 @@
+"""Volume / money-flow primitives (pure, causal). Return float arrays; NaN/soft-seed during warm-up."""
+from __future__ import annotations
+
+import numpy as np
+
+from .. import classic
+from ..classic import ema as _ema
+from ..classic import sma as _sma
+from .osc import _shift, nan_sma, roll_sum_safe
+
+
+def _mfm(high, low, close):
+    """Money-flow multiplier ((C−L)−(H−C))/(H−L); 0 where H==L."""
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    rng = h - l
+    with np.errstate(invalid="ignore", divide="ignore"):
+        m = ((c - l) - (h - c)) / rng
+    m[rng == 0] = 0.0
+    return m
+
+
+def ad_line(high, low, close, volume):
+    return np.cumsum(_mfm(high, low, close) * np.asarray(volume, float))
+
+
+def cmf(high, low, close, volume, n):
+    v = np.asarray(volume, float)
+    return roll_sum_safe(_mfm(high, low, close) * v, n) / roll_sum_safe(v, n)
+
+
+def chaikin_osc(high, low, close, volume, fast, slow):
+    ad = ad_line(high, low, close, volume)
+    return _ema(ad, fast) - _ema(ad, slow)
+
+
+def pvt(close, volume):
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    out = np.zeros(len(c))
+    for i in range(1, len(c)):
+        out[i] = out[i - 1] + (c[i] - c[i - 1]) / c[i - 1] * v[i]
+    return out
+
+
+def tvi(close, volume, min_tick):
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    out = np.zeros(len(c))
+    direction = 1
+    for i in range(1, len(c)):
+        ch = c[i] - c[i - 1]
+        if ch > min_tick:
+            direction = 1
+        elif ch < -min_tick:
+            direction = -1
+        out[i] = out[i - 1] + (v[i] if direction > 0 else -v[i])
+    return out
+
+
+def nvi(close, volume):
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    out = np.full(len(c), 1000.0)
+    for i in range(1, len(c)):
+        out[i] = out[i - 1] * (1.0 + (c[i] - c[i - 1]) / c[i - 1]) if v[i] < v[i - 1] else out[i - 1]
+    return out
+
+
+def pvi(close, volume):
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    out = np.full(len(c), 1000.0)
+    for i in range(1, len(c)):
+        out[i] = out[i - 1] * (1.0 + (c[i] - c[i - 1]) / c[i - 1]) if v[i] > v[i - 1] else out[i - 1]
+    return out
+
+
+def eom(high, low, volume, n, scale=1e6):
+    h, l, v = map(lambda a: np.asarray(a, float), (high, low, volume))
+    hl2 = (h + l) / 2.0
+    dist = hl2 - _shift(hl2, 1)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        box = (v / scale) / (h - l)
+        emv = dist / box
+    return nan_sma(emv, n)
+
+
+def force_index(close, volume, n):
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    dc = np.zeros(len(c))
+    dc[1:] = np.diff(c)
+    return _ema(dc * v, n)
+
+
+def klinger(high, low, close, volume, fast, slow, signal):
+    h, l, c, v = map(lambda a: np.asarray(a, float), (high, low, close, volume))
+    N = len(c)
+    hlc = (h + l + c) / 3.0
+    trend = np.zeros(N)
+    for i in range(1, N):
+        trend[i] = 1.0 if hlc[i] > hlc[i - 1] else -1.0
+    dm = h - l
+    cm = np.zeros(N)
+    for i in range(1, N):
+        cm[i] = cm[i - 1] + dm[i] if trend[i] == trend[i - 1] else dm[i - 1] + dm[i]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        vf = v * np.abs(2.0 * (dm / cm - 1.0)) * trend * 100.0
+    vf[~np.isfinite(vf)] = 0.0
+    kvo = _ema(vf, fast) - _ema(vf, slow)
+    return kvo, _ema(kvo, signal)
+
+
+def vol_osc(volume, fast, slow):
+    v = np.asarray(volume, float)
+    ef, es = _ema(v, fast), _ema(v, slow)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * (ef - es) / es
+
+
+def vzo(close, volume, n):
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    dc = np.zeros(len(c))
+    dc[1:] = np.sign(np.diff(c))
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * _ema(dc * v, n) / _ema(v, n)
+
+
+def demand_index(close, volume, n):
+    """Simplified demand/pressure index ∈ [−1,1]: EMA(up-volume) vs EMA(down-volume)."""
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    dc = np.zeros(len(c))
+    dc[1:] = np.diff(c)
+    bp = _ema(np.where(dc > 0, v, 0.0), n)
+    sp = _ema(np.where(dc < 0, v, 0.0), n)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return (bp - sp) / (bp + sp)
+
+
+def twiggs_mf(high, low, close, volume, n):
+    h, l, c, v = map(lambda a: np.asarray(a, float), (high, low, close, volume))
+    trh = np.maximum(h, _shift(c, 1))
+    trl = np.minimum(l, _shift(c, 1))
+    with np.errstate(invalid="ignore", divide="ignore"):
+        adc = (2.0 * c - trh - trl) / (trh - trl) * v
+    return roll_sum_safe(adc, n) / roll_sum_safe(v, n)
+
+
+def wvad(openp, high, low, close, volume, n):
+    o, h, l, c, v = map(lambda a: np.asarray(a, float), (openp, high, low, close, volume))
+    with np.errstate(invalid="ignore", divide="ignore"):
+        bar = (c - o) / (h - l) * v
+    bar[~np.isfinite(bar)] = 0.0
+    return roll_sum_safe(bar, n)
+
+
+def bw_mfi(high, low, volume):
+    """Bill Williams MFI regime stance: +1 green (mfi↑ & vol↑), −1 fade (mfi↓ & vol↓), else 0."""
+    h, l, v = map(lambda a: np.asarray(a, float), (high, low, volume))
+    with np.errstate(invalid="ignore", divide="ignore"):
+        mfi = (h - l) / v
+    pm, pv = _shift(mfi, 1), _shift(v, 1)
+    st = np.zeros(len(v))
+    mfi_up, v_up = mfi > pm, v > pv
+    st[mfi_up & v_up] = 1.0
+    st[(~mfi_up) & (~v_up) & np.isfinite(pm)] = -1.0
+    return st
+
+
+def volume_ratio_asia(close, volume, n):
+    c, v = np.asarray(close, float), np.asarray(volume, float)
+    dc = np.zeros(len(c))
+    dc[1:] = np.diff(c)
+    up = np.where(dc > 0, v, 0.0) + np.where(dc == 0, 0.5 * v, 0.0)
+    dn = np.where(dc < 0, v, 0.0) + np.where(dc == 0, 0.5 * v, 0.0)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return 100.0 * roll_sum_safe(up, n) / roll_sum_safe(dn, n)
+
+
+def anchored_vwap(high, low, close, volume, session_id):
+    return classic.vwap(high, low, close, volume, session_id)

--- a/subprojects/Parametric-Indicators/indicators/lib_bw.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_bw.py
@@ -1,0 +1,4 @@
+"""bw-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_bw.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_bw.py
@@ -1,4 +1,77 @@
-"""bw-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+"""bw-school indicator classes (Bill Williams + Elliott Wave Oscillator).
+CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+from __future__ import annotations
 
-CLASSES = ()
-SCHEMA = {}
+import numpy as np
+
+from .calc import bw as BW, osc
+from .stances import StanceIndicator, _sign_stance
+
+
+class Alligator(StanceIndicator):
+    """+1 when lips>teeth>jaw (bullish alignment), -1 when lips<teeth<jaw."""
+    key = "alligator"
+    def stance(self, ctx):
+        jaw, teeth, lips = BW.alligator(ctx.high, ctx.low)
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[(lips > teeth) & (teeth > jaw)] = 1
+        st[(lips < teeth) & (teeth < jaw)] = -1
+        return st
+    def warmup_bars(self): return 21
+
+
+class Fractals(StanceIndicator):
+    """Breakout of the last confirmed Williams fractal: +1 above up-fractal, -1 below down-fractal."""
+    key = "fractals"
+    def stance(self, ctx):
+        up, dn = BW.fractal_levels(ctx.high, ctx.low)
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[np.isfinite(up) & (ctx.close > up)] = 1
+        st[np.isfinite(dn) & (ctx.close < dn)] = -1
+        return st
+    def warmup_bars(self): return 5
+
+
+class AwesomeOsc(StanceIndicator):
+    key = "awesome_osc"
+    def stance(self, ctx): return _sign_stance(BW.awesome((ctx.high + ctx.low) / 2.0))
+    def warmup_bars(self): return 34
+
+
+class AccelOsc(StanceIndicator):
+    key = "accel_osc"
+    def stance(self, ctx): return _sign_stance(BW.accel((ctx.high + ctx.low) / 2.0))
+    def warmup_bars(self): return 39
+
+
+class Gator(StanceIndicator):
+    """Alligator direction, gated to only vote while BOTH gator gaps are expanding (trending)."""
+    key = "gator"
+    def stance(self, ctx):
+        jaw, teeth, lips = BW.alligator(ctx.high, ctx.low)
+        upper = np.abs(jaw - teeth)
+        lower = np.abs(teeth - lips)
+        expanding = (upper > osc._shift(upper, 1)) & (lower > osc._shift(lower, 1))
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        direction = np.sign(lips - jaw)
+        st[expanding & (direction > 0)] = 1
+        st[expanding & (direction < 0)] = -1
+        return st
+    def warmup_bars(self): return 21
+
+
+class ElliottWaveOsc(StanceIndicator):
+    key = "elliott_wave_osc"
+    def stance(self, ctx): return _sign_stance(BW.ewo(ctx.close))
+    def warmup_bars(self): return 34
+
+
+CLASSES = (Alligator, Fractals, AwesomeOsc, AccelOsc, Gator, ElliottWaveOsc)
+SCHEMA = {
+    "alligator": {"label": "Alligator", "mode": "confirm", "params": []},
+    "fractals": {"label": "Williams Fractals", "mode": "confirm", "params": []},
+    "awesome_osc": {"label": "Awesome Oscillator", "mode": "confirm", "params": []},
+    "accel_osc": {"label": "Accelerator Oscillator", "mode": "confirm", "params": []},
+    "gator": {"label": "Gator Oscillator", "mode": "confirm", "params": []},
+    "elliott_wave_osc": {"label": "Elliott Wave Oscillator", "mode": "confirm", "params": []},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_levels.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_levels.py
@@ -1,0 +1,4 @@
+"""levels-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_levels.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_levels.py
@@ -1,4 +1,118 @@
-"""levels-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+"""levels-school indicator classes (Ichimoku + session pivots).
+CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+from __future__ import annotations
 
-CLASSES = ()
-SCHEMA = {}
+import numpy as np
+
+from .base import Indicator
+from .calc import levels as LV, osc
+from .stances import StanceIndicator, _sign_stance
+
+
+def _sess(ctx):
+    return ctx.session_id if ctx.session_id is not None else np.zeros(len(ctx.close), dtype=int)
+
+
+def _breakout(close, upper, lower):
+    st = np.zeros(len(close), dtype=np.int8)
+    st[np.isfinite(upper) & (close > upper)] = 1
+    st[np.isfinite(lower) & (close < lower)] = -1
+    return st
+
+
+class IchimokuTKCross(StanceIndicator):
+    key = "ichimoku_tk_cross"
+    def stance(self, ctx):
+        p = self.config.params
+        tenkan, kijun, _, _ = LV.ichimoku_lines(ctx.high, ctx.low, int(p.get("t", 9)), int(p.get("k", 26)), 52)
+        return _sign_stance(tenkan - kijun)
+    def warmup_bars(self): return int(self.config.params.get("k", 26))
+
+
+class IchimokuCloud(StanceIndicator):
+    key = "ichimoku_cloud"
+    def stance(self, ctx):
+        p = self.config.params
+        pa, pb = LV.cloud_past(ctx.high, ctx.low, int(p.get("t", 9)), int(p.get("k", 26)), int(p.get("b", 52)))
+        return _breakout(ctx.close, np.maximum(pa, pb), np.minimum(pa, pb))
+    def warmup_bars(self): return int(self.config.params.get("b", 52)) + 26
+
+
+class IchimokuChikou(StanceIndicator):
+    key = "ichimoku_chikou"
+    def stance(self, ctx):
+        lag = int(self.config.params.get("lag", 26))
+        return _sign_stance(ctx.close - osc._shift(ctx.close, lag))
+    def warmup_bars(self): return int(self.config.params.get("lag", 26))
+
+
+class _Pivot(StanceIndicator):
+    def _pp(self, pO, pH, pL, pC):
+        raise NotImplementedError
+    def stance(self, ctx):
+        pO, pH, pL, pC = LV.prior_session_ohlc(ctx.open, ctx.high, ctx.low, ctx.close, _sess(ctx))
+        return _sign_stance(ctx.close - self._pp(pO, pH, pL, pC))
+    def warmup_bars(self): return 1
+
+
+class PivotFloor(_Pivot):
+    key = "pivot_floor"
+    def _pp(self, pO, pH, pL, pC): return LV.floor_pp(pH, pL, pC)
+
+
+class PivotWoodie(_Pivot):
+    key = "pivot_woodie"
+    def _pp(self, pO, pH, pL, pC): return LV.woodie_pp(pH, pL, pC)
+
+
+class PivotDemark(_Pivot):
+    key = "pivot_demark"
+    def _pp(self, pO, pH, pL, pC): return LV.demark_pp(pO, pH, pL, pC)
+
+
+class PivotCamarilla(StanceIndicator):
+    key = "pivot_camarilla"
+    def stance(self, ctx):
+        _, pH, pL, pC = LV.prior_session_ohlc(ctx.open, ctx.high, ctx.low, ctx.close, _sess(ctx))
+        r3, s3 = LV.camarilla_bands(pH, pL, pC)
+        return _breakout(ctx.close, r3, s3)
+    def warmup_bars(self): return 1
+
+
+class PivotFib(StanceIndicator):
+    key = "pivot_fib"
+    def stance(self, ctx):
+        _, pH, pL, pC = LV.prior_session_ohlc(ctx.open, ctx.high, ctx.low, ctx.close, _sess(ctx))
+        r1, s1 = LV.fib_levels(pH, pL, pC)
+        return _breakout(ctx.close, r1, s1)
+    def warmup_bars(self): return 1
+
+
+class CPR(StanceIndicator):
+    key = "cpr"
+    def stance(self, ctx):
+        _, pH, pL, pC = LV.prior_session_ohlc(ctx.open, ctx.high, ctx.low, ctx.close, _sess(ctx))
+        top, bot = LV.cpr_levels(pH, pL, pC)
+        return _breakout(ctx.close, top, bot)
+    def warmup_bars(self): return 1
+
+
+CLASSES = (IchimokuTKCross, IchimokuCloud, IchimokuChikou, PivotFloor, PivotWoodie, PivotDemark,
+           PivotCamarilla, PivotFib, CPR)
+SCHEMA = {
+    "ichimoku_tk_cross": {"label": "Ichimoku Tenkan/Kijun cross", "mode": "confirm",
+                          "params": [{"name": "t", "default": 9, "min": 2, "max": 100, "step": 1},
+                                     {"name": "k", "default": 26, "min": 2, "max": 200, "step": 1}]},
+    "ichimoku_cloud": {"label": "Ichimoku cloud", "mode": "confirm",
+                       "params": [{"name": "t", "default": 9, "min": 2, "max": 100, "step": 1},
+                                  {"name": "k", "default": 26, "min": 2, "max": 200, "step": 1},
+                                  {"name": "b", "default": 52, "min": 2, "max": 300, "step": 1}]},
+    "ichimoku_chikou": {"label": "Ichimoku Chikou", "mode": "confirm",
+                        "params": [{"name": "lag", "default": 26, "min": 1, "max": 200, "step": 1}]},
+    "pivot_floor": {"label": "Floor pivot", "mode": "confirm", "params": []},
+    "pivot_woodie": {"label": "Woodie pivot", "mode": "confirm", "params": []},
+    "pivot_camarilla": {"label": "Camarilla pivot", "mode": "confirm", "params": []},
+    "pivot_fib": {"label": "Fibonacci pivot", "mode": "confirm", "params": []},
+    "pivot_demark": {"label": "DeMark pivot", "mode": "confirm", "params": []},
+    "cpr": {"label": "Central Pivot Range", "mode": "confirm", "params": []},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_ma.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_ma.py
@@ -1,4 +1,39 @@
-"""ma-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+"""ma-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py.
 
-CLASSES = ()
-SCHEMA = {}
+Each is a moving-average trend stance: +1 when close>fast>slow (uptrend), -1 when close<fast<slow,
+else 0 — identical shape to the built-in EMATrend/SMATrend, differing only in the MA primitive."""
+from __future__ import annotations
+
+import numpy as np
+
+from .calc import ma
+from .stances import StanceIndicator
+
+
+class WMATrend(StanceIndicator):
+    key = "wma"
+
+    def stance(self, ctx):
+        p = self.config.params
+        f = ma.wma(ctx.close, int(p.get("fast", 20)))
+        s = ma.wma(ctx.close, int(p.get("slow", 50)))
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[(ctx.close > f) & (f > s)] = 1
+        st[(ctx.close < f) & (f < s)] = -1
+        return st
+
+    def warmup_bars(self):
+        p = self.config.params
+        return max(int(p.get("fast", 20)), int(p.get("slow", 50)))
+
+    def warmup_deps(self):
+        p = self.config.params
+        return f"WMA({int(p.get('fast', 20))}) & WMA({int(p.get('slow', 50))})"
+
+
+CLASSES = (WMATrend,)
+SCHEMA = {
+    "wma": {"label": "WMA trend", "mode": "confirm",
+            "params": [{"name": "fast", "default": 20, "min": 2, "max": 400, "step": 1},
+                       {"name": "slow", "default": 50, "min": 2, "max": 400, "step": 1}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_ma.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_ma.py
@@ -1,0 +1,4 @@
+"""ma-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_ma.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_ma.py
@@ -1,39 +1,252 @@
 """ma-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py.
 
-Each is a moving-average trend stance: +1 when close>fast>slow (uptrend), -1 when close<fast<slow,
-else 0 — identical shape to the built-in EMATrend/SMATrend, differing only in the MA primitive."""
+Two stance shapes, mirroring the built-ins:
+  * CROSS (like EMATrend/SMATrend): +1 when close>fast>slow, -1 when close<fast<slow — for the simple
+    linear MAs (wma, rma, dema, tema, tma, hma, zlema, sine_wma, vwma, lsma).
+  * SINGLE-LINE (like KeltnerTrend/VWAPTrend): +1 when close>MA, -1 when close<MA — for the adaptive
+    MAs whose "period" is one of several shape params (kama, vidya, alma, t3, mcginley, evwma).
+Plus three specials: gmma (ribbon alignment), ma_envelope (trend + overextension veto), ma_displaced.
+"""
 from __future__ import annotations
 
 import numpy as np
 
+from . import classic
+from .base import BOTH, Indicator
 from .calc import ma
-from .stances import StanceIndicator
+from .stances import StanceIndicator, _sign_stance
 
 
-class WMATrend(StanceIndicator):
-    key = "wma"
+def _cross_stance(close: np.ndarray, f: np.ndarray, s: np.ndarray) -> np.ndarray:
+    st = np.zeros(len(close), dtype=np.int8)
+    st[(close > f) & (f > s)] = 1
+    st[(close < f) & (f < s)] = -1
+    return st
+
+
+class _CrossMA(StanceIndicator):
+    """Base for fast/slow-cross MAs. Subclass sets `key` and `_line(x, n)`; params are fast/slow."""
+    _warm_mult = 1
+
+    def _line(self, x, n):  # noqa: D401
+        raise NotImplementedError
 
     def stance(self, ctx):
         p = self.config.params
-        f = ma.wma(ctx.close, int(p.get("fast", 20)))
-        s = ma.wma(ctx.close, int(p.get("slow", 50)))
-        st = np.zeros(len(ctx.close), dtype=np.int8)
-        st[(ctx.close > f) & (f > s)] = 1
-        st[(ctx.close < f) & (f < s)] = -1
-        return st
+        f = self._line(ctx.close, int(p.get("fast", 20)))
+        s = self._line(ctx.close, int(p.get("slow", 50)))
+        return _cross_stance(ctx.close, f, s)
 
+    def warmup_bars(self):
+        p = self.config.params
+        return self._warm_mult * max(int(p.get("fast", 20)), int(p.get("slow", 50)))
+
+
+class WMATrend(_CrossMA):
+    key = "wma"
+    def _line(self, x, n): return ma.wma(x, n)
+
+
+class RMATrend(_CrossMA):
+    key = "rma"
+    def _line(self, x, n): return classic.rma(x, n)
+
+
+class DEMATrend(_CrossMA):
+    key = "dema"
+    _warm_mult = 2
+    def _line(self, x, n): return ma.dema(x, n)
+
+
+class TEMATrend(_CrossMA):
+    key = "tema"
+    _warm_mult = 3
+    def _line(self, x, n): return ma.tema(x, n)
+
+
+class TMATrend(_CrossMA):
+    key = "tma"
+    def _line(self, x, n): return ma.tma(x, n)
+
+
+class HMATrend(_CrossMA):
+    key = "hma"
+    def _line(self, x, n): return ma.hma(x, n)
+
+
+class ZLEMATrend(_CrossMA):
+    key = "zlema"
+    def _line(self, x, n): return ma.zlema(x, n)
+
+
+class SineWMATrend(_CrossMA):
+    key = "sine_wma"
+    def _line(self, x, n): return ma.sine_wma(x, n)
+
+
+class LSMATrend(_CrossMA):
+    key = "lsma"
+    def _line(self, x, n): return ma.lsma(x, n)
+
+
+class VWMATrend(StanceIndicator):
+    key = "vwma"
+    def stance(self, ctx):
+        p = self.config.params
+        f = ma.vwma(ctx.close, ctx.volume, int(p.get("fast", 20)))
+        s = ma.vwma(ctx.close, ctx.volume, int(p.get("slow", 50)))
+        return _cross_stance(ctx.close, f, s)
     def warmup_bars(self):
         p = self.config.params
         return max(int(p.get("fast", 20)), int(p.get("slow", 50)))
 
-    def warmup_deps(self):
+
+# --- single-line adaptive MAs: stance = sign(close - line) ---
+class KAMATrend(StanceIndicator):
+    key = "kama"
+    def stance(self, ctx):
         p = self.config.params
-        return f"WMA({int(p.get('fast', 20))}) & WMA({int(p.get('slow', 50))})"
+        line = ma.kama(ctx.close, int(p.get("n", 10)), int(p.get("fast", 2)), int(p.get("slow", 30)))
+        return _sign_stance(ctx.close - line)
+    def warmup_bars(self): return int(self.config.params.get("n", 10))
 
 
-CLASSES = (WMATrend,)
+class VIDYATrend(StanceIndicator):
+    key = "vidya"
+    def stance(self, ctx):
+        line = ma.vidya(ctx.close, int(self.config.params.get("n", 14)))
+        return _sign_stance(ctx.close - line)
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class ALMATrend(StanceIndicator):
+    key = "alma"
+    def stance(self, ctx):
+        p = self.config.params
+        line = ma.alma(ctx.close, int(p.get("n", 9)), float(p.get("offset", 0.85)), float(p.get("sigma", 6.0)))
+        return _sign_stance(ctx.close - line)
+    def warmup_bars(self): return int(self.config.params.get("n", 9))
+
+
+class T3Trend(StanceIndicator):
+    key = "t3"
+    def stance(self, ctx):
+        p = self.config.params
+        line = ma.t3(ctx.close, int(p.get("n", 10)), float(p.get("v", 0.7)))
+        return _sign_stance(ctx.close - line)
+    def warmup_bars(self): return 3 * int(self.config.params.get("n", 10))
+
+
+class McGinleyTrend(StanceIndicator):
+    key = "mcginley"
+    def stance(self, ctx):
+        line = ma.mcginley(ctx.close, int(self.config.params.get("n", 14)))
+        return _sign_stance(ctx.close - line)
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class EVWMATrend(StanceIndicator):
+    key = "evwma"
+    def stance(self, ctx):
+        line = ma.evwma(ctx.close, ctx.volume, int(self.config.params.get("n", 20)))
+        return _sign_stance(ctx.close - line)
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+# --- specials ---
+class GMMATrend(StanceIndicator):
+    """Guppy ribbon: +1 when every short EMA is above every long EMA, -1 when every short is below."""
+    key = "gmma"
+    _SHORT = (3, 5, 8, 10, 12, 15)
+    _LONG = (30, 35, 40, 45, 50, 60)
+    def stance(self, ctx):
+        shorts = np.vstack([classic.ema(ctx.close, p) for p in self._SHORT])
+        longs = np.vstack([classic.ema(ctx.close, p) for p in self._LONG])
+        min_short, max_short = shorts.min(0), shorts.max(0)
+        min_long, max_long = longs.min(0), longs.max(0)
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[min_short > max_long] = 1
+        st[max_short < min_long] = -1
+        return st
+    def warmup_bars(self): return max(self._LONG)
+
+
+class MAEnvelope(Indicator):
+    """SMA-envelope: confirm the trend (close vs SMA); veto BOTH sides when price is overextended
+    beyond ±pct% of the SMA (mean-reversion risk)."""
+    key = "ma_envelope"
+    def directions(self, ctx):
+        p = self.config.params
+        n = int(p.get("n", 20))
+        pct = float(p.get("pct", 2.5))
+        mid = classic.sma(ctx.close, n)
+        cdir = _sign_stance(ctx.close - mid)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            dev = np.abs(ctx.close / mid - 1.0) * 100.0
+        vdir = np.zeros(len(ctx.close), dtype=np.int8)
+        vdir[np.isfinite(dev) & (dev > pct)] = BOTH
+        return cdir, vdir
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class MADisplaced(StanceIndicator):
+    """Displaced SMA: stance = sign(close − SMA(n) shifted d bars into the past)."""
+    key = "ma_displaced"
+    def stance(self, ctx):
+        p = self.config.params
+        n = int(p.get("n", 20))
+        d = int(p.get("d", 5))
+        line = classic.sma(ctx.close, n)
+        disp = np.full(len(line), np.nan)
+        if d < len(line):
+            disp[d:] = line[:-d] if d > 0 else line
+        return _sign_stance(ctx.close - disp)
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 20)) + int(p.get("d", 5))
+
+
+CLASSES = (
+    WMATrend, RMATrend, DEMATrend, TEMATrend, TMATrend, HMATrend, ZLEMATrend, SineWMATrend,
+    LSMATrend, VWMATrend, KAMATrend, VIDYATrend, ALMATrend, T3Trend, McGinleyTrend, EVWMATrend,
+    GMMATrend, MAEnvelope, MADisplaced,
+)
+
+_FS = [{"name": "fast", "default": 20, "min": 2, "max": 400, "step": 1},
+       {"name": "slow", "default": 50, "min": 2, "max": 400, "step": 1}]
 SCHEMA = {
-    "wma": {"label": "WMA trend", "mode": "confirm",
-            "params": [{"name": "fast", "default": 20, "min": 2, "max": 400, "step": 1},
-                       {"name": "slow", "default": 50, "min": 2, "max": 400, "step": 1}]},
+    "wma":   {"label": "WMA trend", "mode": "confirm", "params": _FS},
+    "rma":   {"label": "RMA / Wilder trend", "mode": "confirm", "params": _FS},
+    "dema":  {"label": "DEMA trend", "mode": "confirm", "params": _FS},
+    "tema":  {"label": "TEMA trend", "mode": "confirm", "params": _FS},
+    "tma":   {"label": "Triangular MA trend", "mode": "confirm", "params": _FS},
+    "hma":   {"label": "Hull MA trend", "mode": "confirm", "params": _FS},
+    "zlema": {"label": "Zero-lag EMA trend", "mode": "confirm", "params": _FS},
+    "sine_wma": {"label": "Sine-weighted MA trend", "mode": "confirm", "params": _FS},
+    "lsma":  {"label": "Least-squares MA trend", "mode": "confirm", "params": _FS},
+    "vwma":  {"label": "Volume-weighted MA trend", "mode": "confirm", "params": _FS},
+    "kama":  {"label": "KAMA trend", "mode": "confirm",
+              "params": [{"name": "n", "default": 10, "min": 2, "max": 100, "step": 1},
+                         {"name": "fast", "default": 2, "min": 2, "max": 30, "step": 1},
+                         {"name": "slow", "default": 30, "min": 2, "max": 200, "step": 1}]},
+    "vidya": {"label": "VIDYA trend", "mode": "confirm",
+              "params": [{"name": "n", "default": 14, "min": 2, "max": 200, "step": 1}]},
+    "alma":  {"label": "ALMA trend", "mode": "confirm",
+              "params": [{"name": "n", "default": 9, "min": 2, "max": 200, "step": 1},
+                         {"name": "offset", "default": 0.85, "min": 0.0, "max": 1.0, "step": 0.05},
+                         {"name": "sigma", "default": 6.0, "min": 1.0, "max": 12.0, "step": 0.5}]},
+    "t3":    {"label": "T3 trend", "mode": "confirm",
+              "params": [{"name": "n", "default": 10, "min": 2, "max": 100, "step": 1},
+                         {"name": "v", "default": 0.7, "min": 0.0, "max": 1.0, "step": 0.05}]},
+    "mcginley": {"label": "McGinley Dynamic trend", "mode": "confirm",
+                 "params": [{"name": "n", "default": 14, "min": 2, "max": 200, "step": 1}]},
+    "evwma": {"label": "Elastic VWMA trend", "mode": "confirm",
+              "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1}]},
+    "gmma":  {"label": "Guppy MMA ribbon", "mode": "confirm", "params": []},
+    "ma_envelope": {"label": "MA envelope (trend + overextension veto)", "mode": "both",
+                    "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1},
+                               {"name": "pct", "default": 2.5, "min": 0.1, "max": 10.0, "step": 0.1}]},
+    "ma_displaced": {"label": "Displaced MA trend", "mode": "confirm",
+                     "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1},
+                                {"name": "d", "default": 5, "min": 1, "max": 50, "step": 1}]},
 }

--- a/subprojects/Parametric-Indicators/indicators/lib_osc.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_osc.py
@@ -1,4 +1,281 @@
-"""osc-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+"""osc-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py.
 
-CLASSES = ()
-SCHEMA = {}
+Two shapes: zone oscillators (_Zone → votes.band_directions with a per-indicator midpoint) and
+signed-momentum stances (StanceIndicator → sign of the line, or of line-minus-signal)."""
+from __future__ import annotations
+
+import numpy as np
+
+from . import votes
+from .base import Indicator
+from .calc import osc
+from .stances import StanceIndicator, _sign_stance
+
+
+class _Zone(Indicator):
+    """Mean-reversion zone oscillator. Subclass sets key, _MID/_LO/_HI defaults, `_value(ctx)`,
+    warmup_bars. Params lower/upper are tunable; midpoint is fixed per indicator."""
+    _MID = 50.0
+    _LO = 30.0
+    _HI = 70.0
+
+    def _value(self, ctx):
+        raise NotImplementedError
+
+    def directions(self, ctx):
+        p = self.config.params
+        lo = float(p.get("lower", self._LO))
+        hi = float(p.get("upper", self._HI))
+        return votes.band_directions(self._value(ctx), lo, hi, self._MID)
+
+
+# ---------- zone oscillators ----------
+class RSICutler(_Zone):
+    key = "rsi_cutler"
+    def _value(self, ctx): return osc.rsi_cutler(ctx.close, int(self.config.params.get("n", 14)))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class RSIConnors(_Zone):
+    key = "rsi_connors"
+    _LO, _HI = 20.0, 80.0
+    def _value(self, ctx): return osc.connors_rsi(ctx.close)
+    def warmup_bars(self): return 100
+
+
+class StochRSI(_Zone):
+    key = "stoch_rsi"
+    _LO, _HI = 20.0, 80.0
+    def _value(self, ctx):
+        p = self.config.params
+        return osc.stoch_rsi(ctx.close, int(p.get("n", 14)), int(p.get("k", 14)), int(p.get("d", 3)))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 14)) + int(p.get("k", 14))
+
+
+class KDJ(_Zone):
+    key = "kdj"
+    _LO, _HI = 20.0, 80.0
+    def _value(self, ctx): return osc.kdj_k(ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 9)))
+    def warmup_bars(self): return int(self.config.params.get("n", 9))
+
+
+class WilliamsR(_Zone):
+    key = "williams_r"
+    _MID, _LO, _HI = -50.0, -80.0, -20.0
+    def _value(self, ctx): return osc.williams_r(ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 14)))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class CMO(_Zone):
+    key = "cmo"
+    _MID, _LO, _HI = 0.0, -50.0, 50.0
+    def _value(self, ctx): return osc.cmo(ctx.close, int(self.config.params.get("n", 14)))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class UltimateOsc(_Zone):
+    key = "ultimate_osc"
+    def _value(self, ctx): return osc.ultimate_osc(ctx.high, ctx.low, ctx.close)
+    def warmup_bars(self): return 28
+
+
+class SMI(_Zone):
+    key = "smi"
+    _MID, _LO, _HI = 0.0, -40.0, 40.0
+    def _value(self, ctx):
+        p = self.config.params
+        return osc.smi(ctx.high, ctx.low, ctx.close, int(p.get("n", 14)), int(p.get("smooth", 3)))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 14)) + 2 * int(p.get("smooth", 3))
+
+
+class RMI(_Zone):
+    key = "rmi"
+    def _value(self, ctx):
+        p = self.config.params
+        return osc.rmi(ctx.close, int(p.get("n", 14)), int(p.get("m", 5)))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 14)) + int(p.get("m", 5))
+
+
+class DynamicDMI(_Zone):
+    key = "cmo_chande_dmi"
+    def _value(self, ctx): return osc.dynamic_dmi(ctx.close, int(self.config.params.get("n", 14)))
+    def warmup_bars(self): return 2 * int(self.config.params.get("n", 14))
+
+
+class WaveTrend(_Zone):
+    key = "wavetrend"
+    _MID, _LO, _HI = 0.0, -60.0, 60.0
+    def _value(self, ctx):
+        p = self.config.params
+        return osc.wavetrend(ctx.high, ctx.low, ctx.close, int(p.get("n1", 10)), int(p.get("n2", 21)))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n1", 10)) + int(p.get("n2", 21))
+
+
+class PGO(_Zone):
+    key = "pgo"
+    _MID, _LO, _HI = 0.0, -3.0, 3.0
+    def _value(self, ctx): return osc.pgo(ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 14)))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class PSY(_Zone):
+    key = "psy"
+    _LO, _HI = 25.0, 75.0
+    def _value(self, ctx): return osc.psy(ctx.close, int(self.config.params.get("n", 12)))
+    def warmup_bars(self): return int(self.config.params.get("n", 12))
+
+
+# ---------- signed-momentum stances ----------
+class Momentum(StanceIndicator):
+    key = "momentum"
+    def stance(self, ctx): return _sign_stance(osc.momentum(ctx.close, int(self.config.params.get("n", 10))))
+    def warmup_bars(self): return int(self.config.params.get("n", 10))
+
+
+class ROC(StanceIndicator):
+    key = "roc"
+    def stance(self, ctx): return _sign_stance(osc.roc(ctx.close, int(self.config.params.get("n", 9))))
+    def warmup_bars(self): return int(self.config.params.get("n", 9))
+
+
+class Disparity(StanceIndicator):
+    key = "disparity"
+    def stance(self, ctx): return _sign_stance(osc.disparity(ctx.close, int(self.config.params.get("n", 14))))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class BIAS(StanceIndicator):
+    key = "bias"
+    def stance(self, ctx): return _sign_stance(osc.bias(ctx.close, int(self.config.params.get("n", 6))))
+    def warmup_bars(self): return int(self.config.params.get("n", 6))
+
+
+class BalanceOfPower(StanceIndicator):
+    key = "balance_of_power"
+    def stance(self, ctx):
+        return _sign_stance(osc.balance_of_power(ctx.open, ctx.high, ctx.low, ctx.close,
+                                                 int(self.config.params.get("n", 14))))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class TSI(StanceIndicator):
+    key = "tsi"
+    def stance(self, ctx):
+        p = self.config.params
+        t = osc.tsi(ctx.close, int(p.get("r", 25)), int(p.get("s", 13)))
+        sig = osc.nan_ema(t, int(p.get("signal", 13)))
+        return _sign_stance(t - sig)
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("r", 25)) + int(p.get("s", 13))
+
+
+class RVGI(StanceIndicator):
+    key = "rvgi"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 14))
+        rvi = osc.rvgi(ctx.open, ctx.high, ctx.low, ctx.close, n)
+        return _sign_stance(rvi - osc.rvgi_signal(rvi))
+    def warmup_bars(self): return int(self.config.params.get("n", 14)) + 4
+
+
+class Fisher(StanceIndicator):
+    key = "fisher"
+    def stance(self, ctx):
+        f = osc.fisher(ctx.high, ctx.low, int(self.config.params.get("n", 9)))
+        return _sign_stance(f - osc._shift(f, 1))
+    def warmup_bars(self): return int(self.config.params.get("n", 9))
+
+
+class DerivativeOsc(StanceIndicator):
+    key = "derivative_osc"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(osc.derivative_osc(ctx.close, int(p.get("rsi_n", 14)), int(p.get("s1", 5)),
+                                               int(p.get("s2", 3)), int(p.get("signal", 9))))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("rsi_n", 14)) + int(p.get("s1", 5)) + int(p.get("s2", 3)) + int(p.get("signal", 9))
+
+
+class ErgodicOsc(StanceIndicator):
+    key = "ergodic_osc"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(osc.ergodic(ctx.close, int(p.get("r", 32)), int(p.get("s", 5)), int(p.get("signal", 5))))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("r", 32)) + int(p.get("s", 5))
+
+
+_N = lambda default, lo=2, hi=200: [{"name": "n", "default": default, "min": lo, "max": hi, "step": 1}]  # noqa: E731
+_ZONE = lambda lo, hi, lomin=1, lomax=49, himin=51, himax=99: [  # noqa: E731
+    {"name": "lower", "default": lo, "min": lomin, "max": lomax, "step": 1},
+    {"name": "upper", "default": hi, "min": himin, "max": himax, "step": 1}]
+
+CLASSES = (
+    RSICutler, RSIConnors, StochRSI, KDJ, WilliamsR, CMO, UltimateOsc, SMI, RMI, DynamicDMI,
+    WaveTrend, PGO, PSY, Momentum, ROC, Disparity, BIAS, BalanceOfPower, TSI, RVGI, Fisher,
+    DerivativeOsc, ErgodicOsc,
+)
+SCHEMA = {
+    "rsi_cutler": {"label": "RSI (Cutler)", "mode": "both", "params": _N(14, 2, 100) + _ZONE(30, 70)},
+    "rsi_connors": {"label": "Connors RSI", "mode": "both", "params": _ZONE(20, 80)},
+    "stoch_rsi": {"label": "Stochastic RSI", "mode": "both",
+                  "params": _N(14, 2, 100) + [{"name": "k", "default": 14, "min": 2, "max": 100, "step": 1},
+                                              {"name": "d", "default": 3, "min": 1, "max": 50, "step": 1}]
+                  + _ZONE(20, 80)},
+    "kdj": {"label": "KDJ (%K)", "mode": "both", "params": _N(9, 2, 100) + _ZONE(20, 80)},
+    "williams_r": {"label": "Williams %R", "mode": "both",
+                   "params": _N(14, 2, 100) + [{"name": "lower", "default": -80, "min": -99, "max": -51, "step": 1},
+                                               {"name": "upper", "default": -20, "min": -49, "max": -1, "step": 1}]},
+    "cmo": {"label": "Chande Momentum Osc", "mode": "both",
+            "params": _N(14, 2, 100) + [{"name": "lower", "default": -50, "min": -99, "max": -1, "step": 1},
+                                        {"name": "upper", "default": 50, "min": 1, "max": 99, "step": 1}]},
+    "ultimate_osc": {"label": "Ultimate Oscillator", "mode": "both", "params": _ZONE(30, 70)},
+    "smi": {"label": "Stochastic Momentum Index", "mode": "both",
+            "params": _N(14, 2, 100) + [{"name": "smooth", "default": 3, "min": 1, "max": 50, "step": 1},
+                                        {"name": "lower", "default": -40, "min": -99, "max": -1, "step": 1},
+                                        {"name": "upper", "default": 40, "min": 1, "max": 99, "step": 1}]},
+    "rmi": {"label": "Relative Momentum Index", "mode": "both",
+            "params": _N(14, 2, 100) + [{"name": "m", "default": 5, "min": 1, "max": 100, "step": 1}] + _ZONE(30, 70)},
+    "cmo_chande_dmi": {"label": "Dynamic Momentum Index", "mode": "both",
+                       "params": _N(14, 2, 100) + _ZONE(30, 70)},
+    "wavetrend": {"label": "WaveTrend", "mode": "both",
+                  "params": [{"name": "n1", "default": 10, "min": 2, "max": 100, "step": 1},
+                             {"name": "n2", "default": 21, "min": 2, "max": 100, "step": 1},
+                             {"name": "lower", "default": -60, "min": -99, "max": -1, "step": 1},
+                             {"name": "upper", "default": 60, "min": 1, "max": 99, "step": 1}]},
+    "pgo": {"label": "Pretty Good Oscillator", "mode": "both",
+            "params": _N(14, 2, 100) + [{"name": "lower", "default": -3, "min": -20, "max": -1, "step": 1},
+                                        {"name": "upper", "default": 3, "min": 1, "max": 20, "step": 1}]},
+    "psy": {"label": "Psychological Line", "mode": "both", "params": _N(12, 2, 100) + _ZONE(25, 75)},
+    "momentum": {"label": "Momentum", "mode": "confirm", "params": _N(10, 1, 200)},
+    "roc": {"label": "Rate of Change", "mode": "confirm", "params": _N(9, 1, 200)},
+    "disparity": {"label": "Disparity Index", "mode": "confirm", "params": _N(14, 2, 200)},
+    "bias": {"label": "BIAS", "mode": "confirm", "params": _N(6, 2, 200)},
+    "balance_of_power": {"label": "Balance of Power", "mode": "confirm", "params": _N(14, 2, 200)},
+    "tsi": {"label": "True Strength Index", "mode": "confirm",
+            "params": [{"name": "r", "default": 25, "min": 2, "max": 100, "step": 1},
+                       {"name": "s", "default": 13, "min": 2, "max": 100, "step": 1},
+                       {"name": "signal", "default": 13, "min": 1, "max": 100, "step": 1}]},
+    "rvgi": {"label": "Relative Vigor Index", "mode": "confirm", "params": _N(14, 2, 200)},
+    "fisher": {"label": "Fisher Transform", "mode": "confirm", "params": _N(9, 2, 100)},
+    "derivative_osc": {"label": "Derivative Oscillator", "mode": "confirm",
+                       "params": [{"name": "rsi_n", "default": 14, "min": 2, "max": 100, "step": 1},
+                                  {"name": "s1", "default": 5, "min": 1, "max": 50, "step": 1},
+                                  {"name": "s2", "default": 3, "min": 1, "max": 50, "step": 1},
+                                  {"name": "signal", "default": 9, "min": 1, "max": 100, "step": 1}]},
+    "ergodic_osc": {"label": "Ergodic Oscillator", "mode": "confirm",
+                    "params": [{"name": "r", "default": 32, "min": 2, "max": 100, "step": 1},
+                               {"name": "s", "default": 5, "min": 2, "max": 100, "step": 1},
+                               {"name": "signal", "default": 5, "min": 1, "max": 100, "step": 1}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_osc.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_osc.py
@@ -1,0 +1,4 @@
+"""osc-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_quant.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_quant.py
@@ -1,4 +1,123 @@
 """quant-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+from __future__ import annotations
 
-CLASSES = ()
-SCHEMA = {}
+import numpy as np
+
+from . import votes
+from .base import Indicator
+from .calc import osc, quant as Q
+from .stances import StanceIndicator, _sign_stance
+
+
+class ZScore(Indicator):
+    key = "zscore"
+    def directions(self, ctx):
+        p = self.config.params
+        v = Q.zscore(ctx.close, int(p.get("n", 20)))
+        return votes.band_directions(v, float(p.get("lower", -2)), float(p.get("upper", 2)), 0.0)
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class DeMarker(Indicator):
+    key = "demarker"
+    def directions(self, ctx):
+        p = self.config.params
+        v = Q.demarker(ctx.high, ctx.low, int(p.get("n", 14)))
+        return votes.band_directions(v, float(p.get("lower", 0.3)), float(p.get("upper", 0.7)), 0.5)
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class TDREI(Indicator):
+    key = "td_rei"
+    def directions(self, ctx):
+        p = self.config.params
+        v = Q.td_rei(ctx.high, ctx.low, 5)
+        return votes.band_directions(v, float(p.get("lower", -40)), float(p.get("upper", 40)), 0.0)
+    def warmup_bars(self): return 7
+
+
+class HurstExp(Indicator):
+    """Veto BOTH sides when Hurst < threshold (anti-persistent / mean-reverting chop)."""
+    key = "hurst_exp"
+    def directions(self, ctx):
+        p = self.config.params
+        v = Q.hurst_exp(ctx.close, int(p.get("n", 100)))
+        return votes.both_veto(np.isfinite(v) & (v < float(p.get("threshold", 0.5))))
+    def warmup_bars(self): return int(self.config.params.get("n", 100))
+
+
+class DFA(Indicator):
+    """Veto BOTH sides when DFA alpha < threshold (mean-reverting)."""
+    key = "dfa"
+    def directions(self, ctx):
+        p = self.config.params
+        v = Q.dfa(ctx.close, int(p.get("n", 100)))
+        return votes.both_veto(np.isfinite(v) & (v < float(p.get("threshold", 0.5))))
+    def warmup_bars(self): return int(self.config.params.get("n", 100))
+
+
+class Autocorr(Indicator):
+    """Veto BOTH sides when |lag-1 autocorr| < threshold (no linear structure)."""
+    key = "autocorr"
+    def directions(self, ctx):
+        p = self.config.params
+        v = Q.autocorr(ctx.close, int(p.get("n", 50)))
+        return votes.both_veto(np.isfinite(v) & (np.abs(v) < float(p.get("threshold", 0.1))))
+    def warmup_bars(self): return int(self.config.params.get("n", 50))
+
+
+class LinRegR2(Indicator):
+    """Veto BOTH sides when regression R² < threshold (no trend to ride)."""
+    key = "linreg_r2"
+    def directions(self, ctx):
+        p = self.config.params
+        v = Q.linreg_r2(ctx.close, int(p.get("n", 20)))
+        return votes.both_veto(np.isfinite(v) & (v < float(p.get("threshold", 0.2))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class EfficiencyRatio(StanceIndicator):
+    """Kaufman efficiency ratio as a directional filter: vote the net direction only when ER>threshold."""
+    key = "efficiency_ratio"
+    def stance(self, ctx):
+        p = self.config.params
+        n = int(p.get("n", 10))
+        thr = float(p.get("threshold", 0.3))
+        er = Q.efficiency_ratio(ctx.close, n)
+        direction = np.sign(ctx.close - osc._shift(ctx.close, n))
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[np.isfinite(er) & (er > thr) & (direction > 0)] = 1
+        st[np.isfinite(er) & (er > thr) & (direction < 0)] = -1
+        return st
+    def warmup_bars(self): return int(self.config.params.get("n", 10))
+
+
+CLASSES = (ZScore, DeMarker, TDREI, HurstExp, DFA, Autocorr, LinRegR2, EfficiencyRatio)
+SCHEMA = {
+    "zscore": {"label": "Z-Score", "mode": "both",
+               "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1},
+                          {"name": "lower", "default": -2, "min": -5, "max": -1, "step": 1},
+                          {"name": "upper", "default": 2, "min": 1, "max": 5, "step": 1}]},
+    "demarker": {"label": "DeMarker", "mode": "both",
+                 "params": [{"name": "n", "default": 14, "min": 2, "max": 100, "step": 1},
+                            {"name": "lower", "default": 0.3, "min": 0.05, "max": 0.49, "step": 0.01},
+                            {"name": "upper", "default": 0.7, "min": 0.51, "max": 0.95, "step": 0.01}]},
+    "td_rei": {"label": "TD Range Expansion Index", "mode": "both",
+               "params": [{"name": "lower", "default": -40, "min": -99, "max": -1, "step": 1},
+                          {"name": "upper", "default": 40, "min": 1, "max": 99, "step": 1}]},
+    "hurst_exp": {"label": "Hurst Exponent (veto)", "mode": "veto",
+                  "params": [{"name": "n", "default": 100, "min": 20, "max": 400, "step": 1},
+                             {"name": "threshold", "default": 0.5, "min": 0.3, "max": 0.7, "step": 0.01}]},
+    "dfa": {"label": "DFA exponent (veto)", "mode": "veto",
+            "params": [{"name": "n", "default": 100, "min": 20, "max": 400, "step": 1},
+                       {"name": "threshold", "default": 0.5, "min": 0.3, "max": 0.7, "step": 0.01}]},
+    "autocorr": {"label": "Autocorrelation (veto)", "mode": "veto",
+                 "params": [{"name": "n", "default": 50, "min": 5, "max": 200, "step": 1},
+                            {"name": "threshold", "default": 0.1, "min": 0.0, "max": 0.5, "step": 0.01}]},
+    "linreg_r2": {"label": "Linear-Reg R² (veto)", "mode": "veto",
+                  "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1},
+                             {"name": "threshold", "default": 0.2, "min": 0.0, "max": 0.9, "step": 0.01}]},
+    "efficiency_ratio": {"label": "Kaufman Efficiency Ratio", "mode": "confirm",
+                         "params": [{"name": "n", "default": 10, "min": 2, "max": 100, "step": 1},
+                                    {"name": "threshold", "default": 0.3, "min": 0.0, "max": 1.0, "step": 0.05}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_quant.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_quant.py
@@ -1,0 +1,4 @@
+"""quant-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_trend.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_trend.py
@@ -1,4 +1,317 @@
 """trend-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+from __future__ import annotations
 
-CLASSES = ()
-SCHEMA = {}
+import numpy as np
+
+from . import classic, votes
+from .base import BOTH, LONG, SHORT, Indicator
+from .calc import osc, trend as T
+from .stances import StanceIndicator, _sign_stance
+
+
+# ---------- simple signed-line stances ----------
+class PPO(StanceIndicator):
+    key = "ppo"
+    def stance(self, ctx):
+        p = self.config.params
+        line = T.ppo(ctx.close, int(p.get("fast", 12)), int(p.get("slow", 26)))
+        return _sign_stance(line - osc.nan_ema(line, int(p.get("signal", 9))))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("slow", 26)) + int(p.get("signal", 9))
+
+
+class APO(StanceIndicator):
+    key = "apo"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(T.apo(ctx.close, int(p.get("fast", 12)), int(p.get("slow", 26))))
+    def warmup_bars(self): return int(self.config.params.get("slow", 26))
+
+
+class DICross(StanceIndicator):
+    key = "di_cross"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 14))
+        pdi, mdi = T.plus_minus_di(ctx.high, ctx.low, ctx.close, n)
+        return _sign_stance(pdi - mdi)
+    def warmup_bars(self): return 2 * int(self.config.params.get("n", 14))
+
+
+class Aroon(StanceIndicator):
+    """Aroon strong-trend stance: +1 when up≥70 & dn≤30, -1 when dn≥70 & up≤30."""
+    key = "aroon"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 25))
+        up, dn = T.aroon(ctx.high, ctx.low, n)
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[(up >= 70) & (dn <= 30)] = 1
+        st[(dn >= 70) & (up <= 30)] = -1
+        return st
+    def warmup_bars(self): return int(self.config.params.get("n", 25))
+
+
+class AroonOsc(StanceIndicator):
+    key = "aroon_osc"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 25))
+        up, dn = T.aroon(ctx.high, ctx.low, n)
+        return _sign_stance(up - dn)
+    def warmup_bars(self): return int(self.config.params.get("n", 25))
+
+
+class ParabolicSAR(StanceIndicator):
+    key = "psar"
+    def stance(self, ctx):
+        p = self.config.params
+        sar = T.psar(ctx.high, ctx.low, float(p.get("step", 0.02)), float(p.get("max", 0.2)))
+        return _sign_stance(ctx.close - sar)
+    def warmup_bars(self): return 2
+
+
+class Vortex(StanceIndicator):
+    key = "vortex"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 14))
+        vp, vm = T.vortex(ctx.high, ctx.low, ctx.close, n)
+        return _sign_stance(vp - vm)
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class Supertrend(StanceIndicator):
+    key = "supertrend"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(T.supertrend(ctx.high, ctx.low, ctx.close,
+                                         int(p.get("n", 10)), float(p.get("m", 3.0))))
+    def warmup_bars(self): return int(self.config.params.get("n", 10))
+
+
+class TRIX(StanceIndicator):
+    key = "trix"
+    def stance(self, ctx):
+        p = self.config.params
+        line = T.trix(ctx.close, int(p.get("n", 15)))
+        return _sign_stance(line - osc.nan_ema(line, int(p.get("signal", 9))))
+    def warmup_bars(self):
+        p = self.config.params
+        return 3 * int(p.get("n", 15)) + int(p.get("signal", 9))
+
+
+class KST(StanceIndicator):
+    key = "kst"
+    def stance(self, ctx):
+        line = T.kst(ctx.close)
+        return _sign_stance(line - osc.nan_sma(line, int(self.config.params.get("signal", 9))))
+    def warmup_bars(self): return 45
+
+
+class Coppock(StanceIndicator):
+    key = "coppock"
+    def stance(self, ctx): return _sign_stance(T.coppock(ctx.close))
+    def warmup_bars(self): return 24
+
+
+class DPO(StanceIndicator):
+    key = "dpo"
+    def stance(self, ctx): return _sign_stance(T.dpo(ctx.close, int(self.config.params.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class LinRegSlope(StanceIndicator):
+    key = "linreg_slope"
+    def stance(self, ctx): return _sign_stance(T.linreg_slope(ctx.close, int(self.config.params.get("n", 14))))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class QQE(StanceIndicator):
+    key = "qqe"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(T.qqe(ctx.close, int(p.get("n", 14)), int(p.get("sf", 5)), float(p.get("f", 4.236))))
+    def warmup_bars(self): return 2 * int(self.config.params.get("n", 14))
+
+
+class ASI(StanceIndicator):
+    key = "asi"
+    def stance(self, ctx):
+        a = T.asi(ctx.open, ctx.high, ctx.low, ctx.close, float(self.config.params.get("limit", 3.0)))
+        return _sign_stance(a - osc._shift(a, 1))
+    def warmup_bars(self): return 1
+
+
+class EXPMA(StanceIndicator):
+    key = "expma"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(classic.ema(ctx.close, int(p.get("fast", 12))) - classic.ema(ctx.close, int(p.get("slow", 50))))
+    def warmup_bars(self): return int(self.config.params.get("slow", 50))
+
+
+class DMA(StanceIndicator):
+    key = "dma"
+    def stance(self, ctx):
+        p = self.config.params
+        ddd, ama = T.dma(ctx.close, int(p.get("fast", 10)), int(p.get("slow", 50)), int(p.get("m", 10)))
+        return _sign_stance(ddd - ama)
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("slow", 50)) + int(p.get("m", 10))
+
+
+class BBI(StanceIndicator):
+    key = "bbi"
+    def stance(self, ctx): return _sign_stance(ctx.close - T.bbi(ctx.close))
+    def warmup_bars(self): return 24
+
+
+class ElderRay(StanceIndicator):
+    """+1 when bull power >0 and rising; -1 when bear power <0 and falling."""
+    key = "elder_ray"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 13))
+        bull, bear = T.elder_ray(ctx.high, ctx.low, ctx.close, n)
+        pb, pbe = osc._shift(bull, 1), osc._shift(bear, 1)
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[(bull > 0) & (bull > pb)] = 1
+        st[(bear < 0) & (bear < pbe)] = -1
+        return st
+    def warmup_bars(self): return int(self.config.params.get("n", 13))
+
+
+class ElderImpulse(StanceIndicator):
+    """+1 when EMA rising AND MACD-hist rising; -1 when both falling."""
+    key = "elder_impulse"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 13))
+        e = classic.ema(ctx.close, n)
+        _, _, hist = classic.macd(ctx.close, 12, 26, 9)
+        e_up = e > osc._shift(e, 1)
+        h_up = hist > osc._shift(hist, 1)
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[e_up & h_up] = 1
+        st[(~e_up) & (~h_up)] = -1
+        return st
+    def warmup_bars(self): return 35
+
+
+# ---------- veto indicators (custom directions) ----------
+class TrendIntensity(Indicator):
+    """TII zone around 50 (mean-reversion within the trend)."""
+    key = "trend_intensity"
+    def directions(self, ctx):
+        p = self.config.params
+        v = T.trend_intensity(ctx.close, int(p.get("n", 60)))
+        return votes.band_directions(v, float(p.get("lower", 40)), float(p.get("upper", 60)), 50.0)
+    def warmup_bars(self): return int(self.config.params.get("n", 60))
+
+
+class LinRegChannel(Indicator):
+    """Veto BOTH sides when price is beyond ±k·resid-std of the regression line (overextended)."""
+    key = "linreg_channel"
+    def directions(self, ctx):
+        p = self.config.params
+        dev, std = T.linreg_dev(ctx.close, int(p.get("n", 100)))
+        k = float(p.get("k", 2.0))
+        return votes.both_veto(np.isfinite(dev) & np.isfinite(std) & (np.abs(dev) > k * std))
+    def warmup_bars(self): return int(self.config.params.get("n", 100))
+
+
+class Chandelier(Indicator):
+    """Veto longs when close < long chandelier stop; veto shorts when close > short stop."""
+    key = "chandelier"
+    def directions(self, ctx):
+        p = self.config.params
+        ls, ss = T.chandelier(ctx.high, ctx.low, ctx.close, int(p.get("n", 22)), float(p.get("m", 3.0)))
+        c = ctx.close
+        vdir = np.zeros(len(c), dtype=np.int8)
+        vdir[np.isfinite(ls) & (c < ls)] = LONG
+        vdir[np.isfinite(ss) & (c > ss)] = SHORT
+        return np.zeros(len(c), dtype=np.int8), vdir
+    def warmup_bars(self): return int(self.config.params.get("n", 22))
+
+
+class ChandeKroll(Indicator):
+    key = "chande_kroll"
+    def directions(self, ctx):
+        p = self.config.params
+        cl, cs = T.chande_kroll(ctx.high, ctx.low, ctx.close,
+                                int(p.get("n", 10)), float(p.get("m", 1.0)), int(p.get("p", 9)))
+        c = ctx.close
+        vdir = np.zeros(len(c), dtype=np.int8)
+        vdir[np.isfinite(cl) & (c < cl)] = LONG
+        vdir[np.isfinite(cs) & (c > cs)] = SHORT
+        return np.zeros(len(c), dtype=np.int8), vdir
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 10)) + int(p.get("p", 9))
+
+
+CLASSES = (
+    PPO, APO, DICross, Aroon, AroonOsc, ParabolicSAR, Vortex, Supertrend, TRIX, KST, Coppock, DPO,
+    TrendIntensity, LinRegSlope, LinRegChannel, Chandelier, ChandeKroll, QQE, ElderRay, ElderImpulse,
+    ASI, EXPMA, DMA, BBI,
+)
+
+_FS = [{"name": "fast", "default": 12, "min": 2, "max": 200, "step": 1},
+       {"name": "slow", "default": 26, "min": 2, "max": 400, "step": 1}]
+SCHEMA = {
+    "ppo": {"label": "PPO", "mode": "confirm", "params": _FS + [{"name": "signal", "default": 9, "min": 1, "max": 100, "step": 1}]},
+    "apo": {"label": "APO", "mode": "confirm", "params": _FS},
+    "di_cross": {"label": "DMI (+DI/−DI cross)", "mode": "confirm",
+                 "params": [{"name": "n", "default": 14, "min": 2, "max": 100, "step": 1}]},
+    "aroon": {"label": "Aroon (strong trend)", "mode": "confirm",
+              "params": [{"name": "n", "default": 25, "min": 2, "max": 200, "step": 1}]},
+    "aroon_osc": {"label": "Aroon Oscillator", "mode": "confirm",
+                  "params": [{"name": "n", "default": 25, "min": 2, "max": 200, "step": 1}]},
+    "psar": {"label": "Parabolic SAR", "mode": "confirm",
+             "params": [{"name": "step", "default": 0.02, "min": 0.01, "max": 0.2, "step": 0.01},
+                        {"name": "max", "default": 0.2, "min": 0.05, "max": 0.5, "step": 0.01}]},
+    "vortex": {"label": "Vortex", "mode": "confirm",
+               "params": [{"name": "n", "default": 14, "min": 2, "max": 100, "step": 1}]},
+    "supertrend": {"label": "Supertrend", "mode": "confirm",
+                   "params": [{"name": "n", "default": 10, "min": 2, "max": 100, "step": 1},
+                              {"name": "m", "default": 3.0, "min": 1.0, "max": 8.0, "step": 0.5}]},
+    "trix": {"label": "TRIX", "mode": "confirm",
+             "params": [{"name": "n", "default": 15, "min": 2, "max": 100, "step": 1},
+                        {"name": "signal", "default": 9, "min": 1, "max": 100, "step": 1}]},
+    "kst": {"label": "Know Sure Thing", "mode": "confirm",
+            "params": [{"name": "signal", "default": 9, "min": 1, "max": 100, "step": 1}]},
+    "coppock": {"label": "Coppock Curve", "mode": "confirm", "params": []},
+    "dpo": {"label": "Detrended Price Osc", "mode": "confirm",
+            "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1}]},
+    "trend_intensity": {"label": "Trend Intensity Index", "mode": "both",
+                        "params": [{"name": "n", "default": 60, "min": 2, "max": 200, "step": 1},
+                                   {"name": "lower", "default": 40, "min": 1, "max": 49, "step": 1},
+                                   {"name": "upper", "default": 60, "min": 51, "max": 99, "step": 1}]},
+    "linreg_slope": {"label": "Linear-Reg Slope", "mode": "confirm",
+                     "params": [{"name": "n", "default": 14, "min": 2, "max": 200, "step": 1}]},
+    "linreg_channel": {"label": "Linear-Reg Channel (veto)", "mode": "veto",
+                       "params": [{"name": "n", "default": 100, "min": 10, "max": 400, "step": 1},
+                                  {"name": "k", "default": 2.0, "min": 0.5, "max": 5.0, "step": 0.1}]},
+    "chandelier": {"label": "Chandelier Exit (veto)", "mode": "veto",
+                   "params": [{"name": "n", "default": 22, "min": 2, "max": 100, "step": 1},
+                              {"name": "m", "default": 3.0, "min": 1.0, "max": 8.0, "step": 0.5}]},
+    "chande_kroll": {"label": "Chande-Kroll Stop (veto)", "mode": "veto",
+                     "params": [{"name": "n", "default": 10, "min": 2, "max": 100, "step": 1},
+                                {"name": "m", "default": 1.0, "min": 0.5, "max": 5.0, "step": 0.5},
+                                {"name": "p", "default": 9, "min": 2, "max": 100, "step": 1}]},
+    "qqe": {"label": "QQE", "mode": "confirm",
+            "params": [{"name": "n", "default": 14, "min": 2, "max": 100, "step": 1},
+                       {"name": "sf", "default": 5, "min": 1, "max": 50, "step": 1},
+                       {"name": "f", "default": 4.236, "min": 1.0, "max": 8.0, "step": 0.1}]},
+    "elder_ray": {"label": "Elder Ray", "mode": "confirm",
+                  "params": [{"name": "n", "default": 13, "min": 2, "max": 100, "step": 1}]},
+    "elder_impulse": {"label": "Elder Impulse", "mode": "confirm",
+                      "params": [{"name": "n", "default": 13, "min": 2, "max": 100, "step": 1}]},
+    "asi": {"label": "Accumulation Swing Index", "mode": "confirm",
+            "params": [{"name": "limit", "default": 3.0, "min": 0.5, "max": 10.0, "step": 0.5}]},
+    "expma": {"label": "EXPMA cross", "mode": "confirm",
+              "params": [{"name": "fast", "default": 12, "min": 2, "max": 200, "step": 1},
+                         {"name": "slow", "default": 50, "min": 2, "max": 400, "step": 1}]},
+    "dma": {"label": "DMA", "mode": "confirm",
+            "params": [{"name": "fast", "default": 10, "min": 2, "max": 200, "step": 1},
+                       {"name": "slow", "default": 50, "min": 2, "max": 400, "step": 1},
+                       {"name": "m", "default": 10, "min": 1, "max": 100, "step": 1}]},
+    "bbi": {"label": "BBI", "mode": "confirm", "params": []},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_trend.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_trend.py
@@ -1,0 +1,4 @@
+"""trend-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_vol.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_vol.py
@@ -1,4 +1,229 @@
-"""vol-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+"""vol-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py.
 
-CLASSES = ()
-SCHEMA = {}
+Volatility indicators as VETOes (the box strategy is vol-seeking → veto LOW-vol / chop):
+  * _MagVeto  — magnitude vs its own EMA: veto BOTH where value/ref < threshold.
+  * _BandVeto — veto BOTH when price breaks outside the band (overextension).
+  * bounded   — choppiness / mass-index / squeeze veto BOTH on their natural threshold.
+Plus donchian (stance) and rvi_dorsey (zone)."""
+from __future__ import annotations
+
+import numpy as np
+
+from . import votes
+from .base import Indicator
+from .calc import osc, vol as V
+from .stances import StanceIndicator, _sign_stance
+
+
+class _MagVeto(Indicator):
+    """Veto BOTH sides where value / EMA(value, m) < threshold (low-activity chop)."""
+    def _value(self, ctx):
+        raise NotImplementedError
+
+    def directions(self, ctx):
+        p = self.config.params
+        val = self._value(ctx)
+        ref = osc.nan_ema(val, int(p.get("m", 50)))
+        return votes.magnitude_veto(val, ref, float(p.get("threshold", 0.8)))
+
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 20)) + int(p.get("m", 50))
+
+
+class _BandVeto(Indicator):
+    """Veto BOTH sides when price closes outside [lower, upper]."""
+    def _bands(self, ctx):
+        raise NotImplementedError
+
+    def directions(self, ctx):
+        u, lo = self._bands(ctx)
+        c = ctx.close
+        veto = np.isfinite(u) & np.isfinite(lo) & ((c > u) | (c < lo))
+        return votes.both_veto(veto)
+
+
+# ---- magnitude-veto vols ----
+class ATRNorm(_MagVeto):
+    key = "atr_norm"
+    def _value(self, ctx): return V.atr_norm(ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 14)))
+
+
+class StdDev(_MagVeto):
+    key = "stddev"
+    def _value(self, ctx): return V.stddev(ctx.close, int(self.config.params.get("n", 20)))
+
+
+class HistVol(_MagVeto):
+    key = "hist_vol"
+    def _value(self, ctx): return V.hist_vol(ctx.close, int(self.config.params.get("n", 20)))
+
+
+class Parkinson(_MagVeto):
+    key = "parkinson"
+    def _value(self, ctx): return V.parkinson(ctx.high, ctx.low, int(self.config.params.get("n", 20)))
+
+
+class GarmanKlass(_MagVeto):
+    key = "garman_klass"
+    def _value(self, ctx): return V.garman_klass(ctx.open, ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 20)))
+
+
+class RogersSatchell(_MagVeto):
+    key = "rogers_satchell"
+    def _value(self, ctx): return V.rogers_satchell(ctx.open, ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 20)))
+
+
+class YangZhang(_MagVeto):
+    key = "yang_zhang"
+    def _value(self, ctx): return V.yang_zhang(ctx.open, ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 20)))
+
+
+class Ulcer(_MagVeto):
+    key = "ulcer"
+    def _value(self, ctx): return V.ulcer(ctx.close, int(self.config.params.get("n", 14)))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 14)) + int(p.get("m", 50))
+
+
+class VolRatio(_MagVeto):
+    key = "vol_ratio"
+    def _value(self, ctx):
+        p = self.config.params
+        return V.vol_ratio(ctx.high, ctx.low, ctx.close, int(p.get("n_fast", 5)), int(p.get("n_slow", 20)))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n_slow", 20)) + int(p.get("m", 50))
+
+
+# ---- band-veto vols ----
+class STARC(_BandVeto):
+    key = "starc"
+    def _bands(self, ctx):
+        p = self.config.params
+        return V.starc(ctx.high, ctx.low, ctx.close, int(p.get("n", 15)), float(p.get("m", 2.0)))
+    def warmup_bars(self): return int(self.config.params.get("n", 15))
+
+
+class AccelBands(_BandVeto):
+    key = "accel_bands"
+    def _bands(self, ctx):
+        p = self.config.params
+        return V.accel_bands(ctx.high, ctx.low, ctx.close, int(p.get("n", 20)), float(p.get("f", 4.0)))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class ProjBands(_BandVeto):
+    key = "proj_bands"
+    def _bands(self, ctx):
+        return V.proj_bands(ctx.high, ctx.low, int(self.config.params.get("n", 14)))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+# ---- bounded / 0-centred vetoes ----
+class ChaikinVol(Indicator):
+    key = "chaikin_vol"
+    def directions(self, ctx):
+        p = self.config.params
+        cv = V.chaikin_vol(ctx.high, ctx.low, int(p.get("n", 10)), int(p.get("roc_n", 10)))
+        return votes.both_veto(np.isfinite(cv) & (cv < float(p.get("threshold", -10.0))))
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 10)) + int(p.get("roc_n", 10))
+
+
+class MassIndex(Indicator):
+    key = "mass_index"
+    def directions(self, ctx):
+        p = self.config.params
+        mi = V.mass_index(ctx.high, ctx.low, int(p.get("n", 25)))
+        return votes.both_veto(np.isfinite(mi) & (mi > float(p.get("threshold", 27.0))))
+    def warmup_bars(self): return int(self.config.params.get("n", 25)) + 18
+
+
+class Choppiness(Indicator):
+    key = "choppiness"
+    def directions(self, ctx):
+        p = self.config.params
+        ch = V.choppiness(ctx.high, ctx.low, ctx.close, int(p.get("n", 14)))
+        return votes.both_veto(np.isfinite(ch) & (ch >= float(p.get("threshold", 61.8))))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class TTMSqueeze(Indicator):
+    key = "ttm_squeeze"
+    def directions(self, ctx):
+        sq = V.ttm_squeeze(ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 20)))
+        return votes.both_veto(sq > 0.5)
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+# ---- stance / zone ----
+class Donchian(StanceIndicator):
+    key = "donchian"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 20))
+        m = (V._roll_max(ctx.high, n) + V._roll_min(ctx.low, n)) / 2.0
+        return _sign_stance(ctx.close - m)
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class RVIDorsey(Indicator):
+    key = "rvi_dorsey"
+    def directions(self, ctx):
+        p = self.config.params
+        v = V.rvi_dorsey(ctx.close, int(p.get("n", 14)))
+        return votes.band_directions(v, float(p.get("lower", 30)), float(p.get("upper", 70)), 50.0)
+    def warmup_bars(self): return int(self.config.params.get("n", 14)) + 10
+
+
+CLASSES = (
+    ATRNorm, StdDev, HistVol, Parkinson, GarmanKlass, RogersSatchell, YangZhang, Ulcer, VolRatio,
+    STARC, AccelBands, ProjBands, ChaikinVol, MassIndex, Choppiness, TTMSqueeze, Donchian, RVIDorsey,
+)
+
+_MV = lambda ndef=20: [{"name": "n", "default": ndef, "min": 2, "max": 200, "step": 1},  # noqa: E731
+                       {"name": "m", "default": 50, "min": 2, "max": 200, "step": 1},
+                       {"name": "threshold", "default": 0.8, "min": 0.2, "max": 1.5, "step": 0.05}]
+SCHEMA = {
+    "atr_norm": {"label": "Normalized ATR (veto)", "mode": "veto", "params": _MV(14)},
+    "stddev": {"label": "Std Dev (veto)", "mode": "veto", "params": _MV(20)},
+    "hist_vol": {"label": "Historical Vol (veto)", "mode": "veto", "params": _MV(20)},
+    "parkinson": {"label": "Parkinson Vol (veto)", "mode": "veto", "params": _MV(20)},
+    "garman_klass": {"label": "Garman-Klass Vol (veto)", "mode": "veto", "params": _MV(20)},
+    "rogers_satchell": {"label": "Rogers-Satchell Vol (veto)", "mode": "veto", "params": _MV(20)},
+    "yang_zhang": {"label": "Yang-Zhang Vol (veto)", "mode": "veto", "params": _MV(20)},
+    "ulcer": {"label": "Ulcer Index (veto)", "mode": "veto", "params": _MV(14)},
+    "vol_ratio": {"label": "Volatility Ratio (veto)", "mode": "veto",
+                  "params": [{"name": "n_fast", "default": 5, "min": 2, "max": 100, "step": 1},
+                             {"name": "n_slow", "default": 20, "min": 2, "max": 200, "step": 1},
+                             {"name": "m", "default": 50, "min": 2, "max": 200, "step": 1},
+                             {"name": "threshold", "default": 0.8, "min": 0.2, "max": 1.5, "step": 0.05}]},
+    "starc": {"label": "STARC Bands (veto)", "mode": "veto",
+              "params": [{"name": "n", "default": 15, "min": 2, "max": 200, "step": 1},
+                         {"name": "m", "default": 2.0, "min": 0.5, "max": 5.0, "step": 0.1}]},
+    "accel_bands": {"label": "Acceleration Bands (veto)", "mode": "veto",
+                    "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1},
+                               {"name": "f", "default": 4.0, "min": 1.0, "max": 10.0, "step": 0.5}]},
+    "proj_bands": {"label": "Projection Bands (veto)", "mode": "veto",
+                   "params": [{"name": "n", "default": 14, "min": 2, "max": 200, "step": 1}]},
+    "chaikin_vol": {"label": "Chaikin Volatility (veto)", "mode": "veto",
+                    "params": [{"name": "n", "default": 10, "min": 2, "max": 100, "step": 1},
+                               {"name": "roc_n", "default": 10, "min": 1, "max": 100, "step": 1},
+                               {"name": "threshold", "default": -10.0, "min": -50.0, "max": 0.0, "step": 1.0}]},
+    "mass_index": {"label": "Mass Index (veto)", "mode": "veto",
+                   "params": [{"name": "n", "default": 25, "min": 2, "max": 100, "step": 1},
+                              {"name": "threshold", "default": 27.0, "min": 20.0, "max": 35.0, "step": 0.5}]},
+    "choppiness": {"label": "Choppiness Index (veto)", "mode": "veto",
+                   "params": [{"name": "n", "default": 14, "min": 2, "max": 100, "step": 1},
+                              {"name": "threshold", "default": 61.8, "min": 30.0, "max": 80.0, "step": 0.1}]},
+    "ttm_squeeze": {"label": "TTM Squeeze (veto)", "mode": "veto",
+                    "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1}]},
+    "donchian": {"label": "Donchian midline trend", "mode": "confirm",
+                 "params": [{"name": "n", "default": 20, "min": 2, "max": 200, "step": 1}]},
+    "rvi_dorsey": {"label": "Relative Volatility Index", "mode": "both",
+                   "params": [{"name": "n", "default": 14, "min": 2, "max": 100, "step": 1},
+                              {"name": "lower", "default": 30, "min": 1, "max": 49, "step": 1},
+                              {"name": "upper", "default": 70, "min": 51, "max": 99, "step": 1}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_vol.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_vol.py
@@ -1,0 +1,4 @@
+"""vol-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_volume.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_volume.py
@@ -1,0 +1,4 @@
+"""volume-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+
+CLASSES = ()
+SCHEMA = {}

--- a/subprojects/Parametric-Indicators/indicators/lib_volume.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_volume.py
@@ -1,4 +1,198 @@
-"""volume-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+"""volume-school indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py.
 
-CLASSES = ()
-SCHEMA = {}
+Mostly stances = sign of a money-flow line vs its own smoothing; vzo / volume_ratio_asia are zones."""
+from __future__ import annotations
+
+import numpy as np
+
+from . import classic, votes
+from .base import Indicator
+from .calc import volume as VO
+from .stances import StanceIndicator, _sign_stance
+
+
+class AdLine(StanceIndicator):
+    key = "ad_line"
+    def stance(self, ctx):
+        ad = VO.ad_line(ctx.high, ctx.low, ctx.close, ctx.volume)
+        return _sign_stance(ad - classic.sma(ad, int(self.config.params.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class CMF(StanceIndicator):
+    key = "cmf"
+    def stance(self, ctx):
+        return _sign_stance(VO.cmf(ctx.high, ctx.low, ctx.close, ctx.volume, int(self.config.params.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class ChaikinOsc(StanceIndicator):
+    key = "chaikin_osc"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(VO.chaikin_osc(ctx.high, ctx.low, ctx.close, ctx.volume,
+                                           int(p.get("fast", 3)), int(p.get("slow", 10))))
+    def warmup_bars(self): return int(self.config.params.get("slow", 10))
+
+
+class PVT(StanceIndicator):
+    key = "pvt"
+    def stance(self, ctx):
+        p = VO.pvt(ctx.close, ctx.volume)
+        return _sign_stance(p - classic.sma(p, int(self.config.params.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class TVI(StanceIndicator):
+    key = "tvi"
+    def stance(self, ctx):
+        p = self.config.params
+        t = VO.tvi(ctx.close, ctx.volume, float(p.get("min_tick", 0.01)))
+        return _sign_stance(t - classic.sma(t, int(p.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class NVI(StanceIndicator):
+    key = "nvi"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 255))
+        line = VO.nvi(ctx.close, ctx.volume)
+        return _sign_stance(line - classic.ema(line, n))
+    def warmup_bars(self): return int(self.config.params.get("n", 255))
+
+
+class PVI(StanceIndicator):
+    key = "pvi"
+    def stance(self, ctx):
+        n = int(self.config.params.get("n", 255))
+        line = VO.pvi(ctx.close, ctx.volume)
+        return _sign_stance(line - classic.ema(line, n))
+    def warmup_bars(self): return int(self.config.params.get("n", 255))
+
+
+class EOM(StanceIndicator):
+    key = "eom"
+    def stance(self, ctx):
+        return _sign_stance(VO.eom(ctx.high, ctx.low, ctx.volume, int(self.config.params.get("n", 14))))
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class ForceIndex(StanceIndicator):
+    key = "force_index"
+    def stance(self, ctx):
+        return _sign_stance(VO.force_index(ctx.close, ctx.volume, int(self.config.params.get("n", 13))))
+    def warmup_bars(self): return int(self.config.params.get("n", 13))
+
+
+class Klinger(StanceIndicator):
+    key = "klinger"
+    def stance(self, ctx):
+        p = self.config.params
+        kvo, sig = VO.klinger(ctx.high, ctx.low, ctx.close, ctx.volume,
+                              int(p.get("fast", 34)), int(p.get("slow", 55)), int(p.get("signal", 13)))
+        return _sign_stance(kvo - sig)
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("slow", 55)) + int(p.get("signal", 13))
+
+
+class VolOsc(StanceIndicator):
+    key = "vol_osc"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(VO.vol_osc(ctx.volume, int(p.get("fast", 5)), int(p.get("slow", 20))))
+    def warmup_bars(self): return int(self.config.params.get("slow", 20))
+
+
+class DemandIndex(StanceIndicator):
+    key = "demand_index"
+    def stance(self, ctx):
+        return _sign_stance(VO.demand_index(ctx.close, ctx.volume, int(self.config.params.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class TwiggsMF(StanceIndicator):
+    key = "twiggs_mf"
+    def stance(self, ctx):
+        return _sign_stance(VO.twiggs_mf(ctx.high, ctx.low, ctx.close, ctx.volume, int(self.config.params.get("n", 21))))
+    def warmup_bars(self): return int(self.config.params.get("n", 21))
+
+
+class WVAD(StanceIndicator):
+    key = "wvad"
+    def stance(self, ctx):
+        return _sign_stance(VO.wvad(ctx.open, ctx.high, ctx.low, ctx.close, ctx.volume, int(self.config.params.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+class BWMFI(StanceIndicator):
+    key = "bw_mfi"
+    def stance(self, ctx): return _sign_stance(VO.bw_mfi(ctx.high, ctx.low, ctx.volume))
+    def warmup_bars(self): return 1
+
+
+class AnchoredVWAP(StanceIndicator):
+    key = "anchored_vwap"
+    def stance(self, ctx):
+        sess = ctx.session_id if ctx.session_id is not None else np.zeros(len(ctx.close), dtype=int)
+        av = VO.anchored_vwap(ctx.high, ctx.low, ctx.close, ctx.volume, sess)
+        return _sign_stance(ctx.close - av)
+    def warmup_bars(self): return 1
+
+
+class VZO(Indicator):
+    key = "vzo"
+    def directions(self, ctx):
+        p = self.config.params
+        v = VO.vzo(ctx.close, ctx.volume, int(p.get("n", 14)))
+        return votes.band_directions(v, float(p.get("lower", -40)), float(p.get("upper", 40)), 0.0)
+    def warmup_bars(self): return int(self.config.params.get("n", 14))
+
+
+class VolumeRatioAsia(Indicator):
+    key = "volume_ratio_asia"
+    def directions(self, ctx):
+        p = self.config.params
+        v = VO.volume_ratio_asia(ctx.close, ctx.volume, int(p.get("n", 26)))
+        return votes.band_directions(v, float(p.get("lower", 70)), float(p.get("upper", 150)), 100.0)
+    def warmup_bars(self): return int(self.config.params.get("n", 26))
+
+
+CLASSES = (
+    AdLine, CMF, ChaikinOsc, PVT, TVI, NVI, PVI, EOM, ForceIndex, Klinger, VolOsc, DemandIndex,
+    TwiggsMF, WVAD, BWMFI, AnchoredVWAP, VZO, VolumeRatioAsia,
+)
+
+_N = lambda d, lo=2, hi=200: [{"name": "n", "default": d, "min": lo, "max": hi, "step": 1}]  # noqa: E731
+SCHEMA = {
+    "ad_line": {"label": "Accumulation/Distribution Line", "mode": "confirm", "params": _N(20)},
+    "cmf": {"label": "Chaikin Money Flow", "mode": "confirm", "params": _N(20)},
+    "chaikin_osc": {"label": "Chaikin Oscillator", "mode": "confirm",
+                    "params": [{"name": "fast", "default": 3, "min": 2, "max": 50, "step": 1},
+                               {"name": "slow", "default": 10, "min": 2, "max": 100, "step": 1}]},
+    "pvt": {"label": "Price Volume Trend", "mode": "confirm", "params": _N(20)},
+    "tvi": {"label": "Trade Volume Index", "mode": "confirm",
+            "params": [{"name": "min_tick", "default": 0.01, "min": 0.0, "max": 5.0, "step": 0.01}] + _N(20)},
+    "nvi": {"label": "Negative Volume Index", "mode": "confirm", "params": _N(255, 2, 400)},
+    "pvi": {"label": "Positive Volume Index", "mode": "confirm", "params": _N(255, 2, 400)},
+    "eom": {"label": "Ease of Movement", "mode": "confirm", "params": _N(14)},
+    "force_index": {"label": "Force Index", "mode": "confirm", "params": _N(13)},
+    "klinger": {"label": "Klinger Volume Oscillator", "mode": "confirm",
+                "params": [{"name": "fast", "default": 34, "min": 2, "max": 100, "step": 1},
+                           {"name": "slow", "default": 55, "min": 2, "max": 200, "step": 1},
+                           {"name": "signal", "default": 13, "min": 1, "max": 100, "step": 1}]},
+    "vol_osc": {"label": "Volume Oscillator", "mode": "confirm",
+                "params": [{"name": "fast", "default": 5, "min": 2, "max": 100, "step": 1},
+                           {"name": "slow", "default": 20, "min": 2, "max": 200, "step": 1}]},
+    "demand_index": {"label": "Demand Index", "mode": "confirm", "params": _N(20)},
+    "twiggs_mf": {"label": "Twiggs Money Flow", "mode": "confirm", "params": _N(21)},
+    "wvad": {"label": "Williams VAD", "mode": "confirm", "params": _N(20)},
+    "bw_mfi": {"label": "BW Market Facilitation Index", "mode": "confirm", "params": []},
+    "anchored_vwap": {"label": "Anchored VWAP", "mode": "confirm", "params": []},
+    "vzo": {"label": "Volume Zone Oscillator", "mode": "both",
+            "params": _N(14, 2, 100) + [{"name": "lower", "default": -40, "min": -99, "max": -1, "step": 1},
+                                        {"name": "upper", "default": 40, "min": 1, "max": 99, "step": 1}]},
+    "volume_ratio_asia": {"label": "Volume Ratio (VR)", "mode": "both",
+                          "params": _N(26, 2, 200) + [{"name": "lower", "default": 70, "min": 1, "max": 99, "step": 1},
+                                                      {"name": "upper", "default": 150, "min": 101, "max": 400, "step": 1}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/library.py
+++ b/subprojects/Parametric-Indicators/indicators/library.py
@@ -12,24 +12,7 @@ import numpy as np
 
 from . import classic, smc, votes
 from .base import BOTH, Indicator, MarketContext
-
-
-def _sign_stance(x: np.ndarray) -> np.ndarray:
-    """sign with NaN→0, as int8 stance."""
-    s = np.zeros(len(x), dtype=np.int8)
-    a = np.asarray(x, dtype=float)
-    s[a > 0] = 1
-    s[a < 0] = -1
-    return s
-
-
-class StanceIndicator(Indicator):
-    """Indicators whose vote is a plain bullish/bearish stance."""
-    def stance(self, ctx: MarketContext) -> np.ndarray:
-        raise NotImplementedError
-
-    def directions(self, ctx: MarketContext):
-        return votes.stance_directions(self.stance(ctx))
+from .stances import StanceIndicator, _sign_stance
 
 
 class EMATrend(StanceIndicator):
@@ -311,11 +294,15 @@ class CISDConfirm(StanceIndicator):
         return 1
 
 
-REGISTRY = {c.key: c for c in (
+from . import lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant  # noqa: E402
+
+_SCHOOLS = (lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant)
+_BUILTINS = (
     EMATrend, SMATrend, MACD, VWAPTrend, KeltnerTrend, OBVTrend, CCIBreakout,
     RSIZone, StochasticZone, MFIZone, BollingerVeto, ADXVeto,
     StructureTrend, OrderBlock, FVGConfirm, IFVGConfirm, BreakerBlock, CISDConfirm,
-)}
+)
+REGISTRY = {c.key: c for c in (*_BUILTINS, *(c for m in _SCHOOLS for c in m.CLASSES))}
 
 
 def build(key: str, config=None) -> Indicator:
@@ -376,6 +363,11 @@ SCHEMA = {
                    "params": [{"name": "swing_l", "default": 2, "min": 1, "max": 20, "step": 1}]},
     "cisd":       {"label": "CISD — delivery shift (SMC)", "mode": "both", "params": []},
 }
+for _m in _SCHOOLS:                       # merge per-school schemas (keys must be unique)
+    for _k, _v in _m.SCHEMA.items():
+        if _k in SCHEMA:
+            raise KeyError(f"duplicate indicator key {_k!r}")
+        SCHEMA[_k] = _v
 MODES = ("confirm", "veto", "both")
 RETRACE_UNITS = ("atr_mult", "points")
 

--- a/subprojects/Parametric-Indicators/indicators/stances.py
+++ b/subprojects/Parametric-Indicators/indicators/stances.py
@@ -1,0 +1,29 @@
+"""Shared stance base class, extracted from library.py so per-school lib_* modules can subclass it
+without a circular import (library.py imports the lib_* modules, which import StanceIndicator here).
+
+Imports only base + votes (both cycle-free): base defines Indicator/MarketContext; votes maps a raw
+stance to (confirm_dir, veto_dir)."""
+from __future__ import annotations
+
+import numpy as np
+
+from . import votes
+from .base import Indicator, MarketContext
+
+
+def _sign_stance(x: np.ndarray) -> np.ndarray:
+    """sign with NaN→0, as int8 stance."""
+    s = np.zeros(len(x), dtype=np.int8)
+    a = np.asarray(x, dtype=float)
+    s[a > 0] = 1
+    s[a < 0] = -1
+    return s
+
+
+class StanceIndicator(Indicator):
+    """Indicators whose vote is a plain bullish/bearish stance."""
+    def stance(self, ctx: MarketContext) -> np.ndarray:
+        raise NotImplementedError
+
+    def directions(self, ctx: MarketContext):
+        return votes.stance_directions(self.stance(ctx))

--- a/subprojects/Parametric-Indicators/indicators/test_registry_merge.py
+++ b/subprojects/Parametric-Indicators/indicators/test_registry_merge.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from indicators import library
+
+
+def test_every_registry_key_has_schema_and_vice_versa():
+    assert set(library.REGISTRY) == set(library.SCHEMA), (
+        set(library.REGISTRY) ^ set(library.SCHEMA))
+
+
+def test_school_modules_merge_in():
+    # built-ins still present after refactor
+    for k in ("ema_trend", "rsi", "adx"):
+        assert k in library.REGISTRY and k in library.SCHEMA

--- a/subprojects/Parametric-Indicators/indicators/test_votes_helpers.py
+++ b/subprojects/Parametric-Indicators/indicators/test_votes_helpers.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import numpy as np
+
+from indicators import votes
+from indicators.base import BOTH
+
+
+def test_band_directions_matches_rsi_at_mid_50():
+    r = np.array([np.nan, 25.0, 45.0, 50.0, 55.0, 80.0])
+    c1, v1 = votes.band_directions(r, 30, 70, 50.0)
+    c2, v2 = votes.rsi_directions(r, 30, 70)
+    assert np.array_equal(c1, c2) and np.array_equal(v1, v2)
+
+
+def test_band_directions_custom_mid():
+    # Williams %R style: range -100..0, mid -50
+    wr = np.array([-90.0, -60.0, -50.0, -40.0, -10.0])
+    c, v = votes.band_directions(wr, lower=-80, upper=-20, mid=-50.0)
+    # -90 <= -80 -> oversold long; -60 in (-80,-50) bearish short; -50 == mid neutral;
+    # -40 in (-50,-20) bullish long; -10 >= -20 overbought short
+    assert list(c) == [1, -1, 0, 1, -1]
+    assert list(v) == [-1, 1, 0, -1, 1]
+
+
+def test_magnitude_veto_flags_low_ratio_both_sides():
+    val = np.array([1.0, 1.0, 1.0])
+    ref = np.array([2.0, 1.0, np.nan])
+    c, v = votes.magnitude_veto(val, ref, threshold=0.8)  # 0.5<0.8 veto; 1.0 no; nan no
+    assert v[0] == BOTH and v[1] == 0 and v[2] == 0 and not c.any()
+
+
+def test_both_veto_sets_both_on_mask():
+    m = np.array([False, True, False])
+    c, v = votes.both_veto(m)
+    assert v[1] == BOTH and v[0] == 0 and v[2] == 0 and not c.any()

--- a/subprojects/Parametric-Indicators/indicators/votes.py
+++ b/subprojects/Parametric-Indicators/indicators/votes.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from .base import BOTH
+
 
 def stance_directions(stance: np.ndarray):
     """A simple bullish/bearish stance ∈ {+1,-1,0} → confirm that side, veto the other.
@@ -16,20 +18,50 @@ def stance_directions(stance: np.ndarray):
     return s.copy(), (-s).astype(np.int8)
 
 
-def rsi_directions(rsi_vals: np.ndarray, lower: float = 30.0, upper: float = 70.0):
-    """RSI zones (docs §7): overbought ≥upper → (short, veto-long); oversold ≤lower →
-    (long, veto-short); 50<r<upper bullish → (long, veto-short); lower<r<50 bearish →
-    (short, veto-long); NaN or r==50 → neutral."""
-    r = np.asarray(rsi_vals, dtype=float)
-    cdir = np.zeros(len(r), dtype=np.int8)
-    vdir = np.zeros(len(r), dtype=np.int8)
-    valid = ~np.isnan(r)
-    overbought = valid & (r >= upper)
-    oversold = valid & (r <= lower)
-    bullish = valid & ~overbought & ~oversold & (r > 50)
-    bearish = valid & ~overbought & ~oversold & (r < 50)
+def band_directions(v: np.ndarray, lower: float, upper: float, mid: float = 50.0):
+    """Mean-reversion zone logic around a midpoint. overbought ≥upper → (short, veto-long);
+    oversold ≤lower → (long, veto-short); mid<v<upper bullish → (long, veto-short);
+    lower<v<mid bearish → (short, veto-long); NaN or v==mid → neutral. Generalizes RSI's
+    hardcoded 50 midpoint so Williams %R (mid −50), CMO (mid 0), etc. reuse it."""
+    x = np.asarray(v, dtype=float)
+    cdir = np.zeros(len(x), dtype=np.int8)
+    vdir = np.zeros(len(x), dtype=np.int8)
+    valid = ~np.isnan(x)
+    overbought = valid & (x >= upper)
+    oversold = valid & (x <= lower)
+    bullish = valid & ~overbought & ~oversold & (x > mid)
+    bearish = valid & ~overbought & ~oversold & (x < mid)
     long_zone = oversold | bullish          # supports long / vetoes short
     short_zone = overbought | bearish       # supports short / vetoes long
     cdir[long_zone] = +1; vdir[long_zone] = -1
     cdir[short_zone] = -1; vdir[short_zone] = +1
+    return cdir, vdir
+
+
+def rsi_directions(rsi_vals: np.ndarray, lower: float = 30.0, upper: float = 70.0):
+    """RSI zones (docs §7) — thin delegate to band_directions with the classic mid=50."""
+    return band_directions(rsi_vals, lower, upper, 50.0)
+
+
+def magnitude_veto(value: np.ndarray, ref: np.ndarray, threshold: float):
+    """Unbounded magnitude → BOTH-side veto where value/ref < threshold (low-activity chop veto,
+    the box strategy being vol-seeking). cdir is always 0; NaN/inf ratios never veto."""
+    a = np.asarray(value, dtype=float)
+    b = np.asarray(ref, dtype=float)
+    cdir = np.zeros(len(a), dtype=np.int8)
+    vdir = np.zeros(len(a), dtype=np.int8)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        ratio = a / b
+    veto = np.isfinite(ratio) & (ratio < float(threshold))
+    vdir[veto] = BOTH
+    return cdir, vdir
+
+
+def both_veto(mask: np.ndarray):
+    """Boolean condition → BOTH-side veto where True (e.g. high choppiness / squeeze-on).
+    cdir always 0."""
+    m = np.asarray(mask, dtype=bool)
+    cdir = np.zeros(len(m), dtype=np.int8)
+    vdir = np.zeros(len(m), dtype=np.int8)
+    vdir[m] = BOTH
     return cdir, vdir

--- a/subprojects/Parametric-Indicators/optimize/optimizer.py
+++ b/subprojects/Parametric-Indicators/optimize/optimizer.py
@@ -53,13 +53,18 @@ def _suggest_param(trial, name, p):
     return trial.suggest_float(name, lo, hi, step=st)
 
 
-def _suggest_indicators(trial, exclude=(), only=(), prefix=""):
+def _suggest_indicators(trial, exclude=(), only=(), prefix="", max_enabled=None):
     """WS-I.8 search space: each registered indicator on/off + its params (rectangular — params always
     suggested so NSGA crossover stays well-defined). Mode = the schema default. Keys in `exclude`, or (when
     `only` is non-empty) keys NOT in `only`, are forced OFF with default params and NOT suggested (α: revert
     to wsh4-era / restrict to a subset ⇒ fewer dimensions). `_searched` flags which keys entered the search.
     `prefix` namespaces the Optuna param names (e.g. 'es_') so a cross-instrument contributor's committee
-    can be searched alongside NQ's without name collisions; prefix='' is byte-identical to before."""
+    can be searched alongside NQ's without name collisions; prefix='' is byte-identical to before.
+
+    `max_enabled` (WS-EXTRA-IND): cap the number of simultaneously-enabled indicators. With ~125 keys the
+    K-of-N search would otherwise explore 125-way soups; None = uncapped (byte-identical to before). The cap
+    is applied as a POST-suggestion repair (keep the first `max_enabled` enabled in REGISTRY order, force the
+    rest off) so the Optuna param dimensionality stays rectangular — only the feasible region shrinks."""
     specs = []
     for key in library.REGISTRY:
         meta = library.SCHEMA[key]
@@ -71,6 +76,10 @@ def _suggest_indicators(trial, exclude=(), only=(), prefix=""):
         enabled = trial.suggest_categorical(f"{prefix}en_{key}", [False, True])
         params = {p["name"]: _suggest_param(trial, f"{prefix}{key}_{p['name']}", p) for p in meta["params"]}
         specs.append({"key": key, "enabled": enabled, "mode": meta["mode"], "params": params, "_searched": True})
+    if max_enabled is not None:
+        on = [s for s in specs if s["enabled"]]
+        for s in on[int(max_enabled):]:      # deterministic REGISTRY order ⇒ reproducible repair
+            s["enabled"] = False
     return specs
 
 
@@ -384,7 +393,7 @@ def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
         dd_pnl_cap: float = DD_PNL_CAP, contrib_tokens: tuple = (),
         contrib_exclude=None, instrument: str = "NQ", intracandle: bool = False,
         freeze_indicators: bool = False, intracandle_always_on: bool = False,
-        force_eod: bool = False) -> dict:
+        force_eod: bool = False, max_enabled: int | None = None) -> dict:
     # split_sltp (Q3 / E2): when True the optimizer searches SEPARATE long vs short SL/TP (long_*/short_*),
     # widening the space per the user's point-5 goal. Default False ⇒ shared SL/TP ⇒ identical to prior runs.
     # NOTE FOR THE NEXT FULL RUN (wsh5): launch with split_sltp=True to let longs and shorts get their own
@@ -429,7 +438,8 @@ def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
             k_rule = frozen_k
         else:
             specs = [{k: v for k, v in s.items() if k != "_searched"}      # strip the test-hook key
-                     for s in _suggest_indicators(trial, exclude_inds, only_inds)]   # α: scoped search space
+                     for s in _suggest_indicators(trial, exclude_inds, only_inds,
+                                                  max_enabled=max_enabled)]   # α: scoped search space + K-cap
             k_rule = trial.suggest_int("k", 1, 5)       # clamped to #confirmers by confirm_mask
         # Time caps, asked the way the indicators are asked: a yes/no per cap, plus "how much" for the
         # bars cap. Rectangular space (cap_1min always suggested) so NSGA-III sees a fixed dimension set;
@@ -667,6 +677,9 @@ def main() -> int:
     ap.add_argument("--freeze-indicators", action="store_true",
                     help="FIX the indicator layer (on/off + params + k) at the champion's; search only SL/TP + gate "
                          "+ intra-candle. Far fewer dims; the intra-candle gate is memoised once. Needs a champion seed.")
+    ap.add_argument("--max-enabled", type=int, default=None,
+                    help="Cap simultaneously-enabled indicators per trial (post-suggestion repair, REGISTRY order). "
+                         "Keeps the ~125-key K-of-N search sparse/interpretable. Default: uncapped.")
     a = ap.parse_args()
     from optimize import instruments as _inst
     if not _inst.is_valid(a.instrument):
@@ -696,7 +709,7 @@ def main() -> int:
         contrib_tokens=contrib_tokens, instrument=a.instrument,
         intracandle=(a.intracandle or a.intracandle_on),
         freeze_indicators=a.freeze_indicators, intracandle_always_on=a.intracandle_on,
-        force_eod=a.force_eod)
+        force_eod=a.force_eod, max_enabled=a.max_enabled)
     return 0
 
 

--- a/subprojects/Parametric-Indicators/optimize/test_indicator_parity.py
+++ b/subprojects/Parametric-Indicators/optimize/test_indicator_parity.py
@@ -40,7 +40,18 @@ CASES = [
 SS, SH, TP, GP = 30, 40, 60, 60   # the winner box params
 
 
-def main(tf: str = "4h") -> int:
+def _count_mismatch(E, F) -> int:
+    """Trade-for-trade mismatch count between the exact engine (E) and fast engine (F)."""
+    return sum(
+        1 for e, f in zip(E, F)
+        if pd.Timestamp(e["entry_time"]) != pd.Timestamp(f["entry_time"])
+        or e["direction"] != f["direction"] or e["exit_reason"] != f["exit_reason"]
+        or pd.Timestamp(e["exit_time"]) != pd.Timestamp(f["exit_time"])
+        or abs(e["pnl_points"] - f["pnl_points"]) > 1e-6
+    )
+
+
+def main(tf: str = "4h", keys=None) -> int:
     df, df1, box, vf, n = data.load_inputs(tf)
     sig_int = signals_to_int(signals.decision_signals(df, box))
     DD, DC = df["Date"].to_numpy(), df["Close"].to_numpy(float)
@@ -60,18 +71,30 @@ def main(tf: str = "4h") -> int:
         return E, F, int(g.sum())
 
     ok_all = True
-    for name, specs, k in CASES:
-        E, F, ng = run_case(specs, k)
-        diffs = sum(
-            1 for e, f in zip(E, F)
-            if pd.Timestamp(e["entry_time"]) != pd.Timestamp(f["entry_time"])
-            or e["direction"] != f["direction"] or e["exit_reason"] != f["exit_reason"]
-            or pd.Timestamp(e["exit_time"]) != pd.Timestamp(f["exit_time"])
-            or abs(e["pnl_points"] - f["pnl_points"]) > 1e-6
-        )
+    # Legacy combo regressions run only in a full sweep (skipped when --keys narrows the run).
+    if not keys:
+        for name, specs, k in CASES:
+            E, F, ng = run_case(specs, k)
+            diffs = _count_mismatch(E, F)
+            ok = len(E) == len(F) and diffs == 0
+            ok_all &= ok
+            print(f"{name:26} engine={len(E):4} fast={len(F):4} gate_bars={ng:5} mismatch={diffs:3}  "
+                  f"{'OK' if ok else 'FAIL'}")
+
+    # Full-registry sweep: every registered key enabled ALONE at its SCHEMA defaults (k=1).
+    # New indicators auto-enter here — this is the per-batch parity gate. `--keys a,b` narrows it.
+    sweep_keys = keys if keys else list(library.REGISTRY)
+    for key in sweep_keys:
+        if key not in library.SCHEMA:
+            print(f"{key+' solo':26} UNKNOWN KEY"); ok_all = False; continue
+        meta = library.SCHEMA[key]
+        params = {p["name"]: p["default"] for p in meta["params"]}
+        specs = [{"key": key, "enabled": True, "mode": meta["mode"], "params": params}]
+        E, F, ng = run_case(specs, 1)
+        diffs = _count_mismatch(E, F)
         ok = len(E) == len(F) and diffs == 0
         ok_all &= ok
-        print(f"{name:26} engine={len(E):4} fast={len(F):4} gate_bars={ng:5} mismatch={diffs:3}  "
+        print(f"{key+' solo':26} engine={len(E):4} fast={len(F):4} gate_bars={ng:5} mismatch={diffs:3}  "
               f"{'OK' if ok else 'FAIL'}")
 
     # all-off ⇒ confirm/veto masks are identity ⇒ gate == vol_gate exactly
@@ -87,4 +110,12 @@ def main(tf: str = "4h") -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1] if len(sys.argv) > 1 else "4h"))
+    # usage: python optimize/test_indicator_parity.py [tf] [--keys=a,b,c]
+    _argv = [a for a in sys.argv[1:]]
+    _keys = None
+    for _a in list(_argv):
+        if _a.startswith("--keys="):
+            _keys = [k for k in _a.split("=", 1)[1].split(",") if k]
+            _argv.remove(_a)
+    _tf = _argv[0] if _argv else "4h"
+    raise SystemExit(main(_tf, keys=_keys))

--- a/subprojects/Parametric-Indicators/optimize/test_max_enabled_cap.py
+++ b/subprojects/Parametric-Indicators/optimize/test_max_enabled_cap.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import optuna
+
+from optimize import optimizer
+
+
+def test_max_enabled_caps_active_indicators():
+    def obj(trial):
+        specs = optimizer._suggest_indicators(trial, max_enabled=3)
+        n_on = sum(1 for s in specs if s["enabled"])
+        trial.set_user_attr("n_on", n_on)
+        return float(n_on)
+    st = optuna.create_study(sampler=optuna.samplers.RandomSampler(seed=0))
+    st.optimize(obj, n_trials=60)
+    assert max(t.user_attrs["n_on"] for t in st.trials) <= 3
+
+
+def test_no_cap_when_max_enabled_none():
+    # Without a cap, at least one trial should enable more than 3 (sanity that the cap is what limits).
+    def obj(trial):
+        specs = optimizer._suggest_indicators(trial, max_enabled=None)
+        trial.set_user_attr("n_on", sum(1 for s in specs if s["enabled"]))
+        return 0.0
+    st = optuna.create_study(sampler=optuna.samplers.RandomSampler(seed=0))
+    st.optimize(obj, n_trials=60)
+    assert max(t.user_attrs["n_on"] for t in st.trials) > 3

--- a/subprojects/Parametric-Indicators/requirements-dev.txt
+++ b/subprojects/Parametric-Indicators/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Dev/test-only. NOT imported at runtime by the engine/dashboard/optimizer.
+-r requirements.txt
+
+# Optional oracle libraries for scripts/gen_oracle.py ONLY. Indicator reference tests use
+# independent pandas/numpy expressions (see tests/oracle/), so these are NOT required to run the
+# test suite. Install if you want to cross-check against TA-Lib / pandas-ta. Note: older pandas-ta
+# may not import under pandas>=3 / numpy>=2 — that is why the tests do not depend on it.
+pandas-ta ; python_version < "4.0"
+TA-Lib ; platform_system != "Windows"

--- a/subprojects/Parametric-Indicators/scripts/gen_oracle.py
+++ b/subprojects/Parametric-Indicators/scripts/gen_oracle.py
@@ -1,0 +1,43 @@
+"""Offline helper: print pandas-ta reference values for an indicator on the shared fixture, to
+eyeball against a new primitive. NOT part of the test suite (tests use independent pandas/numpy
+oracles). Usage:  python scripts/gen_oracle.py rsi 14
+
+Requires the optional dev oracle: pip install -r requirements-dev.txt (pandas-ta). If pandas-ta is
+unavailable/incompatible with your pandas, this prints a clear message instead of crashing."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pandas as pd
+
+from tests.oracle.fixture import ohlcv
+
+try:
+    import pandas_ta as ta
+except Exception as exc:  # noqa: BLE001 - optional dependency
+    print(f"pandas-ta unavailable ({exc}). Install requirements-dev.txt or write an independent "
+          f"pandas/numpy oracle in the test instead.")
+    raise SystemExit(1)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: python scripts/gen_oracle.py <indicator> [length ...]")
+        raise SystemExit(2)
+    name = sys.argv[1]
+    args = [int(a) for a in sys.argv[2:]]
+    d = ohlcv(300)
+    df = pd.DataFrame(d)
+    fn = getattr(ta, name, None)
+    if fn is None:
+        print(f"pandas-ta has no '{name}'")
+        raise SystemExit(2)
+    kwargs = {"close": df.close, "high": df.high, "low": df.low, "open": df.open, "volume": df.volume}
+    if args:
+        kwargs["length"] = args[0]
+    out = fn(**{k: v for k, v in kwargs.items()})
+    print(out.tail(10).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/subprojects/Parametric-Indicators/tests/oracle/fixture.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/fixture.py
@@ -1,0 +1,21 @@
+"""Deterministic OHLCV fixture shared by every indicator reference test.
+
+Fixed seed → identical arrays every run (no wall-clock / no global RNG state). High/low are widened
+to enclose open & close so every bar is valid. Returns plain numpy arrays (the MarketContext shape)."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def ohlcv(n: int = 300) -> dict:
+    rng = np.random.default_rng(20260725)             # fixed seed → deterministic
+    ret = rng.normal(0.0, 0.01, n)
+    close = 100.0 * np.exp(np.cumsum(ret))
+    spread = np.abs(rng.normal(0.0, 0.4, n)) + 0.1
+    high = close + spread
+    low = close - spread
+    openp = np.concatenate([[close[0]], close[:-1]])   # today's open = yesterday's close
+    high = np.maximum.reduce([high, openp, close])     # enclose O & C
+    low = np.minimum.reduce([low, openp, close])
+    volume = rng.integers(500, 5000, n).astype(float)
+    return {"open": openp, "high": high, "low": low, "close": close, "volume": volume}

--- a/subprojects/Parametric-Indicators/tests/oracle/test_fixture_deterministic.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_fixture_deterministic.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+
+from tests.oracle.fixture import ohlcv
+
+
+def test_fixture_is_deterministic_and_valid():
+    a, b = ohlcv(300), ohlcv(300)
+    for k in ("open", "high", "low", "close", "volume"):
+        assert np.array_equal(a[k], b[k])
+    assert np.all(a["high"] >= a["low"])
+    assert np.all(a["high"] >= a["close"]) and np.all(a["close"] >= a["low"])
+    assert np.all(a["high"] >= a["open"]) and np.all(a["open"] >= a["low"])
+    assert np.all(a["volume"] > 0)
+    assert len(a["close"]) == 300

--- a/subprojects/Parametric-Indicators/tests/oracle/test_levels_bw_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_levels_bw_primitives.py
@@ -1,0 +1,69 @@
+"""Oracle + property tests for Ichimoku/pivot (calc/levels.py) and Bill-Williams (calc/bw.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+
+from indicators.calc import bw as BW, levels as LV
+from indicators.classic import _roll_max, _roll_min
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+O, H, L, C = D["open"], D["high"], D["low"], D["close"]
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def test_ichimoku_tenkan_independent():
+    t = 9
+    exp = (_roll_max(H, t) + _roll_min(L, t)) / 2.0
+    tenkan, _, _, _ = LV.ichimoku_lines(H, L, t, 26, 52)
+    m = ~np.isnan(exp)
+    assert np.allclose(tenkan[m], exp[m], atol=1e-12)
+
+
+def test_prior_session_ohlc_hand_case():
+    o = np.array([1, 2, 3, 4.0]); h = np.array([10, 11, 5, 6.0])
+    l = np.array([1, 2, 0, 1.0]); c = np.array([9, 8, 4, 5.0])
+    sid = np.array([0, 0, 1, 1])
+    pO, pH, pL, pC = LV.prior_session_ohlc(o, h, l, c, sid)
+    assert np.isnan(pH[0]) and np.isnan(pH[1])          # no prior session yet
+    assert pH[2] == 11 and pL[2] == 1 and pC[2] == 8 and pO[2] == 1
+    assert pH[3] == 11 and pL[3] == 1 and pC[3] == 8    # constant within session 1
+
+
+def test_pivot_formulas():
+    pO, pH, pL, pC = LV.prior_session_ohlc(O, H, L, C, np.repeat(np.arange(15), 20))
+    assert np.allclose(_fin(LV.floor_pp(pH, pL, pC)),
+                       _fin((pH + pL + pC) / 3.0), atol=1e-12)
+    top, bot = LV.cpr_levels(pH, pL, pC)
+    m = ~np.isnan(top)
+    assert np.all(top[m] >= bot[m] - 1e-9)
+
+
+def test_awesome_uses_median_ewo_uses_close():
+    ao = BW.awesome((H + L) / 2.0)
+    ew = BW.ewo(C)
+    # different inputs ⇒ generally different series
+    m = ~np.isnan(ao) & ~np.isnan(ew)
+    assert m.sum() > 100 and not np.allclose(ao[m], ew[m])
+
+
+def test_accel_finite_after_fix():
+    assert len(_fin(BW.accel((H + L) / 2.0))) > 100
+
+
+def test_fractal_detects_peak():
+    x = np.array([1, 2, 3, 10, 3, 2, 1.0])       # clear peak at index 3
+    up, dn = BW.fractal_levels(x, x)
+    # peak (center=3) is confirmed at bar 5 (center+2)
+    assert up[5] == 10.0
+
+
+def test_alligator_finite():
+    jaw, teeth, lips = BW.alligator(H, L)
+    assert len(_fin(jaw)) > 100 and len(_fin(lips)) > 100

--- a/subprojects/Parametric-Indicators/tests/oracle/test_ma_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_ma_primitives.py
@@ -1,0 +1,142 @@
+"""Independent-oracle tests for the moving-average primitives (indicators/calc/ma.py).
+
+Oracles are re-derived here (local EMA loop, pandas rolling, numpy polyfit) — NOT imported from the
+production code — so a bug in calc/ma.py cannot hide behind a shared implementation."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+import pandas as pd
+
+from indicators.calc import ma
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+C, V = D["close"], D["volume"]
+
+
+def _ema_ref(x, n):
+    a = 2.0 / (n + 1.0)
+    out = np.empty(len(x))
+    out[0] = x[0]
+    for i in range(1, len(x)):
+        out[i] = a * x[i] + (1.0 - a) * out[i - 1]
+    return out
+
+
+def _wma_ref(x, n):
+    w = np.arange(1, n + 1)
+    return pd.Series(x).rolling(n).apply(lambda s: np.dot(s, w) / w.sum(), raw=True).to_numpy()
+
+
+def _close(a, b):
+    m = ~np.isnan(b)
+    assert m.sum() > 50
+    assert np.allclose(a[m], b[m], atol=1e-8), np.nanmax(np.abs(a[m] - b[m]))
+
+
+def test_dema():
+    e = _ema_ref(C, 20)
+    _close(ma.dema(C, 20), 2.0 * e - _ema_ref(e, 20))
+
+
+def test_tema():
+    e = _ema_ref(C, 20)
+    e2 = _ema_ref(e, 20)
+    e3 = _ema_ref(e2, 20)
+    _close(ma.tema(C, 20), 3.0 * e - 3.0 * e2 + e3)
+
+
+def test_tma():
+    n = 10                                   # ceil(10/2)=5, floor(10/2)+1=6
+    o = pd.Series(pd.Series(C).rolling(5).mean()).rolling(6).mean().to_numpy()
+    _close(ma.tma(C, n), o)
+
+
+def test_hma():
+    n = 16
+    o = _wma_ref(2.0 * _wma_ref(C, n // 2) - _wma_ref(C, n), int(np.sqrt(n)))
+    _close(ma.hma(C, n), o)
+
+
+def test_zlema():
+    n, = (14,)
+    lag = (n - 1) // 2
+    d = C.copy()
+    d[lag:] = 2.0 * C[lag:] - C[:-lag]
+    _close(ma.zlema(C, n), _ema_ref(d, n))
+
+
+def test_sine_wma():
+    n = 20
+    k = np.arange(n)
+    w = np.sin(np.pi * (k + 1) / (n + 1))
+    w /= w.sum()
+    o = pd.Series(C).rolling(n).apply(lambda s: np.dot(s, w), raw=True).to_numpy()
+    _close(ma.sine_wma(C, n), o)
+
+
+def test_vwma():
+    n = 20
+    num = pd.Series(C * V).rolling(n).sum().to_numpy()
+    den = pd.Series(V).rolling(n).sum().to_numpy()
+    _close(ma.vwma(C, V, n), num / den)
+
+
+def test_lsma():
+    n = 14
+    out = np.full(len(C), np.nan)
+    for i in range(n - 1, len(C)):
+        y = C[i - n + 1:i + 1]
+        b, a = np.polyfit(np.arange(n), y, 1)
+        out[i] = a + b * (n - 1)
+    _close(ma.lsma(C, n), out)
+
+
+def test_alma():
+    n, offset, sigma = 9, 0.85, 6.0
+    m = offset * (n - 1)
+    s = n / sigma
+    k = np.arange(n)
+    w = np.exp(-((k - m) ** 2) / (2.0 * s * s))
+    w /= w.sum()
+    o = pd.Series(C).rolling(n).apply(lambda z: np.dot(z, w), raw=True).to_numpy()
+    _close(ma.alma(C, n, offset, sigma), o)
+
+
+def test_t3_coeffs_sum_to_one_and_constant_fixed_point():
+    const = np.full(120, 42.0)
+    out = ma.t3(const, 10, 0.7)
+    assert np.allclose(out[-1], 42.0, atol=1e-6)   # coeffs sum to 1 ⇒ MA of constant is the constant
+
+
+def test_kama_properties():
+    n, fast, slow = 10, 2, 30
+    out = ma.kama(C, n, fast, slow)
+    assert np.isnan(out[:n]).all() and out[n] == C[n]     # NaN warm-up + seed
+    const = np.full(60, 7.0)
+    assert np.allclose(ma.kama(const, n, fast, slow)[n:], 7.0, atol=1e-9)  # constant fixed point
+
+
+def test_vidya_properties():
+    n = 14
+    out = ma.vidya(C, n)
+    assert np.isnan(out[:n]).all() and out[n] == C[n]
+    const = np.full(60, 5.0)
+    assert np.allclose(ma.vidya(const, n)[n:], 5.0, atol=1e-9)
+
+
+def test_mcginley_properties():
+    out = ma.mcginley(C, 14)
+    assert out[0] == C[0] and not np.isnan(out).any()
+    const = np.full(50, 3.0)
+    assert np.allclose(ma.mcginley(const, 14), 3.0, atol=1e-9)   # x/md==1 ⇒ no adjustment
+
+
+def test_evwma_properties():
+    n = 20
+    out = ma.evwma(C, V, n)
+    assert np.isnan(out[:n - 1]).all() and out[n - 1] == C[n - 1]
+    const = np.full(60, 9.0)
+    assert np.allclose(ma.evwma(const, V[:60], n)[n - 1:], 9.0, atol=1e-9)

--- a/subprojects/Parametric-Indicators/tests/oracle/test_ma_wma.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_ma_wma.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+import pandas as pd
+
+from indicators.calc.ma import wma
+from tests.oracle.fixture import ohlcv
+
+
+def test_wma_matches_independent_pandas_oracle():
+    x = ohlcv(300)["close"]
+    n = 10
+    w = np.arange(1, n + 1)
+    oracle = pd.Series(x).rolling(n).apply(lambda s: np.dot(s, w) / w.sum(), raw=True).to_numpy()
+    got = wma(x, n)
+    m = ~np.isnan(oracle)
+    assert np.allclose(got[m], oracle[m], atol=1e-9)
+    assert np.isnan(got[:n - 1]).all()      # causal warm-up
+
+
+def test_wma_weights_recent_more():
+    # ramp input: WMA must exceed SMA (recent-weighted) and trail the latest value
+    x = np.arange(1.0, 21.0)
+    n = 5
+    got = wma(x, n)
+    sma5 = pd.Series(x).rolling(n).mean().to_numpy()
+    assert got[-1] > sma5[-1] and got[-1] < x[-1]

--- a/subprojects/Parametric-Indicators/tests/oracle/test_osc_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_osc_primitives.py
@@ -1,0 +1,130 @@
+"""Independent-oracle + property tests for oscillator primitives (indicators/calc/osc.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+import pandas as pd
+
+from indicators.calc import osc
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+O, H, L, C, V = D["open"], D["high"], D["low"], D["close"], D["volume"]
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def _bounded(a, lo, hi, tol=1e-6):
+    f = _fin(a)
+    assert f.min() >= lo - tol and f.max() <= hi + tol, (f.min(), f.max())
+    assert len(f) > 100
+
+
+# ---- exact independent oracles ----
+def test_momentum():
+    assert np.allclose(_fin(osc.momentum(C, 10)), C[10:] - C[:-10], atol=1e-9)
+
+
+def test_roc():
+    assert np.allclose(_fin(osc.roc(C, 9)), 100.0 * (C[9:] / C[:-9] - 1.0), atol=1e-9)
+
+
+def test_disparity():
+    sma = pd.Series(C).rolling(14).mean().to_numpy()
+    exp = 100.0 * (C / sma - 1.0)
+    got = osc.disparity(C, 14)
+    m = ~np.isnan(exp)
+    assert np.allclose(got[m], exp[m], atol=1e-9)
+
+
+def test_williams_r_matches_pandas():
+    n = 14
+    hh = pd.Series(H).rolling(n).max().to_numpy()
+    ll = pd.Series(L).rolling(n).min().to_numpy()
+    exp = -100.0 * (hh - C) / (hh - ll)
+    got = osc.williams_r(H, L, C, n)
+    m = ~np.isnan(exp)
+    assert np.allclose(got[m], exp[m], atol=1e-9)
+    _bounded(got, -100.0, 0.0)
+
+
+def test_cmo_matches_pandas():
+    n = 14
+    d = np.diff(C)
+    up = pd.Series(np.where(d > 0, d, 0.0)).rolling(n).sum().to_numpy()
+    dn = pd.Series(np.where(d < 0, -d, 0.0)).rolling(n).sum().to_numpy()
+    exp = np.full(len(C), np.nan)
+    exp[1:] = 100.0 * (up - dn) / (up + dn)
+    got = osc.cmo(C, n)
+    m = ~np.isnan(exp)
+    assert np.allclose(got[m], exp[m], atol=1e-9)
+    _bounded(got, -100.0, 100.0)
+
+
+def test_psy():
+    n = 12
+    up = (np.diff(C) > 0).astype(float)
+    exp = np.full(len(C), np.nan)
+    exp[1:] = 100.0 * pd.Series(up).rolling(n).sum().to_numpy() / n
+    got = osc.psy(C, n)
+    m = ~np.isnan(exp)
+    assert np.allclose(got[m], exp[m], atol=1e-9)
+    _bounded(got, 0.0, 100.0)
+
+
+def test_rsi_cutler_matches_sma_rsi():
+    n = 14
+    d = np.diff(C)
+    ag = pd.Series(np.where(d > 0, d, 0.0)).rolling(n).mean().to_numpy()
+    al = pd.Series(np.where(d < 0, -d, 0.0)).rolling(n).mean().to_numpy()
+    exp = np.full(len(C), np.nan)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        exp[1:] = 100.0 - 100.0 / (1.0 + ag / al)
+    got = osc.rsi_cutler(C, n)
+    m = ~np.isnan(exp) & ~np.isnan(got)
+    assert m.sum() > 100 and np.allclose(got[m], exp[m], atol=1e-9)
+    _bounded(got, 0.0, 100.0)
+
+
+# ---- bounded-range / finite properties for the complex ones ----
+def test_bounded_ranges():
+    _bounded(osc.rsi_cutler(C, 14), 0, 100)
+    _bounded(osc.connors_rsi(C), 0, 100)
+    _bounded(osc.rmi(C, 14, 5), 0, 100)
+    _bounded(osc.dynamic_dmi(C, 14), 0, 100)
+    _bounded(osc.stoch_rsi(C, 14, 14, 3), 0, 100)
+    _bounded(osc.kdj_k(H, L, C, 9), 0, 100)
+    _bounded(osc.ultimate_osc(H, L, C), 0, 100)
+    _bounded(osc.tsi(C, 25, 13), -100, 100)
+    _bounded(osc.bias(C, 6), -100, 100)
+
+
+def test_finite_and_warmup():
+    for name, a, warm in [
+        ("smi", osc.smi(H, L, C, 14, 3), 14),
+        ("wavetrend", osc.wavetrend(H, L, C, 10, 21), 1),
+        ("fisher", osc.fisher(H, L, 9), 9),
+        ("derivative_osc", osc.derivative_osc(C, 14, 5, 3, 9), 14),
+        ("ergodic", osc.ergodic(C, 32, 5, 5), 32),
+        ("pgo", osc.pgo(H, L, C, 14), 14),
+        ("rvgi", osc.rvgi(O, H, L, C, 14), 14),
+        ("balance_of_power", osc.balance_of_power(O, H, L, C, 14), 14),
+    ]:
+        assert len(_fin(a)) > 100, name
+
+
+def test_nan_ema_seeds_at_first_finite():
+    x = np.array([np.nan, np.nan, 10.0, 12.0, 14.0])
+    e = osc.nan_ema(x, 3)
+    assert np.isnan(e[0]) and np.isnan(e[1]) and e[2] == 10.0
+    assert not np.isnan(e[3])
+
+
+def test_roll_sum_safe_ignores_leading_nan():
+    x = np.array([np.nan, np.nan, 1.0, 2.0, 3.0, 4.0])
+    s = osc.roll_sum_safe(x, 3)
+    assert np.isnan(s[3]) and s[4] == 6.0 and s[5] == 9.0    # first full-valid window at idx 4

--- a/subprojects/Parametric-Indicators/tests/oracle/test_quant_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_quant_primitives.py
@@ -1,0 +1,64 @@
+"""Oracle + property tests for quant primitives (indicators/calc/quant.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+import pandas as pd
+
+from indicators.calc import quant as Q
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+H, L, C = D["high"], D["low"], D["close"]
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def test_zscore_independent():
+    n = 20
+    sma = pd.Series(C).rolling(n).mean().to_numpy()
+    std = pd.Series(C).rolling(n).std(ddof=0).to_numpy()
+    exp = (C - sma) / std
+    got = Q.zscore(C, n)
+    m = ~np.isnan(exp)
+    assert np.allclose(got[m], exp[m], atol=1e-9)
+
+
+def test_hurst_dfa_near_half_for_random_walk():
+    hu = _fin(Q.hurst_exp(C, 100))
+    df = _fin(Q.dfa(C, 100))
+    assert 0.3 < hu.mean() < 0.8 and 0.3 < df.mean() < 0.9
+    assert hu.min() >= 0.0 and df.min() >= 0.0
+
+
+def test_autocorr_bounded():
+    a = _fin(Q.autocorr(C, 50))
+    assert a.min() >= -1 - 1e-9 and a.max() <= 1 + 1e-9
+
+
+def test_demarker_bounded_unit():
+    d = _fin(Q.demarker(H, L, 14))
+    assert d.min() >= -1e-9 and d.max() <= 1 + 1e-9
+
+
+def test_td_rei_bounded():
+    r = _fin(Q.td_rei(H, L, 5))
+    assert r.min() >= -100 - 1e-6 and r.max() <= 100 + 1e-6
+
+
+def test_linreg_r2_bounded_and_one_on_line():
+    r2 = _fin(Q.linreg_r2(C, 20))
+    assert r2.min() >= -1e-9 and r2.max() <= 1 + 1e-9
+    line = np.linspace(10, 50, 60)              # perfect line ⇒ R²=1
+    assert np.isclose(_fin(Q.linreg_r2(line, 20))[-1], 1.0, atol=1e-9)
+
+
+def test_efficiency_ratio_bounded_and_one_on_monotonic():
+    er = _fin(Q.efficiency_ratio(C, 10))
+    assert er.min() >= -1e-9 and er.max() <= 1 + 1e-9
+    up = np.arange(1.0, 61.0)                    # strictly monotonic ⇒ ER=1
+    assert np.isclose(_fin(Q.efficiency_ratio(up, 10))[-1], 1.0, atol=1e-9)

--- a/subprojects/Parametric-Indicators/tests/oracle/test_trend_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_trend_primitives.py
@@ -1,0 +1,111 @@
+"""Independent-oracle + property tests for trend/directional primitives (indicators/calc/trend.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+
+from indicators.calc import trend as T
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+O, H, L, C = D["open"], D["high"], D["low"], D["close"]
+
+
+def _ema_ref(x, n):
+    a = 2.0 / (n + 1.0)
+    out = np.empty(len(x))
+    out[0] = x[0]
+    for i in range(1, len(x)):
+        out[i] = a * x[i] + (1.0 - a) * out[i - 1]
+    return out
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def test_ppo_apo_independent():
+    ef, es = _ema_ref(C, 12), _ema_ref(C, 26)
+    assert np.allclose(_fin(T.ppo(C, 12, 26)), 100.0 * (ef - es) / es, atol=1e-9)
+    assert np.allclose(_fin(T.apo(C, 12, 26)), ef - es, atol=1e-9)
+
+
+def test_dpo_independent():
+    import pandas as pd
+    n = 20
+    sma = pd.Series(C).rolling(n).mean().to_numpy()
+    shift = n // 2 + 1
+    exp = C - np.concatenate([np.full(shift, np.nan), sma[:-shift]])
+    got = T.dpo(C, n)
+    m = ~np.isnan(exp) & ~np.isnan(got)
+    assert m.sum() > 100 and np.allclose(got[m], exp[m], atol=1e-9)
+
+
+def test_aroon_on_monotonic():
+    up_series = np.arange(1.0, 101.0)          # strictly increasing
+    up, dn = T.aroon(up_series, up_series, 25)
+    assert np.nanmax(up) == 100.0 and np.nanmin(_fin(up)) >= 0.0
+    assert _fin(up)[-1] == 100.0 and _fin(dn)[-1] == 0.0   # newest bar is the high, oldest-in-window the low
+
+
+def test_di_bounded_and_directional():
+    pdi, mdi = T.plus_minus_di(H, L, C, 14)
+    for a in (pdi, mdi):
+        f = _fin(a)
+        assert f.min() >= -1e-6 and f.max() <= 100 + 1e-6
+    # strong uptrend ⇒ +DI dominates
+    up = np.cumsum(np.abs(np.sin(np.arange(200)))) + 100
+    p2, m2 = T.plus_minus_di(up + 1, up - 1, up, 14)
+    assert np.nanmean(p2[50:]) > np.nanmean(m2[50:])
+
+
+def test_psar_and_supertrend_follow_uptrend():
+    up = np.linspace(100, 200, 150)
+    sar = T.psar(up + 1, up - 1, 0.02, 0.2)
+    assert np.nanmean((up - sar)[30:] > 0) > 0.9      # SAR below price in an uptrend
+    st = T.supertrend(up + 1, up - 1, up, 10, 3.0)
+    assert np.nanmean(_fin(st)[30:]) > 0.5            # mostly +1
+
+
+def test_qqe_and_supertrend_are_pm1():
+    for a in (T.qqe(C, 14, 5, 4.236), T.supertrend(H, L, C, 10, 3.0)):
+        u = np.unique(_fin(a))
+        assert set(u.tolist()).issubset({-1.0, 1.0})
+
+
+def test_trend_intensity_bounded():
+    v = _fin(T.trend_intensity(C, 60))
+    assert v.min() >= -1e-6 and v.max() <= 100 + 1e-6
+
+
+def test_linreg_slope_sign_on_ramp():
+    up = np.linspace(50, 150, 120)
+    assert np.nanmean(T.linreg_slope(up, 14)[20:]) > 0
+    down = np.linspace(150, 50, 120)
+    assert np.nanmean(T.linreg_slope(down, 14)[20:]) < 0
+
+
+def test_bbi_and_trix_finite():
+    assert len(_fin(T.bbi(C))) > 100
+    assert len(_fin(T.trix(C, 15))) > 100
+    assert len(_fin(T.kst(C))) > 100
+    assert len(_fin(T.coppock(C))) > 100
+
+
+def test_asi_and_dma_finite():
+    assert len(_fin(T.asi(O, H, L, C, 3.0))) > 100
+    ddd, ama = T.dma(C, 10, 50, 10)
+    assert len(_fin(ddd)) > 100 and len(_fin(ama)) > 100
+
+
+def test_chandelier_stops_bracket_swing():
+    from indicators.classic import _roll_max, _roll_min
+    n = 22
+    ls, ss = T.chandelier(H, L, C, n, 3.0)
+    hh, ll = _roll_max(H, n), _roll_min(L, n)
+    m = ~np.isnan(ls)
+    # long stop = HHn − m·ATR < HHn ; short stop = LLn + m·ATR > LLn  (ATR>0)
+    assert np.all(ls[m] < hh[m] + 1e-9) and np.all(ss[m] > ll[m] - 1e-9)
+    assert m.sum() > 100

--- a/subprojects/Parametric-Indicators/tests/oracle/test_vol_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_vol_primitives.py
@@ -1,0 +1,78 @@
+"""Independent-oracle + property tests for volatility primitives (indicators/calc/vol.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+import pandas as pd
+
+from indicators import library
+from indicators.base import MarketContext
+from indicators.calc import vol as V
+from indicators import classic
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+O, H, L, C = D["open"], D["high"], D["low"], D["close"]
+CTX = MarketContext(O, H, L, C, D["volume"], np.zeros(300, int))
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def test_stddev_matches_pandas():
+    n = 20
+    exp = pd.Series(C).rolling(n).std(ddof=0).to_numpy()
+    got = V.stddev(C, n)
+    m = ~np.isnan(exp)
+    assert np.allclose(got[m], exp[m], atol=1e-9)
+
+
+def test_atr_norm_matches_classic():
+    n = 14
+    exp = classic.atr(H, L, C, n) / C
+    got = V.atr_norm(H, L, C, n)
+    m = ~np.isnan(exp)
+    assert np.allclose(got[m], exp[m], atol=1e-12)
+
+
+def test_positive_vol_estimators():
+    for a in (V.parkinson(H, L, 20), V.garman_klass(O, H, L, C, 20),
+              V.rogers_satchell(O, H, L, C, 20), V.yang_zhang(O, H, L, C, 20),
+              V.hist_vol(C, 20), V.ulcer(C, 14)):
+        f = _fin(a)
+        assert len(f) > 100 and f.min() >= 0.0
+
+
+def test_choppiness_and_mass_finite_positive():
+    ch = _fin(V.choppiness(H, L, C, 14))
+    assert ch.min() >= 0.0 and len(ch) > 100
+    mi = _fin(V.mass_index(H, L, 25))
+    assert mi.min() > 0.0 and len(mi) > 100
+
+
+def test_ttm_squeeze_is_binary():
+    sq = V.ttm_squeeze(H, L, C, 20)
+    assert set(np.unique(sq).tolist()).issubset({0.0, 1.0})
+
+
+def test_rvi_dorsey_bounded():
+    v = _fin(V.rvi_dorsey(C, 14))
+    assert v.min() >= -1e-6 and v.max() <= 100 + 1e-6
+
+
+def test_magnitude_veto_fires_with_permissive_threshold():
+    # threshold 1.05 ⇒ veto whenever value < 1.05·EMA(value) — should fire on many bars.
+    ind = library.from_specs([{"key": "stddev", "enabled": True, "mode": "veto",
+                               "params": {"n": 20, "m": 50, "threshold": 1.05}}])[0]
+    _, vdir = ind.directions(CTX)
+    assert (vdir != 0).sum() > 30
+
+
+def test_choppiness_veto_fires_with_low_threshold():
+    ind = library.from_specs([{"key": "choppiness", "enabled": True, "mode": "veto",
+                               "params": {"n": 14, "threshold": 30.0}}])[0]
+    _, vdir = ind.directions(CTX)
+    assert (vdir != 0).sum() > 30

--- a/subprojects/Parametric-Indicators/tests/oracle/test_volume_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_volume_primitives.py
@@ -1,0 +1,78 @@
+"""Independent-oracle + property tests for volume primitives (indicators/calc/volume.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+import pandas as pd
+
+from indicators.calc import volume as VO
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+O, H, L, C, V = D["open"], D["high"], D["low"], D["close"], D["volume"]
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def test_ad_line_independent():
+    mfm = ((C - L) - (H - C)) / (H - L)
+    exp = np.cumsum(mfm * V)
+    assert np.allclose(VO.ad_line(H, L, C, V), exp, atol=1e-6)
+
+
+def test_cmf_bounded():
+    cmf = _fin(VO.cmf(H, L, C, V, 20))
+    assert cmf.min() >= -1.0 - 1e-9 and cmf.max() <= 1.0 + 1e-9 and len(cmf) > 100
+
+
+def test_pvt_recurrence():
+    p = VO.pvt(C, V)
+    exp = np.zeros(len(C))
+    for i in range(1, len(C)):
+        exp[i] = exp[i - 1] + (C[i] - C[i - 1]) / C[i - 1] * V[i]
+    assert np.allclose(p, exp, atol=1e-9)
+
+
+def test_nvi_pvi_seed_and_change_only_on_volume_regime():
+    nvi = VO.nvi(C, V)
+    assert nvi[0] == 1000.0
+    # NVI changes only when volume falls
+    for i in range(1, len(C)):
+        if V[i] >= V[i - 1]:
+            assert nvi[i] == nvi[i - 1]
+
+
+def test_bw_mfi_is_ternary():
+    assert set(np.unique(VO.bw_mfi(H, L, V)).tolist()).issubset({-1.0, 0.0, 1.0})
+
+
+def test_vzo_bounded():
+    z = _fin(VO.vzo(C, V, 14))
+    assert z.min() >= -100 - 1e-6 and z.max() <= 100 + 1e-6
+
+
+def test_vr_asia_positive():
+    r = _fin(VO.volume_ratio_asia(C, V, 26))
+    assert r.min() >= 0.0 and len(r) > 100
+
+
+def test_anchored_vwap_within_price_range():
+    av = _fin(VO.anchored_vwap(H, L, C, V, np.zeros(300, int)))
+    assert av.min() >= L.min() - 1e-6 and av.max() <= H.max() + 1e-6
+
+
+def test_flow_lines_finite():
+    for a in (VO.chaikin_osc(H, L, C, V, 3, 10), VO.eom(H, L, V, 14),
+              VO.force_index(C, V, 13), VO.klinger(H, L, C, V, 34, 55, 13)[0],
+              VO.demand_index(C, V, 20), VO.twiggs_mf(H, L, C, V, 21),
+              VO.wvad(O, H, L, C, V, 20), VO.vol_osc(V, 5, 20)):
+        assert len(_fin(a)) > 100
+
+
+def test_demand_index_bounded():
+    di = _fin(VO.demand_index(C, V, 20))
+    assert di.min() >= -1 - 1e-9 and di.max() <= 1 + 1e-9


### PR DESCRIPTION
## Summary

Expands the technical-indicator library from **18 → 143** registry keys by adding **125 faithful, single-OHLCV "calc" indicators** as confirm/veto votes on the box signal. Each indicator is written **once** and auto-propagates to all three surfaces — backtester (both engines), dashboard (`schema()`), and optimizer (`_suggest_indicators` loops the registry) — with **structural parity** (fast_engine consumes the shared folded vote mask).

Design + plan: `docs/superpowers/specs/2026-07-25-calc-indicators-library-design.md`, `docs/superpowers/plans/2026-07-25-calc-indicators-library.md`. World inventory: `docs/extra-indicators/INDICATOR-SCHOOLS-INVENTORY.md`.

## What's included (7 phases, 125 indicators)

| Phase | School | Count |
|---|---|---|
| 1 | Moving averages | 19 |
| 2 | Oscillators | 23 |
| 3 | Trend/directional | 24 |
| 4 | Volatility | 18 |
| 5 | Volume/money-flow | 18 |
| 6 | Ichimoku/pivots/Bill Williams | 15 |
| 7 | Quant/statistical | 8 |

Plus framework: per-school registry aggregation (`indicators/lib_<school>.py` + `calc/<school>.py`), generalized vote helpers (`band_directions`, `magnitude_veto`, `both_veto`), deterministic OHLCV oracle harness, full-registry parity sweep, and an optimizer **`--max-enabled` K-cap** to keep the 143-key search sparse.

## Verification

- **86 unit tests** green — every primitive has an **independent pandas/numpy oracle** or property test (TA-Lib/pandas-ta are optional dev-only; not usable under pandas 3.0 / numpy 2.x).
- **Full 143-key parity sweep: 0 mismatches** (fast_engine == exact engine), plus legacy combos + all-off invariant.
- 8 real NaN-poisoning bugs (`classic.sma`/`ema`/`cumsum` on warm-up inputs) caught & fixed via reusable `nan_ema`/`roll_sum_safe`/`nan_sma`.

## Scope notes

- **Confirm/veto votes only** — indicators never originate an entry (per approved design).
- **Tier-2 (~22 hard/approximate)** deferred: MAMA/FRAMA/JMA, Ehlers DSP, TD Sequential, Kalman, cross-series quant.
- No change to box signal, exits, or sizing. The frozen `shareable/` copy is untouched.
- ⚠️ **Adopt-gate still applies**: before any of these 125 is accepted as a champion contributor, the mandatory power + noise + dumb-control + OOS checks must pass. This PR lands the *library*, not any adopted champion.

## Test plan

```
cd subprojects/Parametric-Indicators
python3 -m pytest tests/oracle/ indicators/ optimize/test_max_enabled_cap.py   # 86 passed
python3 optimize/test_indicator_parity.py 4h                                    # 149 OK / 0 FAIL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)