### PR TITLE
feat(indicators): Tier-2 single-series indicators (18)

### DIFF
--- a/subprojects/Parametric-Indicators/indicators/calc/dsp.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/dsp.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 import numpy as np
 
+from ..classic import _roll_max, _roll_min
+from ..classic import ema as _ema
+
 
 def super_smoother(x, n):
     """Ehlers 2-pole SuperSmoother (Butterworth). Zero warm-up NaN — seeded from the raw series."""
@@ -118,3 +121,127 @@ def mama_fama(price, fast=0.5, slow=0.05):
         mama[i] = alpha * p[i] + (1 - alpha) * mama[i - 1]
         fama[i] = 0.5 * alpha * mama[i] + (1 - 0.5 * alpha) * fama[i - 1]
     return mama, fama
+
+
+def laguerre_rsi(price, gamma):
+    """Ehlers Laguerre RSI (0..1): RSI logic over a 4-stage Laguerre filter."""
+    p = np.asarray(price, dtype=float)
+    N = len(p)
+    out = np.full(N, np.nan)
+    l0p = l1p = l2p = l3p = 0.0
+    for i in range(N):
+        l0 = (1 - gamma) * p[i] + gamma * l0p
+        l1 = -gamma * l0 + l0p + gamma * l1p
+        l2 = -gamma * l1 + l1p + gamma * l2p
+        l3 = -gamma * l2 + l2p + gamma * l3p
+        cu = max(l0 - l1, 0) + max(l1 - l2, 0) + max(l2 - l3, 0)
+        cd = max(l1 - l0, 0) + max(l2 - l1, 0) + max(l3 - l2, 0)
+        out[i] = cu / (cu + cd) if (cu + cd) > 0 else 0.5
+        l0p, l1p, l2p, l3p = l0, l1, l2, l3
+    return out
+
+
+def schaff_trend_cycle(close, fast, slow, cycle):
+    """Schaff Trend Cycle (0..100): double stochastic of the MACD line."""
+    c = np.asarray(close, dtype=float)
+    macd = _ema(c, fast) - _ema(c, slow)
+    N = len(c)
+
+    def _stoch_smooth(x):
+        lo, hi = _roll_min(x, cycle), _roll_max(x, cycle)
+        out = np.full(N, np.nan)
+        pf = np.nan
+        for i in range(N):
+            if np.isnan(lo[i]) or hi[i] == lo[i]:
+                k = pf if not np.isnan(pf) else 50.0
+            else:
+                k = 100.0 * (x[i] - lo[i]) / (hi[i] - lo[i])
+            pf = k if np.isnan(pf) else pf + 0.5 * (k - pf)
+            out[i] = pf
+        return out
+
+    return _stoch_smooth(_stoch_smooth(macd))
+
+
+def cyber_cycle(price, alpha):
+    """Ehlers Cyber Cycle oscillator (~0)."""
+    p = np.asarray(price, dtype=float)
+    N = len(p)
+    sm = np.zeros(N)
+    cy = np.zeros(N)
+    for i in range(N):
+        if i < 3:
+            sm[i] = p[i]
+            continue
+        sm[i] = (p[i] + 2 * p[i - 1] + 2 * p[i - 2] + p[i - 3]) / 6.0
+        cy[i] = ((1 - 0.5 * alpha) ** 2 * (sm[i] - 2 * sm[i - 1] + sm[i - 2])
+                 + 2 * (1 - alpha) * cy[i - 1] - (1 - alpha) ** 2 * cy[i - 2])
+    return cy
+
+
+def center_of_gravity(price, n):
+    """Ehlers Center-of-Gravity oscillator (~0)."""
+    p = np.asarray(price, dtype=float)
+    N = len(p)
+    out = np.full(N, np.nan)
+    w = 1 + np.arange(n)
+    for i in range(n - 1, N):
+        seg = p[i - n + 1:i + 1][::-1]     # seg[j] = price[i-j]
+        den = seg.sum()
+        out[i] = (-np.dot(w, seg) / den + (n + 1) / 2.0) if den != 0 else 0.0
+    return out
+
+
+def dominant_cycle(price):
+    """Ehlers homodyne-discriminator dominant cycle period + the 4-bar weighted smooth price."""
+    p = np.asarray(price, dtype=float)
+    N = len(p)
+    z = lambda: np.zeros(N)  # noqa: E731
+    sm, dt, i1, q1, ji, jq, i2, q2, re, im, per, sper = (z() for _ in range(12))
+    for i in range(N):
+        if i < 6:
+            continue
+        adj = 0.075 * per[i - 1] + 0.54
+        sm[i] = (4 * p[i] + 3 * p[i - 1] + 2 * p[i - 2] + p[i - 3]) / 10.0
+        dt[i] = (0.0962 * sm[i] + 0.5769 * sm[i - 2] - 0.5769 * sm[i - 4] - 0.0962 * sm[i - 6]) * adj
+        q1[i] = (0.0962 * dt[i] + 0.5769 * dt[i - 2] - 0.5769 * dt[i - 4] - 0.0962 * dt[i - 6]) * adj
+        i1[i] = dt[i - 3]
+        ji[i] = (0.0962 * i1[i] + 0.5769 * i1[i - 2] - 0.5769 * i1[i - 4] - 0.0962 * i1[i - 6]) * adj
+        jq[i] = (0.0962 * q1[i] + 0.5769 * q1[i - 2] - 0.5769 * q1[i - 4] - 0.0962 * q1[i - 6]) * adj
+        i2[i] = 0.2 * (i1[i] - jq[i]) + 0.8 * i2[i - 1]
+        q2[i] = 0.2 * (q1[i] + ji[i]) + 0.8 * q2[i - 1]
+        re[i] = 0.2 * (i2[i] * i2[i - 1] + q2[i] * q2[i - 1]) + 0.8 * re[i - 1]
+        im[i] = 0.2 * (i2[i] * q2[i - 1] - q2[i] * i2[i - 1]) + 0.8 * im[i - 1]
+        pv = 360.0 / np.degrees(np.arctan(im[i] / re[i])) if (im[i] != 0 and re[i] != 0) else per[i - 1]
+        if per[i - 1] > 0:
+            pv = min(max(pv, 0.67 * per[i - 1]), 1.5 * per[i - 1])
+        pv = min(max(pv, 6.0), 50.0)
+        per[i] = 0.2 * pv + 0.8 * per[i - 1]
+        sper[i] = 0.33 * per[i] + 0.67 * sper[i - 1]
+    return sper, sm
+
+
+def hilbert_sinewave(price):
+    """Ehlers Sine Wave: (sine, leadsine) from the dominant-cycle phase (DCPhase)."""
+    sper, sm = dominant_cycle(price)
+    N = len(price)
+    sine = np.full(N, np.nan)
+    lead = np.full(N, np.nan)
+    for i in range(N):
+        dc = int(sper[i] + 0.5)
+        if dc < 1 or i < dc:
+            continue
+        rp = ip = 0.0
+        for count in range(dc):
+            ang = np.radians(360.0 * count / dc)
+            rp += np.sin(ang) * sm[i - count]
+            ip += np.cos(ang) * sm[i - count]
+        dcphase = np.degrees(np.arctan(ip / rp)) if abs(rp) > 1e-3 else 90.0
+        dcphase += 90.0
+        if rp < 0:
+            dcphase += 180.0
+        if dcphase > 315.0:
+            dcphase -= 360.0
+        sine[i] = np.sin(np.radians(dcphase))
+        lead[i] = np.sin(np.radians(dcphase + 45.0))
+    return sine, lead

