### PR TITLE
fix(indicators): cross-series inert (not blocking) without a reference

### DIFF
--- a/subprojects/Parametric-Indicators/indicators/base.py
+++ b/subprojects/Parametric-Indicators/indicators/base.py
@@ -61,6 +61,8 @@ class IndicatorConfig:
 class Indicator(ABC):
     """Base indicator. Subclasses implement `directions(ctx)`."""
     key: str = ""
+    needs_ref: bool = False   # True for cross-series indicators — treated as INACTIVE (not a confirmer/
+                              # vetoer, so it never tightens the K-rule) when ctx.ref_close is None.
 
     def __init__(self, config: IndicatorConfig | None = None) -> None:
         self.config = (config or IndicatorConfig()).validate()

--- a/subprojects/Parametric-Indicators/indicators/confirm.py
+++ b/subprojects/Parametric-Indicators/indicators/confirm.py
@@ -40,8 +40,11 @@ def build_gate(ctx, box_dir, indicators, k, base_gate=None):
     n = len(box_dir)
     base = np.ones(n, dtype=bool) if base_gate is None else np.asarray(base_gate, dtype=bool)
     if indicators:
+        no_ref = getattr(ctx, "ref_close", None) is None
         votes_arr = np.stack([ind.vote(ctx, box_dir) for ind in indicators])
-        active = np.array([bool(ind.config.enabled) for ind in indicators])
+        # A needs_ref (cross-series) indicator with no reference is INACTIVE — it never tightens K.
+        active = np.array([bool(ind.config.enabled) and not (ind.needs_ref and no_ref)
+                           for ind in indicators])
     else:
         votes_arr = np.zeros((0, n), dtype=np.int8)
         active = np.zeros(0, dtype=bool)

--- a/subprojects/Parametric-Indicators/indicators/lib_xseries.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_xseries.py
@@ -24,6 +24,7 @@ class RollingCorr(Indicator, _NeedsRef):
     """Veto BOTH sides when primary↔reference return correlation is low (reference decoupled ⇒ its
     signal is unreliable). |corr| below threshold ⇒ veto."""
     key = "rolling_corr"
+    needs_ref = True
     def directions(self, ctx):
         r = self._ref(ctx)
         n = len(ctx.close)
@@ -38,6 +39,7 @@ class RollingCorr(Indicator, _NeedsRef):
 class RollingBeta(StanceIndicator, _NeedsRef):
     """Beta-scaled reference lead: sign(beta · reference's recent move) — expect the primary to follow."""
     key = "rolling_beta"
+    needs_ref = True
     def stance(self, ctx):
         r = self._ref(ctx)
         if r is None:
@@ -55,6 +57,7 @@ class RollingBeta(StanceIndicator, _NeedsRef):
 class Cointegration(Indicator, _NeedsRef):
     """Pair spread z-score (mean-reversion): z≥upper ⇒ primary rich vs reference → short; z≤lower → long."""
     key = "cointegration"
+    needs_ref = True
     def directions(self, ctx):
         r = self._ref(ctx)
         n = len(ctx.close)
@@ -69,6 +72,7 @@ class Cointegration(Indicator, _NeedsRef):
 class PCAFactor(StanceIndicator, _NeedsRef):
     """2-series PCA common-factor direction: sign of the primary's projection on PC1 of [primary,ref] returns."""
     key = "pca_factor"
+    needs_ref = True
     def stance(self, ctx):
         r = self._ref(ctx)
         if r is None:

--- a/subprojects/Parametric-Indicators/indicators/runner.py
+++ b/subprojects/Parametric-Indicators/indicators/runner.py
@@ -196,7 +196,8 @@ def veto_mask(df, box, indicators, src=None, votes=None, ref_df=None):
     n = len(df)
     out = np.zeros(n, dtype=bool)
     vetoers = [ind for ind in indicators
-               if ind.config.enabled and ind.config.mode in ("veto", "both")]
+               if ind.config.enabled and ind.config.mode in ("veto", "both")
+               and not (ind.needs_ref and ref_df is None)]     # cross-series inert without a reference
     if not vetoers:
         return out
     if votes is None:
@@ -219,7 +220,8 @@ def confirm_mask(df, box, indicators, k, src=None, votes=None, ref_df=None):
     n = len(df)
     out = np.ones(n, dtype=bool)
     confirmers = [ind for ind in indicators
-                  if ind.config.enabled and ind.config.mode in ("confirm", "both")]
+                  if ind.config.enabled and ind.config.mode in ("confirm", "both")
+                  and not (ind.needs_ref and ref_df is None)]     # cross-series inert without a reference
     k_eff = min(int(k), len(confirmers))
     if k_eff <= 0:
         return out                                # no confirm requirement (parity)
