### PR TITLE
feat(indicators): Tier-2 cross-series (4) + MarketContext reference extension

### DIFF
--- a/subprojects/Parametric-Indicators/indicators/base.py
+++ b/subprojects/Parametric-Indicators/indicators/base.py
@@ -34,6 +34,8 @@ class MarketContext:
     close: np.ndarray
     volume: np.ndarray
     session_id: np.ndarray | None = None
+    ref_close: np.ndarray | None = None   # reference-instrument close, causally aligned to these bars
+                                           # (cross-series indicators only; None ⇒ they stay neutral)
 
     def __len__(self) -> int:
         return len(self.close)

--- a/subprojects/Parametric-Indicators/indicators/calc/xseries.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/xseries.py
@@ -1,0 +1,82 @@
+"""Cross-series primitives: primary close `c` vs an aligned reference close `r` (both same length).
+Reference NaNs (leading, from causal alignment) propagate to NaN output for that window."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _returns(x):
+    d = np.full(len(x), np.nan)
+    d[1:] = np.diff(np.asarray(x, dtype=float))
+    return d
+
+
+def rolling_corr(c, r, n):
+    """Rolling Pearson correlation of the two return series over n."""
+    rc, rr = _returns(c), _returns(r)
+    N = len(c)
+    out = np.full(N, np.nan)
+    for i in range(n, N):
+        a, b = rc[i - n + 1:i + 1], rr[i - n + 1:i + 1]
+        if np.isnan(a).any() or np.isnan(b).any():
+            continue
+        sa, sb = a.std(), b.std()
+        if sa > 0 and sb > 0:
+            out[i] = np.mean((a - a.mean()) * (b - b.mean())) / (sa * sb)
+    return out
+
+
+def rolling_beta(c, r, n):
+    """Rolling OLS beta of primary returns on reference returns (cov/var) over n."""
+    rc, rr = _returns(c), _returns(r)
+    N = len(c)
+    out = np.full(N, np.nan)
+    for i in range(n, N):
+        a, b = rc[i - n + 1:i + 1], rr[i - n + 1:i + 1]
+        if np.isnan(a).any() or np.isnan(b).any():
+            continue
+        vb = b.var()
+        if vb > 0:
+            out[i] = np.mean((a - a.mean()) * (b - b.mean())) / vb
+    return out
+
+
+def spread_zscore(c, r, n):
+    """Engle-Granger-style pair spread z-score: hedge ratio b=cov(c,r)/var(r) over the window,
+    spread = c − b·r, z of the latest spread. (Full ADF cointegration test deferred.)"""
+    c = np.asarray(c, float)
+    r = np.asarray(r, float)
+    N = len(c)
+    out = np.full(N, np.nan)
+    for i in range(n, N):
+        cc, rr = c[i - n + 1:i + 1], r[i - n + 1:i + 1]
+        if np.isnan(cc).any() or np.isnan(rr).any():
+            continue
+        vr = rr.var()
+        if vr <= 0:
+            continue
+        b = np.mean((cc - cc.mean()) * (rr - rr.mean())) / vr
+        spread = cc - b * rr
+        s = spread.std()
+        if s > 0:
+            out[i] = (spread[-1] - spread.mean()) / s
+    return out
+
+
+def pca_factor(c, r, n):
+    """2-series rolling PCA of [primary_ret, ref_ret]: latest point's projection on PC1, signed by the
+    primary loading (positive ⇒ shared up-move). Extend to a basket later for a true common factor."""
+    rc, rr = _returns(c), _returns(r)
+    N = len(c)
+    out = np.full(N, np.nan)
+    for i in range(n, N):
+        a, b = rc[i - n + 1:i + 1], rr[i - n + 1:i + 1]
+        if np.isnan(a).any() or np.isnan(b).any():
+            continue
+        ac, bc = a - a.mean(), b - b.mean()
+        cov = np.vstack([ac, bc]) @ np.vstack([ac, bc]).T / (n - 1)
+        _, vecs = np.linalg.eigh(cov)          # ascending eigenvalues
+        pc1 = vecs[:, -1]                       # dominant component
+        score = np.array([ac[-1], bc[-1]]) @ pc1
+        out[i] = score * (np.sign(pc1[0]) if pc1[0] != 0 else 1.0)
+    return out

--- a/subprojects/Parametric-Indicators/indicators/lib_xseries.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_xseries.py
@@ -1,0 +1,94 @@
+"""Cross-series (Tier-2) indicator classes — primary vs an aligned reference instrument.
+All read ctx.ref_close; when it is None (no reference wired) they emit NO votes ⇒ existing parity holds.
+CLASSES/SCHEMA merged into library.REGISTRY/SCHEMA by library.py."""
+from __future__ import annotations
+
+import numpy as np
+
+from . import votes
+from .base import Indicator
+from .calc import osc, xseries as xs
+from .stances import StanceIndicator, _sign_stance
+
+_NEUTRAL2 = None  # sentinel unused; explicit zeros below for clarity
+
+
+class _NeedsRef:
+    """Mixin: True when a usable reference close is present."""
+    @staticmethod
+    def _ref(ctx):
+        return ctx.ref_close if getattr(ctx, "ref_close", None) is not None else None
+
+
+class RollingCorr(Indicator, _NeedsRef):
+    """Veto BOTH sides when primary↔reference return correlation is low (reference decoupled ⇒ its
+    signal is unreliable). |corr| below threshold ⇒ veto."""
+    key = "rolling_corr"
+    def directions(self, ctx):
+        r = self._ref(ctx)
+        n = len(ctx.close)
+        if r is None:
+            return np.zeros(n, np.int8), np.zeros(n, np.int8)
+        p = self.config.params
+        corr = xs.rolling_corr(ctx.close, r, int(p.get("n", 50)))
+        return votes.both_veto(np.isfinite(corr) & (np.abs(corr) < float(p.get("threshold", 0.3))))
+    def warmup_bars(self): return int(self.config.params.get("n", 50))
+
+
+class RollingBeta(StanceIndicator, _NeedsRef):
+    """Beta-scaled reference lead: sign(beta · reference's recent move) — expect the primary to follow."""
+    key = "rolling_beta"
+    def stance(self, ctx):
+        r = self._ref(ctx)
+        if r is None:
+            return np.zeros(len(ctx.close), np.int8)
+        p = self.config.params
+        n, lag = int(p.get("n", 50)), int(p.get("lag", 5))
+        beta = xs.rolling_beta(ctx.close, r, n)
+        refret = r - osc._shift(r, lag)
+        return _sign_stance(beta * refret)
+    def warmup_bars(self):
+        p = self.config.params
+        return int(p.get("n", 50)) + int(p.get("lag", 5))
+
+
+class Cointegration(Indicator, _NeedsRef):
+    """Pair spread z-score (mean-reversion): z≥upper ⇒ primary rich vs reference → short; z≤lower → long."""
+    key = "cointegration"
+    def directions(self, ctx):
+        r = self._ref(ctx)
+        n = len(ctx.close)
+        if r is None:
+            return np.zeros(n, np.int8), np.zeros(n, np.int8)
+        p = self.config.params
+        z = xs.spread_zscore(ctx.close, r, int(p.get("n", 50)))
+        return votes.band_directions(z, float(p.get("lower", -2)), float(p.get("upper", 2)), 0.0)
+    def warmup_bars(self): return int(self.config.params.get("n", 50))
+
+
+class PCAFactor(StanceIndicator, _NeedsRef):
+    """2-series PCA common-factor direction: sign of the primary's projection on PC1 of [primary,ref] returns."""
+    key = "pca_factor"
+    def stance(self, ctx):
+        r = self._ref(ctx)
+        if r is None:
+            return np.zeros(len(ctx.close), np.int8)
+        return _sign_stance(xs.pca_factor(ctx.close, r, int(self.config.params.get("n", 50))))
+    def warmup_bars(self): return int(self.config.params.get("n", 50))
+
+
+CLASSES = (RollingCorr, RollingBeta, Cointegration, PCAFactor)
+SCHEMA = {
+    "rolling_corr": {"label": "Cross-corr (veto decoupled)", "mode": "veto",
+                     "params": [{"name": "n", "default": 50, "min": 5, "max": 300, "step": 1},
+                                {"name": "threshold", "default": 0.3, "min": 0.0, "max": 0.95, "step": 0.05}]},
+    "rolling_beta": {"label": "Cross-beta lead", "mode": "confirm",
+                     "params": [{"name": "n", "default": 50, "min": 5, "max": 300, "step": 1},
+                                {"name": "lag", "default": 5, "min": 1, "max": 50, "step": 1}]},
+    "cointegration": {"label": "Pair spread z-score", "mode": "both",
+                      "params": [{"name": "n", "default": 50, "min": 10, "max": 300, "step": 1},
+                                 {"name": "lower", "default": -2, "min": -5, "max": -1, "step": 1},
+                                 {"name": "upper", "default": 2, "min": 1, "max": 5, "step": 1}]},
+    "pca_factor": {"label": "PCA common-factor direction", "mode": "confirm",
+                   "params": [{"name": "n", "default": 50, "min": 5, "max": 300, "step": 1}]},
+}

--- a/subprojects/Parametric-Indicators/indicators/library.py
+++ b/subprojects/Parametric-Indicators/indicators/library.py
@@ -295,10 +295,10 @@ class CISDConfirm(StanceIndicator):
 
 
 from . import lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant  # noqa: E402
-from . import lib_dsp, lib_tier2  # noqa: E402  (Tier-2)
+from . import lib_dsp, lib_tier2, lib_xseries  # noqa: E402  (Tier-2)
 
 _SCHOOLS = (lib_ma, lib_trend, lib_osc, lib_vol, lib_volume, lib_levels, lib_bw, lib_quant,
-            lib_dsp, lib_tier2)
+            lib_dsp, lib_tier2, lib_xseries)
 _BUILTINS = (
     EMATrend, SMATrend, MACD, VWAPTrend, KeltnerTrend, OBVTrend, CCIBreakout,
     RSIZone, StochasticZone, MFIZone, BollingerVeto, ADXVeto,

--- a/subprojects/Parametric-Indicators/indicators/runner.py
+++ b/subprojects/Parametric-Indicators/indicators/runner.py
@@ -19,14 +19,31 @@ from .confirm import build_gate
 from .timing import resolve_retrace_entry, resolve_entry_1min
 
 
-def market_context(df: pd.DataFrame) -> MarketContext:
-    """Build a MarketContext from a decision-timeframe OHLCV frame (session = calendar day)."""
+def _align_reference(df: pd.DataFrame, ref_df: pd.DataFrame) -> np.ndarray:
+    """Causally align a reference instrument's Close onto df's decision Dates.
+
+    merge_asof(direction='backward') matches each decision bar with the reference bar whose Date is
+    the LATEST at-or-before it — so a decision bar at time t only ever sees reference closes known by
+    t, NEVER a future reference bar. Leading decision bars with no prior reference bar → NaN.
+    """
+    left = pd.DataFrame({"Date": pd.to_datetime(df["Date"]).to_numpy()})
+    right = pd.DataFrame({"Date": pd.to_datetime(ref_df["Date"]).to_numpy(),
+                          "_ref": ref_df["Close"].to_numpy(float)}).sort_values("Date")
+    merged = pd.merge_asof(left, right, on="Date", direction="backward")  # left order preserved
+    return merged["_ref"].to_numpy(float)
+
+
+def market_context(df: pd.DataFrame, ref_df: pd.DataFrame | None = None) -> MarketContext:
+    """Build a MarketContext from a decision-timeframe OHLCV frame (session = calendar day).
+    `ref_df` (optional): a reference instrument's OHLCV at the same tf — causally aligned into
+    `ref_close` for the cross-series indicators. None ⇒ ref_close None ⇒ those indicators stay neutral."""
     sess = pd.to_datetime(df["Date"]).dt.normalize().astype("int64").to_numpy()
     return MarketContext(
         open=df["Open"].to_numpy(float), high=df["High"].to_numpy(float),
         low=df["Low"].to_numpy(float), close=df["Close"].to_numpy(float),
         volume=df["Volume"].to_numpy(float) if "Volume" in df.columns else np.zeros(len(df)),
         session_id=sess,
+        ref_close=(_align_reference(df, ref_df) if ref_df is not None else None),
     )
 
 
@@ -142,12 +159,13 @@ def _ind_vote(ind, ctx, bdir, src=None) -> np.ndarray:
     return _vote_from_1min(ind, ctx_1m, j_idx, bdir)
 
 
-def composite_gate(vol_gate, df, box, indicators, k):
+def composite_gate(vol_gate, df, box, indicators, k, ref_df=None):
     """vol_gate: per-bar bool (engine idx). indicators: list of Indicator instances (enabled+disabled).
-    Returns (gate, votes, active): gate = vol_gate ∧ (indicator allow, aligned to the signal bar)."""
+    Returns (gate, votes, active): gate = vol_gate ∧ (indicator allow, aligned to the signal bar).
+    `ref_df` (optional) supplies the cross-series reference instrument."""
     vg = np.asarray(vol_gate, dtype=bool)
     n = len(vg)
-    ctx = market_context(df)
+    ctx = market_context(df, ref_df)
     bdir = box_direction_int(df, box)
     allow, votes, active = build_gate(ctx, bdir, indicators, k, base_gate=None)
     # Entry at idx uses the just-closed bar idx-1, so align the allow-mask forward by one bar.
@@ -157,18 +175,19 @@ def composite_gate(vol_gate, df, box, indicators, k):
     return vg & aligned, votes, active
 
 
-def compute_votes(df, box, indicators, src=None) -> dict:
+def compute_votes(df, box, indicators, src=None, ref_df=None) -> dict:
     """Per-decision-bar vote array for every ENABLED indicator, keyed by id(ind). Computed ONCE so
     the veto gate, the confirm resolver and the attribution all reuse it (no 3× recompute). Disabled
     indicators are skipped entirely (they don't trade and aren't worth computing — esp. the costly
-    SMC ones on the 1-minute frame)."""
-    ctx = market_context(df)
+    SMC ones on the 1-minute frame). `ref_df` (optional) supplies a reference instrument for the
+    cross-series indicators; None ⇒ they see no reference and stay neutral."""
+    ctx = market_context(df, ref_df)
     bdir = box_direction_int(df, box)
     return {id(ind): _ind_vote(ind, ctx, bdir, src)
             for ind in indicators if ind.config.enabled}
 
 
-def veto_mask(df, box, indicators, src=None, votes=None):
+def veto_mask(df, box, indicators, src=None, votes=None, ref_df=None):
     """Per-decision-bar veto mask (Q5: veto lives in the gate). True where any ENABLED veto-capable
     (mode∈{veto,both}) indicator votes VETO, read at the just-closed signal bar and aligned to the
     entry bar (mask[idx] = veto at idx-1; idx 0 = False). No veto indicators ⇒ all False (parity).
@@ -181,7 +200,7 @@ def veto_mask(df, box, indicators, src=None, votes=None):
     if not vetoers:
         return out
     if votes is None:
-        votes = compute_votes(df, box, vetoers, src)
+        votes = compute_votes(df, box, vetoers, src, ref_df)
     raw = np.zeros(n, dtype=bool)
     for ind in vetoers:
         raw |= (votes[id(ind)] == VETO)
@@ -189,7 +208,7 @@ def veto_mask(df, box, indicators, src=None, votes=None):
     return out
 
 
-def confirm_mask(df, box, indicators, k, src=None, votes=None):
+def confirm_mask(df, box, indicators, k, src=None, votes=None, ref_df=None):
     """Per-decision-bar CONFIRM gate (vectorised, for the optimiser fast path — WS-I.7).
     True where ≥ K_eff enabled confirm-capable (mode∈{confirm,both}) indicators vote CONFIRM at the
     just-closed signal bar, aligned to the entry bar (mask[idx] = confirms at idx-1; idx 0 = True).
@@ -205,7 +224,7 @@ def confirm_mask(df, box, indicators, k, src=None, votes=None):
     if k_eff <= 0:
         return out                                # no confirm requirement (parity)
     if votes is None:
-        votes = compute_votes(df, box, confirmers, src)
+        votes = compute_votes(df, box, confirmers, src, ref_df)
     cc = np.zeros(n, dtype=np.int64)
     for ind in confirmers:
         cc += (votes[id(ind)] == CONFIRM).astype(np.int64)
@@ -214,7 +233,7 @@ def confirm_mask(df, box, indicators, k, src=None, votes=None):
     return out
 
 
-def confirm_count(df, box, indicators, src=None, votes=None):
+def confirm_count(df, box, indicators, src=None, votes=None, ref_df=None):
     """Entry-shifted per-bar CONFIRM count + #confirm-capable-enabled indicators. Mirrors confirm_mask's
     internals so confirm_mask(df,box,inds,k) == [True] + (cc_entry[1:] >= min(k, n_confirmers)). The
     cross-instrument topology combine needs the raw count (merged pools counts), not just the >=K gate."""
@@ -225,7 +244,7 @@ def confirm_count(df, box, indicators, src=None, votes=None):
     if not confirmers:
         return cc_entry, 0
     if votes is None:
-        votes = compute_votes(df, box, confirmers, src)
+        votes = compute_votes(df, box, confirmers, src, ref_df)
     cc = np.zeros(n, dtype=np.int64)
     for ind in confirmers:
         cc += (votes[id(ind)] == CONFIRM).astype(np.int64)

--- a/subprojects/Parametric-Indicators/indicators/test_reference_alignment.py
+++ b/subprojects/Parametric-Indicators/indicators/test_reference_alignment.py
@@ -1,0 +1,55 @@
+"""Guard tests for causal cross-instrument reference alignment (runner.market_context ref_df)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import numpy as np
+import pandas as pd
+
+from indicators import runner
+
+
+def _frame(dates, close):
+    return pd.DataFrame({"Date": pd.to_datetime(dates), "Open": close, "High": close,
+                         "Low": close, "Close": close, "Volume": np.ones(len(close))})
+
+
+def test_reference_aligns_backward_same_timestamp():
+    d = pd.date_range("2025-01-01", periods=5, freq="D")
+    dec = _frame(d, [1.0, 2, 3, 4, 5])
+    ref = _frame(d, [10.0, 20, 30, 40, 50])
+    ctx = runner.market_context(dec, ref_df=ref)
+    assert np.array_equal(ctx.ref_close, [10, 20, 30, 40, 50])   # exact same-timestamp match
+
+
+def test_reference_uses_last_prior_bar_when_missing():
+    dec = _frame(pd.date_range("2025-01-01", periods=4, freq="D"), [1.0, 2, 3, 4])
+    # reference missing day 2 (2025-01-02) ⇒ that decision bar must reuse day 1's ref, not day 3's
+    ref = _frame(["2025-01-01", "2025-01-03", "2025-01-04"], [10.0, 30, 40])
+    ctx = runner.market_context(dec, ref_df=ref)
+    assert list(ctx.ref_close) == [10.0, 10.0, 30.0, 40.0]       # ffill from PAST only
+
+
+def test_no_lookahead_future_ref_bars_cannot_change_the_past():
+    d = pd.date_range("2025-01-01", periods=10, freq="D")
+    dec = _frame(d, np.arange(10.0))
+    ref = _frame(d, np.arange(100.0, 110.0))
+    base = runner.market_context(dec, ref_df=ref).ref_close.copy()
+    # Mutate the reference's FUTURE bars (indices 5..9) arbitrarily
+    ref2 = ref.copy()
+    ref2.loc[5:, "Close"] = [999, 888, 777, 666, 555]
+    mutated = runner.market_context(dec, ref_df=ref2).ref_close
+    # early decision bars (0..4) must be byte-identical — no future leak
+    assert np.array_equal(base[:5], mutated[:5])
+
+
+def test_leading_unmatched_is_nan():
+    dec = _frame(pd.date_range("2025-01-01", periods=3, freq="D"), [1.0, 2, 3])
+    ref = _frame(["2025-01-02", "2025-01-03"], [20.0, 30])       # no ref for day 1
+    ctx = runner.market_context(dec, ref_df=ref)
+    assert np.isnan(ctx.ref_close[0]) and ctx.ref_close[1] == 20.0
+
+
+def test_none_ref_leaves_ref_close_none():
+    dec = _frame(pd.date_range("2025-01-01", periods=3, freq="D"), [1.0, 2, 3])
+    assert runner.market_context(dec).ref_close is None

--- a/subprojects/Parametric-Indicators/optimize/test_indicator_parity.py
+++ b/subprojects/Parametric-Indicators/optimize/test_indicator_parity.py
@@ -51,6 +51,20 @@ def _count_mismatch(E, F) -> int:
     )
 
 
+CROSS_SERIES = ("rolling_corr", "rolling_beta", "cointegration", "pca_factor")
+
+
+def _load_reference(tf, instrument="ES"):
+    """Load a reference instrument's decision frame (Date+Close) for the cross-series indicators.
+    Returns None if unavailable — the cross-series keys then stay neutral (still parity-valid)."""
+    try:
+        rdf, *_ = data.load_inputs(tf, instrument)
+        return rdf
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ref] {instrument} {tf} unavailable ({exc}); cross-series keys will be inert")
+        return None
+
+
 def main(tf: str = "4h", keys=None) -> int:
     df, df1, box, vf, n = data.load_inputs(tf)
     sig_int = signals_to_int(signals.decision_signals(df, box))
@@ -58,10 +72,12 @@ def main(tf: str = "4h", keys=None) -> int:
     MD = df1["Date"].to_numpy(); MH = df1["High"].to_numpy(float)
     ML = df1["Low"].to_numpy(float); MC = df1["Close"].to_numpy(float); MO = df1["Open"].to_numpy(float)
     vol_gate = vf <= float(np.percentile(vf[:n], GP))
+    ref_df = _load_reference(tf, "ES")
 
-    def run_case(specs, k):
+    def run_case(specs, k, rd=None):
         inds = library.from_specs(specs)
-        g = vol_gate & ~runner.veto_mask(df, box, inds) & runner.confirm_mask(df, box, inds, k)
+        g = (vol_gate & ~runner.veto_mask(df, box, inds, ref_df=rd)
+             & runner.confirm_mask(df, box, inds, k, ref_df=rd))
         sp = SimpleStrategyParams(sl_soft_points=SS, sl_hard_points=SH,
                                   tp_hard_points=TP, data_path_4h="", data_path_1min="",
                                   box_data_path="", flip_entry_direction=False)
@@ -90,7 +106,8 @@ def main(tf: str = "4h", keys=None) -> int:
         meta = library.SCHEMA[key]
         params = {p["name"]: p["default"] for p in meta["params"]}
         specs = [{"key": key, "enabled": True, "mode": meta["mode"], "params": params}]
-        E, F, ng = run_case(specs, 1)
+        rd = ref_df if key in CROSS_SERIES else None       # only the cross-series keys use the reference
+        E, F, ng = run_case(specs, 1, rd)
         diffs = _count_mismatch(E, F)
         ok = len(E) == len(F) and diffs == 0
         ok_all &= ok

--- a/subprojects/Parametric-Indicators/tests/oracle/test_xseries_primitives.py
+++ b/subprojects/Parametric-Indicators/tests/oracle/test_xseries_primitives.py
@@ -1,0 +1,56 @@
+"""Tests for cross-series primitives (indicators/calc/xseries.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import numpy as np
+
+from indicators.calc import xseries as xs
+
+
+def _fin(a):
+    a = np.asarray(a, float)
+    return a[~np.isnan(a)]
+
+
+def test_rolling_corr_bounded_and_extremes():
+    rng = np.random.default_rng(0)
+    r = np.cumsum(rng.normal(0, 1, 400))
+    c_same = r.copy()                       # identical returns ⇒ corr ≈ 1
+    corr = _fin(xs.rolling_corr(c_same, r, 50))
+    assert corr.min() >= -1 - 1e-9 and corr.max() <= 1 + 1e-9
+    assert corr[-1] > 0.99
+    c_indep = np.cumsum(rng.normal(0, 1, 400))  # independent ⇒ corr near 0
+    assert abs(np.median(_fin(xs.rolling_corr(c_indep, r, 50)))) < 0.4
+
+
+def test_rolling_beta_recovers_known_slope():
+    rng = np.random.default_rng(1)
+    r = np.cumsum(rng.normal(0, 1, 400))
+    c = 2.0 * r + 5.0                        # primary returns = 2× reference returns
+    beta = _fin(xs.rolling_beta(c, r, 50))
+    assert np.allclose(beta, 2.0, atol=1e-6)
+
+
+def test_spread_zscore_centered():
+    rng = np.random.default_rng(2)
+    r = np.cumsum(rng.normal(0, 1, 400))
+    c = 1.5 * r + np.cumsum(rng.normal(0, 0.3, 400))
+    z = _fin(xs.spread_zscore(c, r, 50))
+    assert abs(z.mean()) < 1.0 and z.min() >= -6 and z.max() <= 6
+
+
+def test_pca_factor_finite():
+    rng = np.random.default_rng(3)
+    r = np.cumsum(rng.normal(0, 1, 400))
+    c = r + np.cumsum(rng.normal(0, 0.5, 400))
+    assert len(_fin(xs.pca_factor(c, r, 50))) > 200
+
+
+def test_reference_nan_propagates_to_nan_not_crash():
+    rng = np.random.default_rng(4)
+    c = np.cumsum(rng.normal(0, 1, 100))                               # non-degenerate primary
+    r = np.concatenate([np.full(40, np.nan), np.cumsum(rng.normal(0, 1, 60))])  # leading ref NaN
+    out = xs.rolling_corr(c, r, 20)
+    assert np.isnan(out[:41]).all()          # windows touching the NaN region are NaN
+    assert not np.isnan(out[70:]).all()      # once past the NaN region, finite again


### PR DESCRIPTION
Closes #13. Part of #12. Completes **Tier-2 (22/22)**; registry **161 → 165**.

Adds the 4 cross-series indicators that compare the primary instrument against an aligned reference:
- `rolling_corr` (veto when the reference decouples), `rolling_beta` (beta-scaled reference lead),
  `cointegration` (pair spread z-score), `pca_factor` (2-series common-factor direction).

### Framework extension
- `MarketContext.ref_close` — reference close **causally aligned** via `merge_asof(direction='backward')`: a decision bar at time *t* only ever sees reference closes known by *t*.
- **No cross-instrument lookahead** — proven by `indicators/test_reference_alignment.py` (mutating the reference's future bars cannot change any past-aligned value).
- `ref_df` threaded through the runner with **default `None` → existing keys byte-identical** (the 4 stay neutral when no reference is wired). Parity harness loads ES to exercise them.

### Verification
- Full **171/171 parity OK, 0 mismatch** (165 keys + legacy combos); the 4 cross-series exercised with a real ES reference.
- 114 unit tests pass, incl. cross-series primitive tests (beta recovers a known slope, corr bounded, NaN-propagation) + 5 alignment/lookahead guards.

### Not in this PR
Optimizer hot-path reference wiring (so they *contribute in studies*) → **#17** (gated behind the adopt gate #14 anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)