--- a/subprojects/Parametric-Indicators/indicators/calc/dsp.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/dsp.py
@@ -1,0 +1,25 @@
+"""Tier-2 DSP / adaptive-MA primitives (Ehlers filters, single-series, causal).
+
+These are the deferred "hard" indicators — exact where a published closed form exists (Ehlers 2-pole
+filters), documented as approximate otherwise. Reuse the NaN-safe helpers from calc/osc.py."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def super_smoother(x, n):
+    """Ehlers 2-pole SuperSmoother (Butterworth). Zero warm-up NaN — seeded from the raw series."""
+    x = np.asarray(x, dtype=float)
+    N = len(x)
+    out = np.full(N, np.nan)
+    if N == 0:
+        return out
+    a1 = np.exp(-np.sqrt(2.0) * np.pi / n)
+    b1 = 2.0 * a1 * np.cos(np.sqrt(2.0) * np.pi / n)
+    c2, c3 = b1, -a1 * a1
+    c1 = 1.0 - c2 - c3
+    out[0] = x[0]
+    out[1] = x[1] if N > 1 else x[0]
+    for i in range(2, N):
+        out[i] = c1 * (x[i] + x[i - 1]) / 2.0 + c2 * out[i - 1] + c3 * out[i - 2]
+    return out

--- a/subprojects/Parametric-Indicators/indicators/calc/dsp.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/dsp.py
@@ -23,3 +23,98 @@ def super_smoother(x, n):
     for i in range(2, N):
         out[i] = c1 * (x[i] + x[i - 1]) / 2.0 + c2 * out[i - 1] + c3 * out[i - 2]
     return out
+
+
+def highpass(x, period):
+    """Ehlers 2-pole high-pass filter (removes trend below `period`)."""
+    x = np.asarray(x, dtype=float)
+    N = len(x)
+    hp = np.zeros(N)
+    a = ((np.cos(0.707 * 2 * np.pi / period) + np.sin(0.707 * 2 * np.pi / period) - 1)
+         / np.cos(0.707 * 2 * np.pi / period))
+    for i in range(2, N):
+        hp[i] = ((1 - a / 2) ** 2 * (x[i] - 2 * x[i - 1] + x[i - 2])
+                 + 2 * (1 - a) * hp[i - 1] - (1 - a) ** 2 * hp[i - 2])
+    return hp
+
+
+def roofing(x, hp_period, lp_period):
+    """Ehlers Roofing Filter = SuperSmoother(HighPass(x)). A band-limited cycle oscillator ~0."""
+    return super_smoother(highpass(x, hp_period), lp_period)
+
+
+def bandpass(x, period, bandwidth):
+    """Ehlers Band-Pass filter centred on `period`."""
+    x = np.asarray(x, dtype=float)
+    N = len(x)
+    bp = np.zeros(N)
+    beta = np.cos(2 * np.pi / period)
+    gamma = 1.0 / np.cos(4 * np.pi * bandwidth / period)
+    alpha = gamma - np.sqrt(gamma * gamma - 1.0)
+    for i in range(2, N):
+        bp[i] = (0.5 * (1 - alpha) * (x[i] - x[i - 2])
+                 + beta * (1 + alpha) * bp[i - 1] - alpha * bp[i - 2])
+    return bp
+
+
+def frama(high, low, close, n):
+    """Ehlers Fractal Adaptive MA. Fractal dimension of high/low → adaptive EMA of close."""
+    h, l, c = map(lambda a: np.asarray(a, float), (high, low, close))
+    N = len(c)
+    if n % 2:
+        n += 1
+    half = n // 2
+    fr = np.full(N, np.nan)
+    for i in range(N):
+        if i < n:
+            fr[i] = c[i]
+            continue
+        h1, l1 = h[i - n + 1:i - half + 1], l[i - n + 1:i - half + 1]     # older half
+        h2, l2 = h[i - half + 1:i + 1], l[i - half + 1:i + 1]             # recent half
+        n1 = (h1.max() - l1.min()) / half
+        n2 = (h2.max() - l2.min()) / half
+        n3 = (h[i - n + 1:i + 1].max() - l[i - n + 1:i + 1].min()) / n
+        d = (np.log(n1 + n2) - np.log(n3)) / np.log(2) if (n1 > 0 and n2 > 0 and n3 > 0) else 1.0
+        alpha = min(max(np.exp(-4.6 * (d - 1)), 0.01), 1.0)
+        fr[i] = alpha * c[i] + (1 - alpha) * fr[i - 1]
+    return fr
+
+
+def mama_fama(price, fast=0.5, slow=0.05):
+    """Ehlers MESA Adaptive MA (MAMA) + Following AMA (FAMA), via the Hilbert-transform homodyne
+    discriminator. Returns (mama, fama). Canonical Ehlers algorithm (phase in degrees)."""
+    p = np.asarray(price, dtype=float)
+    N = len(p)
+    z = lambda: np.zeros(N)  # noqa: E731
+    sm, dt, i1, q1 = z(), z(), z(), z()
+    ji, jq, i2, q2 = z(), z(), z(), z()
+    re, im, per, sper, phase = z(), z(), z(), z(), z()
+    mama, fama = np.full(N, np.nan), np.full(N, np.nan)
+    for i in range(N):
+        if i < 6:
+            mama[i] = fama[i] = p[i]
+            continue
+        adj = 0.075 * per[i - 1] + 0.54
+        sm[i] = (4 * p[i] + 3 * p[i - 1] + 2 * p[i - 2] + p[i - 3]) / 10.0
+        dt[i] = (0.0962 * sm[i] + 0.5769 * sm[i - 2] - 0.5769 * sm[i - 4] - 0.0962 * sm[i - 6]) * adj
+        q1[i] = (0.0962 * dt[i] + 0.5769 * dt[i - 2] - 0.5769 * dt[i - 4] - 0.0962 * dt[i - 6]) * adj
+        i1[i] = dt[i - 3]
+        ji[i] = (0.0962 * i1[i] + 0.5769 * i1[i - 2] - 0.5769 * i1[i - 4] - 0.0962 * i1[i - 6]) * adj
+        jq[i] = (0.0962 * q1[i] + 0.5769 * q1[i - 2] - 0.5769 * q1[i - 4] - 0.0962 * q1[i - 6]) * adj
+        i2[i] = 0.2 * (i1[i] - jq[i]) + 0.8 * i2[i - 1]
+        q2[i] = 0.2 * (q1[i] + ji[i]) + 0.8 * q2[i - 1]
+        re[i] = 0.2 * (i2[i] * i2[i - 1] + q2[i] * q2[i - 1]) + 0.8 * re[i - 1]
+        im[i] = 0.2 * (i2[i] * q2[i - 1] - q2[i] * i2[i - 1]) + 0.8 * im[i - 1]
+        pv = 360.0 / np.degrees(np.arctan(im[i] / re[i])) if (im[i] != 0 and re[i] != 0) else per[i - 1]
+        if per[i - 1] > 0:
+            pv = min(pv, 1.5 * per[i - 1])
+            pv = max(pv, 0.67 * per[i - 1])
+        pv = min(max(pv, 6.0), 50.0)
+        per[i] = 0.2 * pv + 0.8 * per[i - 1]
+        sper[i] = 0.33 * per[i] + 0.67 * sper[i - 1]
+        phase[i] = np.degrees(np.arctan(q1[i] / i1[i])) if i1[i] != 0 else phase[i - 1]
+        dphase = max(phase[i - 1] - phase[i], 1.0)
+        alpha = min(max(fast / dphase, slow), fast)
+        mama[i] = alpha * p[i] + (1 - alpha) * mama[i - 1]
+        fama[i] = 0.5 * alpha * mama[i] + (1 - 0.5 * alpha) * fama[i - 1]
+    return mama, fama

--- a/subprojects/Parametric-Indicators/indicators/calc/tier2.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/tier2.py
@@ -1,0 +1,135 @@
+"""Tier-2 approximate / stateful primitives (pure, causal). Honestly labeled where approximate:
+  * jma        — commonly-cited open APPROXIMATION of the proprietary Jurik MA.
+  * ewma_vol   — RiskMetrics EWMA volatility (full GARCH-MLE deferred).
+  * ehlers_emd — Ehlers' bandpass-based Empirical Mode Decomposition (NOT Hilbert-Huang sifting).
+  * td_setup / td_combo — DeMark TD *Setup* phase (Countdown left to a follow-up).
+  * kalman     — 1-D random-walk Kalman smoother.
+  * ou_halflife— Ornstein-Uhlenbeck mean-reversion coefficient / half-life."""
+from __future__ import annotations
+
+import numpy as np
+
+from ..classic import sma as _sma
+from .dsp import bandpass
+
+
+def jma(price, length, phase, power):
+    """Jurik MA (open approximation). Adaptive triple-stage filter."""
+    p = np.asarray(price, dtype=float)
+    N = len(p)
+    out = np.full(N, np.nan)
+    if N == 0:
+        return out
+    phase_ratio = 0.5 if phase < -100 else (2.5 if phase > 100 else phase / 100.0 + 1.5)
+    beta = 0.45 * (length - 1) / (0.45 * (length - 1) + 2)
+    alpha = beta ** power
+    e0, e1, e2 = p[0], 0.0, 0.0     # seed e0 at first price (0-seed integrates a permanent offset)
+    jval = p[0]
+    for i in range(N):
+        e0 = (1 - alpha) * p[i] + alpha * e0
+        e1 = (p[i] - e0) * (1 - beta) + beta * e1
+        e2 = (e0 + phase_ratio * e1 - jval) * (1 - alpha) ** 2 + alpha ** 2 * e2
+        jval = jval + e2
+        out[i] = jval
+    return out
+
+
+def ewma_vol(close, lam):
+    """RiskMetrics EWMA volatility of log returns (var = lam*var[-1] + (1-lam)*ret^2)."""
+    c = np.asarray(close, dtype=float)
+    N = len(c)
+    ret = np.zeros(N)
+    ret[1:] = np.diff(np.log(c))
+    var = np.full(N, np.nan)
+    if N < 2:
+        return var
+    var[1] = ret[1] ** 2
+    for i in range(2, N):
+        var[i] = lam * var[i - 1] + (1 - lam) * ret[i] ** 2
+    return np.sqrt(var)
+
+
+def ehlers_emd(high, low, period, bandwidth):
+    """Ehlers EMD: (mean, avg-peak, avg-valley) of the band-pass — trend vs cycle mode."""
+    mid = (np.asarray(high, float) + np.asarray(low, float)) / 2.0
+    bp = bandpass(mid, period, bandwidth)
+    N = len(bp)
+    peak = np.zeros(N)
+    valley = np.zeros(N)
+    for i in range(2, N):
+        peak[i], valley[i] = peak[i - 1], valley[i - 1]
+        if bp[i - 1] > bp[i] and bp[i - 1] > bp[i - 2]:
+            peak[i] = bp[i - 1]
+        if bp[i - 1] < bp[i] and bp[i - 1] < bp[i - 2]:
+            valley[i] = bp[i - 1]
+    w = 2 * period
+    mean = _sma(bp, w)
+    return mean, 0.1 * _sma(peak, w), 0.1 * _sma(valley, w)
+
+
+def _td_setup_core(close, perfected):
+    """TD buy/sell setup completion signal: +1 at a 9-bar buy setup, -1 at a 9-bar sell setup.
+    `perfected` requires the DeMark perfection (bar 8/9 extreme vs bar 6/7)."""
+    c = np.asarray(close, dtype=float)
+    N = len(c)
+    sig = np.zeros(N)
+    buy = sell = 0
+    for i in range(N):
+        if i < 4:
+            continue
+        if c[i] < c[i - 4]:
+            buy, sell = buy + 1, 0
+        elif c[i] > c[i - 4]:
+            sell, buy = sell + 1, 0
+        else:
+            buy = sell = 0
+        if buy == 9:
+            ok = (not perfected) or (i >= 2 and (c[i] <= c[i - 2] and c[i] <= c[i - 3]))
+            if ok:
+                sig[i] = 1
+            buy = 0
+        elif sell == 9:
+            ok = (not perfected) or (i >= 2 and (c[i] >= c[i - 2] and c[i] >= c[i - 3]))
+            if ok:
+                sig[i] = -1
+            sell = 0
+    return sig
+
+
+def td_sequential(close):
+    return _td_setup_core(close, perfected=False)
+
+
+def td_combo(close):
+    return _td_setup_core(close, perfected=True)
+
+
+def kalman(price, q, r):
+    """1-D random-walk Kalman smoother. q=process var, r=measurement var."""
+    p = np.asarray(price, dtype=float)
+    N = len(p)
+    out = np.full(N, np.nan)
+    if N == 0:
+        return out
+    x, P = p[0], 1.0
+    for i in range(N):
+        P = P + q
+        k = P / (P + r)
+        x = x + k * (p[i] - x)
+        P = (1 - k) * P
+        out[i] = x
+    return out
+
+
+def ou_coefficient(close, n):
+    """OU mean-reversion coefficient b from ΔP = a + b·P[-1] over a rolling window (b<0 ⇒ reverting)."""
+    c = np.asarray(close, dtype=float)
+    N = len(c)
+    out = np.full(N, np.nan)
+    for i in range(n, N):
+        lag = c[i - n:i]
+        dy = c[i - n + 1:i + 1] - lag
+        v = lag.var()
+        if v > 0:
+            out[i] = ((lag - lag.mean()) * (dy - dy.mean())).sum() / (n * v)
+    return out

--- a/subprojects/Parametric-Indicators/indicators/lib_dsp.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_dsp.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from . import votes
+from .base import Indicator
 from .calc import dsp
 from .stances import StanceIndicator, _sign_stance
 
@@ -51,7 +53,59 @@ class MAMAFAMATrend(StanceIndicator):
     def warmup_bars(self): return 20
 
 
-CLASSES = (SuperSmootherTrend, RoofingOsc, BandpassOsc, FRAMATrend, MAMAFAMATrend)
+class LaguerreRSI(Indicator):
+    key = "laguerre_rsi"
+    def directions(self, ctx):
+        p = self.config.params
+        v = dsp.laguerre_rsi(ctx.close, float(p.get("gamma", 0.5)))
+        return votes.band_directions(v, float(p.get("lower", 0.2)), float(p.get("upper", 0.8)), 0.5)
+    def warmup_bars(self): return 10
+
+
+class SchaffTC(Indicator):
+    key = "schaff_trend_cycle"
+    def directions(self, ctx):
+        p = self.config.params
+        v = dsp.schaff_trend_cycle(ctx.close, int(p.get("fast", 23)), int(p.get("slow", 50)), int(p.get("cycle", 10)))
+        return votes.band_directions(v, float(p.get("lower", 25)), float(p.get("upper", 75)), 50.0)
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("slow", 50)) + 2 * int(p.get("cycle", 10))
+
+
+class CyberCycle(StanceIndicator):
+    key = "cyber_cycle"
+    def stance(self, ctx): return _sign_stance(dsp.cyber_cycle(ctx.close, float(self.config.params.get("alpha", 0.07))))
+    def warmup_bars(self): return 7
+
+
+class CenterOfGravity(StanceIndicator):
+    key = "center_of_gravity"
+    def stance(self, ctx): return _sign_stance(dsp.center_of_gravity(ctx.close, int(self.config.params.get("n", 10))))
+    def warmup_bars(self): return int(self.config.params.get("n", 10))
+
+
+class Sinewave(StanceIndicator):
+    """Ehlers Sine Wave: +1 when sine > leadsine (cycle up-phase), −1 otherwise."""
+    key = "sinewave"
+    def stance(self, ctx):
+        sine, lead = dsp.hilbert_sinewave(ctx.close)
+        return _sign_stance(sine - lead)
+    def warmup_bars(self): return 20
+
+
+class HilbertCycle(Indicator):
+    """Veto BOTH sides when the measured dominant cycle period is very short (fast/unstable chop)."""
+    key = "hilbert_cycle"
+    def directions(self, ctx):
+        per, _ = dsp.dominant_cycle(ctx.close)
+        thr = float(self.config.params.get("threshold", 10.0))
+        return votes.both_veto((per > 0) & (per < thr))
+    def warmup_bars(self): return 20
+
+
+CLASSES = (SuperSmootherTrend, RoofingOsc, BandpassOsc, FRAMATrend, MAMAFAMATrend,
+           LaguerreRSI, SchaffTC, CyberCycle, CenterOfGravity, Sinewave, HilbertCycle)
 SCHEMA = {
     "super_smoother": {"label": "Ehlers SuperSmoother trend", "mode": "confirm",
                        "params": [{"name": "n", "default": 20, "min": 4, "max": 200, "step": 1}]},
@@ -66,4 +120,21 @@ SCHEMA = {
     "mama_fama": {"label": "MESA Adaptive MA (MAMA/FAMA)", "mode": "confirm",
                   "params": [{"name": "fast", "default": 0.5, "min": 0.1, "max": 1.0, "step": 0.05},
                              {"name": "slow", "default": 0.05, "min": 0.01, "max": 0.5, "step": 0.01}]},
+    "laguerre_rsi": {"label": "Laguerre RSI", "mode": "both",
+                     "params": [{"name": "gamma", "default": 0.5, "min": 0.1, "max": 0.9, "step": 0.05},
+                                {"name": "lower", "default": 0.2, "min": 0.05, "max": 0.45, "step": 0.05},
+                                {"name": "upper", "default": 0.8, "min": 0.55, "max": 0.95, "step": 0.05}]},
+    "schaff_trend_cycle": {"label": "Schaff Trend Cycle", "mode": "both",
+                           "params": [{"name": "fast", "default": 23, "min": 2, "max": 100, "step": 1},
+                                      {"name": "slow", "default": 50, "min": 2, "max": 200, "step": 1},
+                                      {"name": "cycle", "default": 10, "min": 2, "max": 50, "step": 1},
+                                      {"name": "lower", "default": 25, "min": 1, "max": 49, "step": 1},
+                                      {"name": "upper", "default": 75, "min": 51, "max": 99, "step": 1}]},
+    "cyber_cycle": {"label": "Ehlers Cyber Cycle", "mode": "confirm",
+                    "params": [{"name": "alpha", "default": 0.07, "min": 0.01, "max": 0.5, "step": 0.01}]},
+    "center_of_gravity": {"label": "Ehlers Center of Gravity", "mode": "confirm",
+                          "params": [{"name": "n", "default": 10, "min": 2, "max": 100, "step": 1}]},
+    "sinewave": {"label": "Ehlers Sine Wave", "mode": "confirm", "params": []},
+    "hilbert_cycle": {"label": "Hilbert dominant-cycle (veto)", "mode": "veto",
+                      "params": [{"name": "threshold", "default": 10.0, "min": 6.0, "max": 30.0, "step": 1.0}]},
 }

--- a/subprojects/Parametric-Indicators/indicators/lib_dsp.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_dsp.py
@@ -1,0 +1,20 @@
+"""dsp-school (Tier-2) indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA."""
+from __future__ import annotations
+
+from .calc import dsp
+from .stances import StanceIndicator, _sign_stance
+
+
+class SuperSmootherTrend(StanceIndicator):
+    """Ehlers SuperSmoother trend: sign(close − SuperSmoother(close, n))."""
+    key = "super_smoother"
+    def stance(self, ctx):
+        return _sign_stance(ctx.close - dsp.super_smoother(ctx.close, int(self.config.params.get("n", 20))))
+    def warmup_bars(self): return int(self.config.params.get("n", 20))
+
+
+CLASSES = (SuperSmootherTrend,)
+SCHEMA = {
+    "super_smoother": {"label": "Ehlers SuperSmoother trend", "mode": "confirm",
+                       "params": [{"name": "n", "default": 20, "min": 4, "max": 200, "step": 1}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/lib_dsp.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_dsp.py
@@ -1,6 +1,8 @@
 """dsp-school (Tier-2) indicator classes. CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA."""
 from __future__ import annotations
 
+import numpy as np
+
 from .calc import dsp
 from .stances import StanceIndicator, _sign_stance
 
@@ -13,8 +15,55 @@ class SuperSmootherTrend(StanceIndicator):
     def warmup_bars(self): return int(self.config.params.get("n", 20))
 
 
-CLASSES = (SuperSmootherTrend,)
+class RoofingOsc(StanceIndicator):
+    """Ehlers Roofing Filter cycle: +1 above zero, −1 below (band-limited oscillator)."""
+    key = "roofing"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(dsp.roofing(ctx.close, int(p.get("hp_period", 48)), int(p.get("lp_period", 10))))
+    def warmup_bars(self): return int(self.config.params.get("hp_period", 48))
+
+
+class BandpassOsc(StanceIndicator):
+    """Ehlers Band-Pass cycle: +1 above zero, −1 below."""
+    key = "bandpass"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(dsp.bandpass(ctx.close, int(p.get("period", 20)), float(p.get("bandwidth", 0.3))))
+    def warmup_bars(self): return 2 * int(self.config.params.get("period", 20))
+
+
+class FRAMATrend(StanceIndicator):
+    """Fractal Adaptive MA trend: sign(close − FRAMA(n))."""
+    key = "frama"
+    def stance(self, ctx):
+        return _sign_stance(ctx.close - dsp.frama(ctx.high, ctx.low, ctx.close, int(self.config.params.get("n", 16))))
+    def warmup_bars(self): return int(self.config.params.get("n", 16)) + 1
+
+
+class MAMAFAMATrend(StanceIndicator):
+    """MESA Adaptive MA cross: +1 when MAMA>FAMA (uptrend), −1 when MAMA<FAMA."""
+    key = "mama_fama"
+    def stance(self, ctx):
+        p = self.config.params
+        mama, fama = dsp.mama_fama(ctx.close, float(p.get("fast", 0.5)), float(p.get("slow", 0.05)))
+        return _sign_stance(mama - fama)
+    def warmup_bars(self): return 20
+
+
+CLASSES = (SuperSmootherTrend, RoofingOsc, BandpassOsc, FRAMATrend, MAMAFAMATrend)
 SCHEMA = {
     "super_smoother": {"label": "Ehlers SuperSmoother trend", "mode": "confirm",
                        "params": [{"name": "n", "default": 20, "min": 4, "max": 200, "step": 1}]},
+    "roofing": {"label": "Ehlers Roofing Filter", "mode": "confirm",
+                "params": [{"name": "hp_period", "default": 48, "min": 10, "max": 200, "step": 1},
+                           {"name": "lp_period", "default": 10, "min": 4, "max": 100, "step": 1}]},
+    "bandpass": {"label": "Ehlers Band-Pass", "mode": "confirm",
+                 "params": [{"name": "period", "default": 20, "min": 4, "max": 200, "step": 1},
+                            {"name": "bandwidth", "default": 0.3, "min": 0.1, "max": 0.9, "step": 0.05}]},
+    "frama": {"label": "Fractal Adaptive MA trend", "mode": "confirm",
+              "params": [{"name": "n", "default": 16, "min": 4, "max": 200, "step": 2}]},
+    "mama_fama": {"label": "MESA Adaptive MA (MAMA/FAMA)", "mode": "confirm",
+                  "params": [{"name": "fast", "default": 0.5, "min": 0.1, "max": 1.0, "step": 0.05},
+                             {"name": "slow", "default": 0.05, "min": 0.01, "max": 0.5, "step": 0.01}]},
 }

--- a/subprojects/Parametric-Indicators/indicators/lib_tier2.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_tier2.py
@@ -1,0 +1,99 @@
+"""tier2-misc (approximate/stateful) indicator classes. Merged into library.REGISTRY/SCHEMA."""
+from __future__ import annotations
+
+import numpy as np
+
+from . import votes
+from .base import Indicator
+from .calc import osc, tier2 as T2
+from .stances import StanceIndicator, _sign_stance
+
+
+class JMATrend(StanceIndicator):
+    """Jurik MA (approx) trend: sign(close − JMA)."""
+    key = "jma"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(ctx.close - T2.jma(ctx.close, int(p.get("length", 14)),
+                                               float(p.get("phase", 0)), int(p.get("power", 2))))
+    def warmup_bars(self): return int(self.config.params.get("length", 14))
+
+
+class GarchEWMA(Indicator):
+    """EWMA (RiskMetrics) volatility as a vol-seeking veto (block low-vol chop)."""
+    key = "garch_ewma"
+    def directions(self, ctx):
+        p = self.config.params
+        val = T2.ewma_vol(ctx.close, float(p.get("lam", 0.94)))
+        ref = osc.nan_ema(val, int(p.get("m", 50)))
+        return votes.magnitude_veto(val, ref, float(p.get("threshold", 0.8)))
+    def warmup_bars(self): return int(self.config.params.get("m", 50)) + 2
+
+
+class EMDMode(StanceIndicator):
+    """Ehlers EMD trend/cycle mode: +1 mean>avg-peak (uptrend), −1 mean<avg-valley, else 0 (cycle)."""
+    key = "emd"
+    def stance(self, ctx):
+        p = self.config.params
+        mean, apeak, avalley = T2.ehlers_emd(ctx.high, ctx.low, int(p.get("period", 20)), float(p.get("bandwidth", 0.3)))
+        st = np.zeros(len(ctx.close), dtype=np.int8)
+        st[np.isfinite(mean) & (mean > apeak)] = 1
+        st[np.isfinite(mean) & (mean < avalley)] = -1
+        return st
+    def warmup_bars(self): return 2 * int(self.config.params.get("period", 20))
+
+
+class TDSequential(StanceIndicator):
+    """DeMark TD Setup: +1 on a 9-bar buy setup (reversal up), −1 on a 9-bar sell setup."""
+    key = "td_sequential"
+    def stance(self, ctx): return _sign_stance(T2.td_sequential(ctx.close))
+    def warmup_bars(self): return 9
+
+
+class TDCombo(StanceIndicator):
+    """DeMark TD Setup with perfection (bar 8/9 extreme)."""
+    key = "td_combo"
+    def stance(self, ctx): return _sign_stance(T2.td_combo(ctx.close))
+    def warmup_bars(self): return 9
+
+
+class KalmanTrend(StanceIndicator):
+    """1-D random-walk Kalman smoother trend: sign(close − Kalman)."""
+    key = "kalman"
+    def stance(self, ctx):
+        p = self.config.params
+        return _sign_stance(ctx.close - T2.kalman(ctx.close, float(p.get("q", 0.001)), float(p.get("r", 0.1))))
+    def warmup_bars(self): return 5
+
+
+class OUHalflife(Indicator):
+    """Veto BOTH sides when the OU coefficient b ≥ 0 (no mean-reversion structure / random walk)."""
+    key = "ou_halflife"
+    def directions(self, ctx):
+        n = int(self.config.params.get("n", 50))
+        b = T2.ou_coefficient(ctx.close, n)
+        return votes.both_veto(np.isfinite(b) & (b >= 0))
+    def warmup_bars(self): return int(self.config.params.get("n", 50))
+
+
+CLASSES = (JMATrend, GarchEWMA, EMDMode, TDSequential, TDCombo, KalmanTrend, OUHalflife)
+SCHEMA = {
+    "jma": {"label": "Jurik MA (approx) trend", "mode": "confirm",
+            "params": [{"name": "length", "default": 14, "min": 2, "max": 200, "step": 1},
+                       {"name": "phase", "default": 0, "min": -100, "max": 100, "step": 5},
+                       {"name": "power", "default": 2, "min": 1, "max": 4, "step": 1}]},
+    "garch_ewma": {"label": "EWMA volatility (veto)", "mode": "veto",
+                   "params": [{"name": "lam", "default": 0.94, "min": 0.8, "max": 0.99, "step": 0.01},
+                              {"name": "m", "default": 50, "min": 2, "max": 200, "step": 1},
+                              {"name": "threshold", "default": 0.8, "min": 0.2, "max": 1.5, "step": 0.05}]},
+    "emd": {"label": "Ehlers EMD (trend/cycle mode)", "mode": "confirm",
+            "params": [{"name": "period", "default": 20, "min": 4, "max": 100, "step": 1},
+                       {"name": "bandwidth", "default": 0.3, "min": 0.1, "max": 0.9, "step": 0.05}]},
+    "td_sequential": {"label": "TD Sequential (setup)", "mode": "both", "params": []},
+    "td_combo": {"label": "TD Combo (perfected setup)", "mode": "both", "params": []},
+    "kalman": {"label": "Kalman trend", "mode": "confirm",
+               "params": [{"name": "q", "default": 0.001, "min": 0.0001, "max": 1.0, "step": 0.0001},
+                          {"name": "r", "default": 0.1, "min": 0.001, "max": 10.0, "step": 0.01}]},
+    "ou_halflife": {"label": "OU half-life (veto no-reversion)", "mode": "veto",
+                    "params": [{"name": "n", "default": 50, "min": 10, "max": 300, "step": 1}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/library.py
+++ b/subprojects/Parametric-Indicators/indicators/library.py
@@ -295,9 +295,10 @@ class CISDConfirm(StanceIndicator):
 
 
 from . import lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant  # noqa: E402
-from . import lib_dsp  # noqa: E402  (Tier-2)
+from . import lib_dsp, lib_tier2  # noqa: E402  (Tier-2)
 
-_SCHOOLS = (lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant, lib_dsp)
+_SCHOOLS = (lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant,
+            lib_dsp, lib_tier2)
 _BUILTINS = (
     EMATrend, SMATrend, MACD, VWAPTrend, KeltnerTrend, OBVTrend, CCIBreakout,
     RSIZone, StochasticZone, MFIZone, BollingerVeto, ADXVeto,

--- a/subprojects/Parametric-Indicators/indicators/library.py
+++ b/subprojects/Parametric-Indicators/indicators/library.py
@@ -295,8 +295,9 @@ class CISDConfirm(StanceIndicator):
 
 
 from . import lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant  # noqa: E402
+from . import lib_dsp  # noqa: E402  (Tier-2)
 
-_SCHOOLS = (lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant)
+_SCHOOLS = (lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant, lib_dsp)
 _BUILTINS = (
     EMATrend, SMATrend, MACD, VWAPTrend, KeltnerTrend, OBVTrend, CCIBreakout,
     RSIZone, StochasticZone, MFIZone, BollingerVeto, ADXVeto,

--- a/subprojects/Parametric-Indicators/tests/oracle/test_dsp_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_dsp_primitives.py
@@ -59,3 +59,35 @@ def test_mama_fama_finite_and_fama_smoother():
     assert not np.isnan(mama).any() and not np.isnan(fama).any()
     assert np.std(np.diff(fama)) < np.std(np.diff(mama))    # FAMA follows more slowly
 
+
+def test_laguerre_rsi_bounded_unit():
+    v = _fin(dsp.laguerre_rsi(C, 0.5))
+    assert v.min() >= -1e-9 and v.max() <= 1 + 1e-9 and len(v) > 200
+
+
+def test_schaff_bounded_0_100():
+    v = _fin(dsp.schaff_trend_cycle(C, 23, 50, 10))
+    assert v.min() >= -1e-6 and v.max() <= 100 + 1e-6
+
+
+def test_cyber_and_cg_oscillate_around_zero():
+    for a in (dsp.cyber_cycle(C, 0.07), dsp.center_of_gravity(C, 10)):
+        f = _fin(a)
+        assert abs(f.mean()) < f.std() + 1e-9 and len(f) > 200
+
+
+def test_dominant_cycle_period_bounded():
+    per, _ = dsp.dominant_cycle(C)
+    # candidate period is clamped [6,50]; the EMA-smoothed output ramps from 0 → upper bound holds,
+    # and once warmed the period settles inside the band.
+    assert per.max() <= 50 + 1e-6
+    settled = per[80:]
+    assert 6 - 1e-6 <= np.median(settled) <= 50 + 1e-6
+
+
+def test_sinewave_bounded_unit():
+    sine, lead = dsp.hilbert_sinewave(C)
+    for a in (sine, lead):
+        f = _fin(a)
+        assert f.min() >= -1 - 1e-9 and f.max() <= 1 + 1e-9 and len(f) > 100
+

--- a/subprojects/Parametric-Indicators/tests/oracle/test_dsp_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_dsp_primitives.py
@@ -8,7 +8,13 @@ import numpy as np
 from indicators.calc import dsp
 from tests.oracle.fixture import ohlcv
 
-C = ohlcv(300)["close"]
+D = ohlcv(300)
+H, L, C = D["high"], D["low"], D["close"]
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
 
 
 def test_super_smoother_constant_fixed_point():
@@ -25,3 +31,31 @@ def test_super_smoother_smooths_and_no_nan():
     a1 = np.exp(-np.sqrt(2) * np.pi / 20)
     b1 = 2 * a1 * np.cos(np.sqrt(2) * np.pi / 20)
     assert np.isclose(1 - b1 - (-a1 * a1) + b1 + (-a1 * a1), 1.0)
+
+
+def test_roofing_bandpass_oscillate_around_zero():
+    for a in (dsp.roofing(C, 48, 10), dsp.bandpass(C, 20, 0.3)):
+        f = _fin(a)
+        assert abs(f.mean()) < f.std()               # zero-centred oscillator
+        assert len(f) > 200
+
+
+def test_frama_tracks_price_and_smooths():
+    fr = _fin(dsp.frama(H, L, C, 16))
+    assert len(fr) > 200
+    # FRAMA stays within the price envelope
+    assert fr.min() >= L.min() - 1e-6 and fr.max() <= H.max() + 1e-6
+
+
+def test_frama_constant_fixed_point():
+    n = 300
+    h = np.full(n, 11.0); l = np.full(n, 9.0); c = np.full(n, 10.0)
+    fr = dsp.frama(h, l, c, 16)
+    assert np.allclose(fr[20:], 10.0, atol=1e-6)
+
+
+def test_mama_fama_finite_and_fama_smoother():
+    mama, fama = dsp.mama_fama(C)
+    assert not np.isnan(mama).any() and not np.isnan(fama).any()
+    assert np.std(np.diff(fama)) < np.std(np.diff(mama))    # FAMA follows more slowly
+

--- a/subprojects/Parametric-Indicators/tests/oracle/test_dsp_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_dsp_primitives.py
@@ -1,0 +1,27 @@
+"""Tests for Tier-2 DSP primitives (indicators/calc/dsp.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+
+from indicators.calc import dsp
+from tests.oracle.fixture import ohlcv
+
+C = ohlcv(300)["close"]
+
+
+def test_super_smoother_constant_fixed_point():
+    const = np.full(120, 42.0)
+    out = dsp.super_smoother(const, 20)
+    assert np.allclose(out[5:], 42.0, atol=1e-6)    # c1+c2+c3==1 ⇒ constant maps to itself
+
+
+def test_super_smoother_smooths_and_no_nan():
+    out = dsp.super_smoother(C, 20)
+    assert not np.isnan(out).any()
+    assert out.std() < C.std()                       # a low-pass filter reduces variance
+    # coefficient identity c1 = 1 - c2 - c3
+    a1 = np.exp(-np.sqrt(2) * np.pi / 20)
+    b1 = 2 * a1 * np.cos(np.sqrt(2) * np.pi / 20)
+    assert np.isclose(1 - b1 - (-a1 * a1) + b1 + (-a1 * a1), 1.0)

--- a/subprojects/Parametric-Indicators/tests/oracle/test_tier2_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_tier2_primitives.py
@@ -1,0 +1,64 @@
+"""Tests for Tier-2 approximate/stateful primitives (indicators/calc/tier2.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+
+from indicators.calc import tier2 as T2
+from tests.oracle.fixture import ohlcv
+
+D = ohlcv(300)
+H, L, C = D["high"], D["low"], D["close"]
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def test_jma_tracks_price_and_smooths():
+    j = T2.jma(C, 14, 0, 2)
+    assert not np.isnan(j).any()
+    assert j.min() >= C.min() - 5 and j.max() <= C.max() + 5
+    assert np.std(np.diff(j)) < np.std(np.diff(C))     # smoother than price
+
+
+def test_jma_constant_fixed_point():
+    const = np.full(200, 25.0)
+    assert np.allclose(T2.jma(const, 14, 0, 2)[20:], 25.0, atol=1e-6)
+
+
+def test_ewma_vol_positive():
+    v = _fin(T2.ewma_vol(C, 0.94))
+    assert v.min() >= 0 and len(v) > 200
+
+
+def test_td_signals_are_ternary_and_fire():
+    for s in (T2.td_sequential(C), T2.td_combo(C)):
+        assert set(np.unique(s).tolist()).issubset({-1.0, 0.0, 1.0})
+        assert (s != 0).sum() >= 1
+    # combo (perfected) fires no more often than sequential
+    assert (T2.td_combo(C) != 0).sum() <= (T2.td_sequential(C) != 0).sum()
+
+
+def test_td_buy_setup_hand_case():
+    # 4 warmup + 9 strictly-decreasing-vs-4-bars-ago closes ⇒ buy setup at bar 12
+    c = np.array([100, 100, 100, 100, 99, 98, 97, 96, 95, 94, 93, 92, 91.0])
+    s = T2.td_sequential(c)
+    assert s[12] == 1.0
+
+
+def test_kalman_tracks_and_smooths():
+    k = T2.kalman(C, 0.001, 0.1)
+    assert not np.isnan(k).any() and np.std(np.diff(k)) < np.std(np.diff(C))
+
+
+def test_ou_coefficient_mostly_negative_on_meanreverting():
+    # AR(1) mean-reverting series ⇒ OU coefficient b < 0
+    rng = np.random.default_rng(1)
+    x = np.zeros(400)
+    for i in range(1, 400):
+        x[i] = 10 + 0.7 * (x[i - 1] - 10) + rng.normal(0, 0.5)
+    b = _fin(T2.ou_coefficient(x, 50))
+    assert np.median(b) < 0


### PR DESCRIPTION
Part of #12. Adds the **18 single-series Tier-2 indicators** (the deferred hard/approximate group,
minus the 4 cross-series which need a framework extension — tracked in #13).

Registry **143 → 161 keys**. Same architecture as Tier-1: confirm/veto votes, auto-wired to
backtester/dashboard/optimizer, structural parity.

### Included
- **DSP/adaptive MA (5):** `super_smoother`, `roofing`, `bandpass`, `frama`, `mama_fama` (Ehlers exact formulas; canonical Hilbert-homodyne MAMA/FAMA).
- **Ehlers cycle (6):** `laguerre_rsi`, `schaff_trend_cycle`, `cyber_cycle`, `center_of_gravity`, `sinewave` (DCPhase from dominant cycle), `hilbert_cycle` (dominant-period regime veto).
- **Approx/stateful (7):** `jma` (open approximation), `garch_ewma` (RiskMetrics EWMA — full GARCH-MLE deferred), `emd` (Ehlers bandpass mode, not Hilbert-Huang), `td_sequential` + `td_combo` (DeMark TD *Setup* ± perfection; Countdown deferred), `kalman` (1-D random-walk), `ou_halflife` (OU coefficient veto).

**Honest labeling:** every approximate/partial indicator is documented as such in its docstring/label — no false claims of exactness.

### Verification
- New `tests/oracle/test_dsp_primitives.py` (11) + `test_tier2_primitives.py` (7) — property/fixed-point/hand-case oracles.
- **18/18 parity green** (fast_engine == exact engine, 0 mismatch) via `test_indicator_parity.py --keys=...`.
- Bugs caught & fixed: JMA / dominant-cycle seeding (fixed-point), TMA/AO NaN-poisoning, over-strict test invariants.

### Not in this PR
- Cross-series 4 (`cointegration`, `rolling_corr`, `rolling_beta`, `pca_factor`) — need `MarketContext` reference-series extension → #13.
- Adopt-gate validation → #14 (treatment run in progress on the server).

### Test plan
```
cd subprojects/Parametric-Indicators
python3 -m pytest tests/oracle/ indicators/ -q
python3 optimize/test_indicator_parity.py 4h    # all keys, 0 mismatch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)