@@ -239,7 +241,8 @@ def confirm_count(df, box, indicators, src=None, votes=None, ref_df=None):
     cross-instrument topology combine needs the raw count (merged pools counts), not just the >=K gate."""
     n = len(df)
     confirmers = [ind for ind in indicators
-                  if ind.config.enabled and ind.config.mode in ("confirm", "both")]
+                  if ind.config.enabled and ind.config.mode in ("confirm", "both")
+                  and not (ind.needs_ref and ref_df is None)]     # cross-series inert without a reference
     cc_entry = np.zeros(n, dtype=np.int64)
     if not confirmers:
         return cc_entry, 0
@@ -294,7 +297,8 @@ def build_entry_resolver(df, box, indicators, k,
     ctx = market_context(df)
     bdir = box_direction_int(df, box)
     confirmers = [ind for ind in indicators
-                  if ind.config.enabled and ind.config.mode in ("confirm", "both")]
+                  if ind.config.enabled and ind.config.mode in ("confirm", "both")
+                  and not (ind.needs_ref and ref_df is None)]     # cross-series inert without a reference
     n_confirm = len(confirmers)
     if votes is None:
         votes = {id(ind): _ind_vote(ind, ctx, bdir, src) for ind in confirmers}

--- a/subprojects/Parametric-Indicators/indicators/test_reference_alignment.py
+++ b/subprojects/Parametric-Indicators/indicators/test_reference_alignment.py
@@ -53,3 +53,24 @@ def test_leading_unmatched_is_nan():
 def test_none_ref_leaves_ref_close_none():
     dec = _frame(pd.date_range("2025-01-01", periods=3, freq="D"), [1.0, 2, 3])
     assert runner.market_context(dec).ref_close is None
+
+
+def test_needs_ref_indicator_inactive_without_reference():
+    """#19 framework fix: a cross-series (needs_ref) indicator with no ctx.ref_close is INACTIVE — it
+    never tightens the K-rule. With a reference it becomes active and constrains the gate."""
+    from indicators import confirm, library
+    from indicators.base import MarketContext
+    n = 160
+    rng = np.random.default_rng(0)
+    close = np.cumsum(rng.normal(0, 1, n)) + 100
+    ref = close * 1.3 + np.cumsum(rng.normal(0, 0.3, n))
+    box_dir = np.tile([1, -1, 0, 1], n // 4).astype(np.int8)
+    ind = library.from_specs([{"key": "cointegration", "enabled": True, "mode": "both",
+                               "params": {"n": 50, "lower": -2, "upper": 2}}])[0]
+    z = np.ones(n)
+    g0, _, active0 = confirm.build_gate(MarketContext(close, close, close, close, z, None, None),
+                                        box_dir, [ind], k=1)
+    assert active0[0] == np.False_ and g0.all()          # inactive ⇒ no constraint ⇒ everything allowed
+    g1, _, active1 = confirm.build_gate(MarketContext(close, close, close, close, z, None, ref),
+                                        box_dir, [ind], k=1)
+    assert active1[0] == np.True_ and not np.array_equal(g0, g1)   # active ⇒ it changes the gate

--- a/subprojects/Parametric-Indicators/optimize/core.py
+++ b/subprojects/Parametric-Indicators/optimize/core.py
@@ -171,9 +171,9 @@ def _contributor_gate(d, d1, box, vfw, vf, n_split, gate_ref_vf, gate_pct, param
     if inds and any(i.config.enabled for i in inds):
         src = _cached_source(d, d1, bar_duration) if params.get("ind_1min") else None
         votes = _cached_votes(d, d1, box, inds, src, bar_duration, ref_df)
-        nq_veto = runner.veto_mask(d, box, inds, src=src, votes=votes)
-        nq_confirm = runner.confirm_mask(d, box, inds, int(params.get("k", 1)), src=src, votes=votes)
-        nq_cc, nq_nconf = runner.confirm_count(d, box, inds, src=src, votes=votes)
+        nq_veto = runner.veto_mask(d, box, inds, src=src, votes=votes, ref_df=ref_df)
+        nq_confirm = runner.confirm_mask(d, box, inds, int(params.get("k", 1)), src=src, votes=votes, ref_df=ref_df)
+        nq_cc, nq_nconf = runner.confirm_count(d, box, inds, src=src, votes=votes, ref_df=ref_df)
     else:
         m = len(d)
         nq_veto = np.zeros(m, dtype=bool); nq_confirm = np.ones(m, dtype=bool)
@@ -314,8 +314,8 @@ def backtest_metrics(
                 # and shared by the veto + confirm masks.
                 src = _cached_source(d, d1, bar_duration) if params.get("ind_1min") else None
                 votes = _cached_votes(d, d1, box, inds, src, bar_duration, ref_df)
-                vmask = runner.veto_mask(d, box, inds, src=src, votes=votes)
-                cmask = runner.confirm_mask(d, box, inds, int(params.get("k", 1)), src=src, votes=votes)
+                vmask = runner.veto_mask(d, box, inds, src=src, votes=votes, ref_df=ref_df)
+                cmask = runner.confirm_mask(d, box, inds, int(params.get("k", 1)), src=src, votes=votes, ref_df=ref_df)
                 gate = base & ~vmask & cmask
                 # News veto: a scheduled high-impact release can only ever REMOVE eligibility. Absent /
                 # off ⇒ _news_window_mask returns None ⇒ gate untouched ⇒ byte-identical (golden-locked).


### PR DESCRIPTION
Closes #19. Part of #12.

Framework fix: `Indicator.needs_ref` (True on the 4 cross-series). A `needs_ref` indicator with no reference is treated as **inactive** — dropped from the confirmer/vetoer set so it never tightens the K-rule. Previously an enabled cross-series with no reference could never confirm and **gated out every entry (0 trades)**.

- **Fixes the dashboard footgun without touching `server.py`** — its calls default `ref_df=None`, so cross-series are inert there via the shared gate layer. Protects every caller.
- Also threads `ref_df` through `core.py`'s mask calls so the confirmer set matches the (ref-computed) votes (caught a mid-fix bug: cross-series went inert even *with* a reference).
- Verified: cointegration inert without ref (n_taken==bare 65), active with ES (33). Provably parity-safe for the 161 non-cross-series.
- **Full 171/171 parity OK, 0 mismatch**; 117 unit tests + new build_gate regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)