### PR TITLE
Optimizer Control Center P1: control + settings + progress/ETA (#23)

### DIFF
--- a/subprojects/Parametric-Indicators/indicators/library.py
+++ b/subprojects/Parametric-Indicators/indicators/library.py
@@ -373,11 +373,24 @@ for _m in _SCHOOLS:                       # merge per-school schemas (keys must 
 MODES = ("confirm", "veto", "both")
 RETRACE_UNITS = ("atr_mult", "points")
 
+# Indicator family (school) per key — the control-center UI groups/selects by family. Built from the
+# lib_<school> modules; the 18 built-ins map to "builtin".
+_FAMILY_BY_MODULE = {
+    "lib_ma": "ma", "lib_osc": "oscillator", "lib_trend": "trend", "lib_vol": "volatility",
+    "lib_volume": "volume", "lib_levels": "levels", "lib_bw": "bill_williams", "lib_quant": "quant",
+    "lib_dsp": "dsp", "lib_tier2": "dsp", "lib_xseries": "cross_series",
+}
+_KEY_FAMILY = {}
+for _m in _SCHOOLS:
+    _fam = _FAMILY_BY_MODULE.get(_m.__name__.rsplit(".", 1)[-1], "other")
+    for _k in _m.SCHEMA:
+        _KEY_FAMILY[_k] = _fam
+
 
 def schema():
-    """UI schema for every registered indicator (key + label + default mode + tunable params).
+    """UI schema for every registered indicator (key + family + label + default mode + tunable params).
     Plus the shared enums. The frontend builds the whole indicator panel from this — no hardcoding."""
-    inds = [dict(key=k, **SCHEMA[k]) for k in REGISTRY]
+    inds = [dict(key=k, family=_KEY_FAMILY.get(k, "builtin"), **SCHEMA[k]) for k in REGISTRY]
     return {"indicators": inds, "modes": list(MODES), "retrace_units": list(RETRACE_UNITS),
             "retrace_default": {"amount": 0.0, "unit": "atr_mult"}, "wait_default": 0, "k_default": 1,
             "gen_params": [{"name": "swing_l", "default": 2, "min": 1, "max": 20, "step": 1},

--- a/subprojects/Parametric-Indicators/indicators/test_schema_family.py
+++ b/subprojects/Parametric-Indicators/indicators/test_schema_family.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from indicators import library
+
+
+def test_every_indicator_has_a_family():
+    inds = library.schema()["indicators"]
+    assert all("family" in i for i in inds), [i["key"] for i in inds if "family" not in i]
+    fams = {i["family"] for i in inds}
+    assert {"ma", "oscillator", "trend", "cross_series"} <= fams, fams
+    # families cover the whole registry
+    assert len(inds) == len(library.REGISTRY)
+
+
+def test_family_assignment_is_correct():
+    fam = {i["key"]: i["family"] for i in library.schema()["indicators"]}
+    assert fam["wma"] == "ma"
+    assert fam["rsi_cutler"] == "oscillator"
+    assert fam["supertrend"] == "trend"
+    assert fam["cointegration"] == "cross_series"
+    assert fam["super_smoother"] == "dsp"
+    assert fam["ema_trend"] == "builtin"      # one of the 18 originals

--- a/subprojects/Parametric-Indicators/optimize/dashboard/WORKSTREAM_optimizer_dashboard_TRACKER.md
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/WORKSTREAM_optimizer_dashboard_TRACKER.md
@@ -10,6 +10,22 @@ metadata:
 
 # 🧭 WORKSTREAM TRACKER — Optimizer Control & Visualization Dashboard
 
+## 🆕 Control Center v2 — P1 (control + settings + progress/ETA) — issues #22 (epic) / #23 (P1)
+**Branch `feat/optimizer-control-center` (off dev@247afd7). Design + plan in `docs/superpowers/{specs,plans}/2026-07-25-optimizer-control-center-*`.**
+
+P1 replaces terminal launching with a Vue SPA served by the FastAPI control plane. Status by phase:
+- **A (backend)** ✅ schema `family` tag · cfg→CLI wiring (only/exclude/reference/K-cap/instrument/tf/ind-frame/cold) · `/api/live/progress`+ETA · `/api/presets` · `/api/queue` (+`max_trials` budget clamp) · `/api/health`.
+- **B (scaffold)** ✅ `web/` Vite+Vue3, 3-column shell, `api.js`+reactive `store.js`, mounted at `/` (StaticFiles) below `/api/*`; `run_dashboard.sh` builds first.
+- **C (control)** ✅ start/resume/stop · progress bar + live ETA · health strip · SSE log tail (filterable).
+- **D (settings)** ✅ indicator+family picker · instruments×tf matrix · trials three-way + knobs · command preview (`/api/plan` returns the exact `optimizer.py` command) · presets UI · queue + budget guard.
+- **E (integration)** ⏳ guardrails (golden 6/6 · parity 4h · VPN-bind) + user-run live acceptance over VPN.
+
+Guardrails: **no scoring-engine change** — additions are dashboard/control/config/queue only. `optimize/dashboard/` unit suite = 49 green. Live acceptance (real launch over VPN + screenshot) is the user's step; click-path in the #23 PR body.
+P2 (live figures) + P3 (leaderboard/reports/adopt-gate) are separate plans under epic #22.
+
+---
+
+
 > **READ FIRST WHEN RESUMING.** Single source of truth for this workstream. Spec + plan are written; the
 > user explicitly **held implementation**. Do not write dashboard code until the user says go.
 

--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from fastapi import Body, FastAPI
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 
-from optimize.dashboard import control, progress
+from optimize.dashboard import control, progress, queue, run_presets
 
 app = FastAPI(title="Optimizer Control Plane")
 _STATIC = Path(__file__).resolve().parent / "static"
@@ -60,6 +60,39 @@ def api_progress(tf: str = "4h"):
 def api_live_progress(tf: str = "4h", target: int = 0):
     sp = control.study_progress(tf, target or None)
     return progress.live(tf, sp["done"], sp["target"], time.time())
+
+
+@app.get("/api/presets")
+def api_presets():
+    names = run_presets.list_names()
+    return {"names": names, "presets": {n: run_presets.get(n) for n in names}}
+
+
+@app.get("/api/presets/{name}")
+def api_preset_get(name: str):
+    return {"name": name, "cfg": run_presets.get(name)}
+
+
+@app.post("/api/presets/{name}")
+def api_preset_save(name: str, cfg: dict = Body(default={})):
+    run_presets.save(name, cfg)
+    return {"ok": True, "names": run_presets.list_names()}
+
+
+@app.delete("/api/presets/{name}")
+def api_preset_delete(name: str):
+    run_presets.delete(name)
+    return {"ok": True, "names": run_presets.list_names()}
+
+
+@app.post("/api/queue")
+def api_queue_launch(cfg: dict = Body(default={})):
+    return {"queue": queue.launch(cfg, control.start)}
+
+
+@app.get("/api/queue")
+def api_queue_state():
+    return {"queue": queue.state()}
 
 
 @app.post("/api/bundle")

--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -50,6 +50,11 @@ def api_status():
     return control.status()
 
 
+@app.get("/api/health")
+def api_health():
+    return control.health()
+
+
 @app.get("/api/progress")
 def api_progress(tf: str = "4h"):
     def gen():

--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from fastapi import Body, FastAPI
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 
-from optimize.dashboard import control
+from optimize.dashboard import control, progress
 
 app = FastAPI(title="Optimizer Control Plane")
 _STATIC = Path(__file__).resolve().parent / "static"
@@ -54,6 +54,12 @@ def api_progress(tf: str = "4h"):
         for line in control.follow_logs(tf):
             yield f"data: {json.dumps({'line': line})}\n\n"
     return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+@app.get("/api/live/progress")
+def api_live_progress(tf: str = "4h", target: int = 0):
+    sp = control.study_progress(tf, target or None)
+    return progress.live(tf, sp["done"], sp["target"], time.time())
 
 
 @app.post("/api/bundle")

--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -8,11 +8,13 @@ from pathlib import Path
 
 from fastapi import Body, FastAPI
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
 
 from optimize.dashboard import control, progress, queue, run_presets
 
 app = FastAPI(title="Optimizer Control Plane")
 _STATIC = Path(__file__).resolve().parent / "static"
+_WEB_DIST = Path(__file__).resolve().parent / "web" / "dist"       # built Vue SPA (npm run build)
 _BUNDLES: dict[str, str] = {}
 
 
@@ -111,7 +113,15 @@ def api_bundle_get(bid: str):
     return FileResponse(path, filename=Path(path).name, media_type="application/gzip")
 
 
-@app.get("/", response_class=HTMLResponse)
-def index():
-    f = _STATIC / "index.html"
-    return f.read_text() if f.exists() else "<h1>optimizer control plane up</h1>"
+# Serve the built Vue SPA at '/' (mounted LAST so every '/api/*' route above wins first).
+# `html=True` returns index.html for '/' and for client-side routes. If the SPA hasn't been built
+# yet, fall back to the legacy static index / a stub so the control plane still boots.
+if _WEB_DIST.exists():
+    app.mount("/", StaticFiles(directory=str(_WEB_DIST), html=True), name="spa")
+else:
+    @app.get("/", response_class=HTMLResponse)
+    def index():
+        f = _STATIC / "index.html"
+        if f.exists():
+            return f.read_text()
+        return "<h1>optimizer control plane up — run `npm --prefix web run build` to serve the SPA</h1>"

--- a/subprojects/Parametric-Indicators/optimize/dashboard/control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/control.py
@@ -135,6 +135,20 @@ def status() -> dict:
     return data
 
 
+def study_progress(tf: str, target: int | None = None) -> dict:
+    """Completed-trial count + target for one timeframe's study, read defensively from `status()`
+    (the live `stats --json` shape varies). Returns {done, target}."""
+    done, tgt = 0, int(target or 0)
+    for st in status().get("studies", []):
+        name = str(st.get("tf") or st.get("name") or "")
+        if name == str(tf) or name.endswith(str(tf)):
+            done = int(st.get("complete", st.get("done", st.get("n_complete", 0))) or 0)
+            if not target:
+                tgt = int(st.get("target", st.get("recommended", st.get("n_trials", 0))) or 0)
+            break
+    return {"done": done, "target": tgt}
+
+
 # ── logs (SSE source) ─────────────────────────────────────────────────────────────────────────────
 def _log_path(tf: str) -> Path:
     return _LOGS_DIR / f"{tf}.log"

--- a/subprojects/Parametric-Indicators/optimize/dashboard/control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/control.py
@@ -20,6 +20,7 @@ if str(_PI) not in sys.path:
     sys.path.insert(0, str(_PI))
 
 from optimize import optimizer as OPT               # SAMPLER_CHOICES, search_dims, recommended_trials, print_plan
+from optimize import instruments as INST            # TOKENS (tradeable instrument list)
 from indicators import library                      # schema()
 
 _REMOTE = _PI / "optimize" / "server" / "remote_wsi.sh"
@@ -49,8 +50,8 @@ def config() -> dict:
     except Exception:
         pl = []
     return {"samplers": list(OPT.SAMPLER_CHOICES), "engines": ["single", "two_stage"],
-            "stage_b": ["cmaes", "gp"], "timeframes": TIMEFRAMES, "bounds": bounds,
-            "indicators": library.schema().get("indicators", []), "presets": pl,
+            "stage_b": ["cmaes", "gp"], "timeframes": TIMEFRAMES, "instruments": list(INST.TOKENS),
+            "bounds": bounds, "indicators": library.schema().get("indicators", []), "presets": pl,
             "trials_per_dim": OPT.TRIALS_PER_DIM}
 
 

--- a/subprojects/Parametric-Indicators/optimize/dashboard/control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/control.py
@@ -131,9 +131,34 @@ def status() -> dict:
     try:
         data = json.loads(r["stdout"])
     except Exception:
-        return {"ok": False, "studies": [], "raw": r["stdout"][-400:]}
+        return {"ok": False, "studies": [], "running": False, "n_studies": 0, "raw": r["stdout"][-400:]}
     data["ok"] = r["ok"]
+    studies = data.get("studies", [])
+    # Normalized top-level flags the UI drives buttons + health off of. A run is "running" if ANY
+    # study still has worker processes (`running` = live worker count from `stats --json`).
+    data["running"] = any(int(s.get("running", s.get("workers", 0)) or 0) > 0 for s in studies)
+    data["n_studies"] = len(studies)
     return data
+
+
+# ── health ────────────────────────────────────────────────────────────────────────────────────────
+def health() -> dict:
+    """Host + run health for the control panel's health strip. Runs on the same box as the optimizer,
+    so psutil reflects the server. Every field degrades to None if unavailable (psutil missing, no server)."""
+    h = {"cpu_pct": None, "mem_pct": None, "workers": None, "n_studies": 0, "running": False}
+    try:
+        import psutil
+        h["cpu_pct"] = round(psutil.cpu_percent(interval=0.0), 1)
+        h["mem_pct"] = round(psutil.virtual_memory().percent, 1)
+    except Exception:
+        pass
+    st = status()
+    studies = st.get("studies", [])
+    h["n_studies"] = len(studies)
+    h["running"] = bool(st.get("running"))
+    w = sum(int(s.get("running", s.get("workers", 0)) or 0) for s in studies)
+    h["workers"] = w or None
+    return h
 
 
 def study_progress(tf: str, target: int | None = None) -> dict:

--- a/subprojects/Parametric-Indicators/optimize/dashboard/control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/control.py
@@ -74,6 +74,19 @@ def _apply_env(cfg: dict) -> None:
             os.environ[env] = str(cfg[key])
     os.environ["WSH_SPLIT"] = "1" if cfg.get("split_sltp") else ""
     os.environ["WSH_CONFIRM"] = "1"                # UI already showed the plan + user accepted → skip prompt
+    # Control-center run parameters (#23). Absent keys are left unset ⇒ remote_wsi.sh omits the flag
+    # ⇒ byte-identical to a bare launch. List-valued selections are comma-joined for --only/--exclude.
+    for key, env in {"only_indicators": "WSH_ONLY", "exclude_indicators": "WSH_EXCLUDE"}.items():
+        if cfg.get(key):
+            os.environ[env] = ",".join(str(x) for x in cfg[key])
+    for key, env in {"reference": "WSH_REFERENCE", "max_enabled": "WSH_MAXENABLED",
+                     "instrument": "WSH_INSTRUMENT", "dd_cap": "WSH_DD_CAP"}.items():
+        if cfg.get(key) not in (None, ""):
+            os.environ[env] = str(cfg[key])
+    if cfg.get("timeframes"):
+        os.environ["WSH_TFS"] = " ".join(str(t) for t in cfg["timeframes"])
+    os.environ["WSH_IND1MIN"] = "1" if cfg.get("ind_1min", True) else "0"   # default ON (backward-compat)
+    os.environ["WSH_NOWARM"] = "1" if cfg.get("cold_start") else ""         # cold ⇒ --no-warm-start
 
 
 def start(cfg: dict) -> dict:

--- a/subprojects/Parametric-Indicators/optimize/dashboard/control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/control.py
@@ -56,12 +56,51 @@ def config() -> dict:
 
 
 def plan(cfg: dict) -> dict:
-    """Acceptance preview: search dimensions → recommended (∝-dimension) trial budget."""
+    """Acceptance preview: search dimensions → recommended (∝-dimension) trial budget + the exact
+    optimizer command the run will execute (so the UI shows what the launch actually does)."""
     split = bool(cfg.get("split_sltp", False))
     per_dim = int(cfg.get("trials_per_dim", OPT.TRIALS_PER_DIM))
     dims = OPT.search_dims(split)
     return {"dims": dims["total"], "breakdown": dims, "trials_per_dim": per_dim,
-            "recommended_trials": OPT.recommended_trials(split, per_dim)}
+            "recommended_trials": OPT.recommended_trials(split, per_dim),
+            "command": preview_command(cfg)}
+
+
+def preview_command(cfg: dict) -> str:
+    """Render the optimizer.py invocation equivalent to this cfg — mirrors remote_wsi.sh's IND_ARGS
+    construction exactly (same flags, same order, opt-in flags omitted when unset). Representative of
+    the FIRST selected timeframe; a matrix launches one such command per (instrument, tf)."""
+    tfs = cfg.get("timeframes") or ([cfg["timeframe"]] if cfg.get("timeframe") else ["4h"])
+    tf = str(tfs[0])
+    # trials: 'one' ⇒ user count; otherwise the ∝-dim recommended target the watchdog drives toward.
+    if cfg.get("trials_mode") == "one" and cfg.get("trials"):
+        trials = str(int(cfg["trials"]))
+    else:
+        trials = str(OPT.recommended_trials(bool(cfg.get("split_sltp")),
+                                            int(cfg.get("trials_per_dim", OPT.TRIALS_PER_DIM))))
+    parts = ["python3 optimize/optimizer.py", tf, "--trials", trials, "--folds 5", "--min-trades 5"]
+    if cfg.get("ind_1min", True):
+        parts.append("--ind-1min")
+    if cfg.get("split_sltp"):
+        parts.append("--split-sltp")
+    if cfg.get("sampler"):
+        parts.append(f"--sampler {cfg['sampler']}")
+    if cfg.get("exclude_indicators"):
+        parts.append("--exclude-indicators " + ",".join(str(x) for x in cfg["exclude_indicators"]))
+    if cfg.get("only_indicators"):
+        parts.append("--only-indicators " + ",".join(str(x) for x in cfg["only_indicators"]))
+    if cfg.get("reference"):
+        parts.append(f"--reference {cfg['reference']}")
+    if cfg.get("max_enabled"):
+        parts.append(f"--max-enabled {int(cfg['max_enabled'])}")
+    if cfg.get("cold_start"):
+        parts.append("--no-warm-start")
+    if cfg.get("dd_cap") not in (None, ""):
+        parts.append(f"--dd-pnl-cap {cfg['dd_cap']}")
+    inst = str(cfg.get("instrument", "NQ"))
+    if inst != "NQ":
+        parts.append(f"--instrument {inst}")
+    return " ".join(parts)
 
 
 # ── lifecycle: start / stop(pause) / resume ──────────────────────────────────────────────────────

--- a/subprojects/Parametric-Indicators/optimize/dashboard/progress.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/progress.py
@@ -1,0 +1,45 @@
+"""Live progress + ETA for the control center. Pure `compute_eta` (unit-tested) + a thin study reader.
+
+ETA = remaining trials ÷ the trailing trial-rate (Δdone/Δt over the sample buffer). None when the rate
+is non-positive (can't estimate). No optimizer-engine import — reads only trial counts."""
+from __future__ import annotations
+
+
+def compute_eta(samples: list[tuple[float, int]], target: int) -> dict:
+    """samples: list of (epoch_seconds, trials_done), oldest→newest. Returns
+    {done, target, rate_per_min, eta_seconds|None, elapsed_seconds}."""
+    if not samples:
+        return {"done": 0, "target": target, "rate_per_min": 0.0, "eta_seconds": None,
+                "elapsed_seconds": 0.0}
+    t0, d0 = samples[0]
+    t1, d1 = samples[-1]
+    dt = t1 - t0
+    rate_per_sec = (d1 - d0) / dt if dt > 0 else 0.0
+    remaining = max(0, target - d1)
+    if remaining == 0:
+        eta = 0.0
+    elif rate_per_sec > 0:
+        eta = remaining / rate_per_sec
+    else:
+        eta = None
+    return {"done": d1, "target": target, "rate_per_min": rate_per_sec * 60.0,
+            "eta_seconds": eta, "elapsed_seconds": dt}
+
+
+# Per-study rolling sample buffer, keyed by study name (process-local; the control plane is single-process).
+_BUFFERS: dict[str, list[tuple[float, int]]] = {}
+_MAX_SAMPLES = 20
+
+
+def record(study: str, now: float, done: int, keep: int = _MAX_SAMPLES) -> list[tuple[float, int]]:
+    """Append a (now, done) sample for `study` and return the trailing buffer (capped)."""
+    buf = _BUFFERS.setdefault(study, [])
+    if not buf or buf[-1][1] != done or (now - buf[-1][0]) >= 1.0:
+        buf.append((now, done))
+        del buf[:-keep]
+    return buf
+
+
+def live(study: str, done: int, target: int, now: float) -> dict:
+    """Record a fresh sample and return the ETA dict for `study`."""
+    return compute_eta(record(study, now, done), target)

--- a/subprojects/Parametric-Indicators/optimize/dashboard/queue.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/queue.py
@@ -1,0 +1,52 @@
+"""Run-queue: expand an instruments×timeframes matrix into per-study configs and launch them.
+`expand` is the pure, tested core; the launcher is a thin wrapper over control.start."""
+from __future__ import annotations
+
+_SHARED_DROP = {"instruments", "timeframes", "trials_mode", "per_trials", "trials"}
+
+
+def expand(cfg: dict) -> list[dict]:
+    """Expand {instruments, timeframes, trials_mode, trials|per_trials, ...shared} into one config per
+    (instrument, timeframe). trials_mode ∈ {auto, one, per}."""
+    insts = cfg.get("instruments") or [cfg.get("instrument", "NQ")]
+    tfs = cfg.get("timeframes") or [cfg.get("timeframe", "4h")]
+    mode = cfg.get("trials_mode", "auto")
+    per = cfg.get("per_trials", {}) or {}
+    shared = {k: v for k, v in cfg.items() if k not in _SHARED_DROP}
+    out = []
+    for inst in insts:
+        for tf in tfs:
+            c = dict(shared)
+            c["instrument"] = inst
+            c["timeframe"] = tf
+            c["timeframes"] = [tf]                         # single-tf launch per study
+            if mode == "auto":
+                c["auto_trials"] = True
+            elif mode == "one":
+                c["auto_trials"] = False
+                c["trials"] = int(cfg.get("trials", 0))
+            elif mode == "per":
+                c["auto_trials"] = False
+                c["trials"] = int(per.get(f"{inst}:{tf}", per.get(tf, 0)))
+            out.append(c)
+    return out
+
+
+# In-process queue state (single-process control plane).
+_QUEUE: list[dict] = []
+
+
+def launch(cfg: dict, start_fn) -> list[dict]:
+    """Expand + launch each study via start_fn (control.start); record status. Returns the queue."""
+    global _QUEUE
+    _QUEUE = [{"instrument": c["instrument"], "timeframe": c["timeframe"], "state": "pending", "cfg": c}
+              for c in expand(cfg)]
+    for item in _QUEUE:
+        r = start_fn(item["cfg"])
+        item["state"] = "launched" if r.get("ok") else "failed"
+        item["detail"] = r.get("detail", "")
+    return _QUEUE
+
+
+def state() -> list[dict]:
+    return [{k: v for k, v in it.items() if k != "cfg"} for it in _QUEUE]

--- a/subprojects/Parametric-Indicators/optimize/dashboard/queue.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/queue.py
@@ -2,16 +2,20 @@
 `expand` is the pure, tested core; the launcher is a thin wrapper over control.start."""
 from __future__ import annotations
 
-_SHARED_DROP = {"instruments", "timeframes", "trials_mode", "per_trials", "trials"}
+_SHARED_DROP = {"instruments", "timeframes", "trials_mode", "per_trials", "trials", "max_trials"}
 
 
 def expand(cfg: dict) -> list[dict]:
     """Expand {instruments, timeframes, trials_mode, trials|per_trials, ...shared} into one config per
-    (instrument, timeframe). trials_mode ∈ {auto, one, per}."""
+    (instrument, timeframe). trials_mode ∈ {auto, one, per}.
+
+    Budget guard: `max_trials` (per-study) caps every study's trial count. Under a cap, an 'auto'
+    study becomes an explicit bounded count (auto can't run unbounded beneath a budget)."""
     insts = cfg.get("instruments") or [cfg.get("instrument", "NQ")]
     tfs = cfg.get("timeframes") or [cfg.get("timeframe", "4h")]
     mode = cfg.get("trials_mode", "auto")
     per = cfg.get("per_trials", {}) or {}
+    cap = int(cfg.get("max_trials") or 0)
     shared = {k: v for k, v in cfg.items() if k not in _SHARED_DROP}
     out = []
     for inst in insts:
@@ -28,6 +32,9 @@ def expand(cfg: dict) -> list[dict]:
             elif mode == "per":
                 c["auto_trials"] = False
                 c["trials"] = int(per.get(f"{inst}:{tf}", per.get(tf, 0)))
+            if cap:                                        # budget guard: bound (and de-auto) trials
+                c["auto_trials"] = False
+                c["trials"] = min(int(c.get("trials") or cap), cap)
             out.append(c)
     return out
 

--- a/subprojects/Parametric-Indicators/optimize/dashboard/run_dashboard.sh
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/run_dashboard.sh
@@ -10,6 +10,16 @@ set -a; source "$ENV_FILE"; set +a
 : "${WSH_STORAGE_URL:?set WSH_STORAGE_URL in dashboard.env}"
 echo "binding dashboard to $DASH_BIND_IP (control:${DASH_CONTROL_PORT:-8350} optuna:${DASH_OPTUNA_PORT:-8081})"
 
+# 0) build the Vue SPA (served by the control plane at '/'). Skip if dist/ is present and DASH_SKIP_BUILD=1.
+if [ -z "${DASH_SKIP_BUILD:-}" ] || [ ! -d "$HERE/web/dist" ]; then
+  if command -v npm >/dev/null 2>&1; then
+    echo "building control-center SPA (npm run build)…"
+    ( cd "$HERE/web" && npm install --no-audit --no-fund --silent && npm run build --silent )
+  else
+    echo "npm not found — serving without the SPA (control plane API still up)"
+  fi
+fi
+
 # 1) optuna-dashboard (live graphs/Pareto) — reads the same Postgres the optimizer writes to
 optuna-dashboard "$WSH_STORAGE_URL" --host "$DASH_BIND_IP" --port "${DASH_OPTUNA_PORT:-8081}" \
   > "$HERE/optuna_dashboard.log" 2>&1 &

--- a/subprojects/Parametric-Indicators/optimize/dashboard/run_presets.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/run_presets.py
@@ -1,0 +1,41 @@
+"""Saved run-config presets for the control center (named optimizer configs). JSON-file store.
+Distinct from the top-level `presets` module (strategy/playbook presets)."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+_STORE = Path(os.environ.get("WSH_RUN_PRESETS", str(Path.home() / ".wsh" / "run_presets.json")))
+
+
+def _load() -> dict:
+    try:
+        return json.loads(_STORE.read_text()) if _STORE.exists() else {}
+    except Exception:
+        return {}
+
+
+def _save_all(d: dict) -> None:
+    _STORE.parent.mkdir(parents=True, exist_ok=True)
+    _STORE.write_text(json.dumps(d, indent=2, sort_keys=True))
+
+
+def save(name: str, cfg: dict) -> None:
+    d = _load()
+    d[name] = cfg
+    _save_all(d)
+
+
+def list_names() -> list[str]:
+    return sorted(_load())
+
+
+def get(name: str):
+    return _load().get(name)
+
+
+def delete(name: str) -> None:
+    d = _load()
+    if d.pop(name, None) is not None:
+        _save_all(d)

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_control.py
@@ -88,6 +88,30 @@ def test_status_bad_json_is_safe(monkeypatch):
     assert s["ok"] is False and s["studies"] == []
 
 
+def test_status_derives_running_and_study_count(monkeypatch):
+    sample = ('{"studies":[{"tf":"4h","complete":10,"running":3},'
+              '{"tf":"1h","complete":40,"running":0}]}')
+    monkeypatch.setattr(C, "_run_remote", lambda args, timeout=120:
+                        {"ok": True, "stdout": sample, "stderr": "", "code": 0})
+    s = C.status()
+    assert s["running"] is True and s["n_studies"] == 2      # any worker>0 ⇒ running
+
+
+def test_status_running_false_when_no_workers(monkeypatch):
+    monkeypatch.setattr(C, "_run_remote", lambda args, timeout=120:
+                        {"ok": True, "stdout": '{"studies":[{"tf":"4h","complete":10,"running":0}]}',
+                         "stderr": "", "code": 0})
+    assert C.status()["running"] is False
+
+
+def test_health_reports_studies_and_survives_no_psutil(monkeypatch):
+    monkeypatch.setattr(C, "_run_remote", lambda args, timeout=120:
+                        {"ok": True, "stdout": '{"studies":[{"tf":"4h","complete":10,"running":2}]}',
+                         "stderr": "", "code": 0})
+    h = C.health()
+    assert h["n_studies"] == 1 and h["running"] is True and "cpu_pct" in h and "mem_pct" in h
+
+
 def test_tail_logs(tmp_path, monkeypatch):
     log = tmp_path / "4h.log"; log.write_text("l1\nl2\nl3\n")
     monkeypatch.setattr(C, "_log_path", lambda tf: log)

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_control.py
@@ -26,6 +26,26 @@ def test_plan_scales_with_split():
     assert split["recommended_trials"] == split["dims"] * base["trials_per_dim"]
 
 
+def test_plan_includes_command_string():
+    p = C.plan({"timeframes": ["1h"], "only_indicators": ["rsi", "macd"], "reference": "ES",
+                "instrument": "GC", "split_sltp": True, "cold_start": True, "max_enabled": 3,
+                "trials_mode": "one", "trials": 8000, "ind_1min": True})
+    cmd = p["command"]
+    assert "optimize/optimizer.py 1h" in cmd
+    assert "--only-indicators rsi,macd" in cmd and "--reference ES" in cmd
+    assert "--instrument GC" in cmd and "--split-sltp" in cmd and "--no-warm-start" in cmd
+    assert "--max-enabled 3" in cmd and "--ind-1min" in cmd and "--trials 8000" in cmd
+
+
+def test_preview_command_minimal_is_bare():
+    # No opt-in selections ⇒ command carries only the always-on flags (byte-identical to a bare run).
+    cmd = C.preview_command({"timeframes": ["4h"], "trials_mode": "auto"})
+    assert "optimize/optimizer.py 4h" in cmd and "--ind-1min" in cmd
+    for flag in ("--only-indicators", "--exclude-indicators", "--reference",
+                 "--instrument", "--split-sltp", "--no-warm-start", "--max-enabled"):
+        assert flag not in cmd
+
+
 def test_start_single_builds_env_and_calls_run(monkeypatch):
     seen = {}
     monkeypatch.setattr(C, "_run_remote", lambda args, timeout=120: seen.update({"args": args}) or

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_control_cfg.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_control_cfg.py
@@ -29,6 +29,13 @@ def test_apply_env_maps_the_new_selections():
     assert os.environ["WSH_DD_CAP"] == "0.5"
 
 
+def test_config_exposes_instruments_and_indicator_families():
+    cfg = control.config()
+    assert set(("NQ", "ES", "GC")).issubset(set(cfg["instruments"]))   # matrix picker source (D2)
+    inds = cfg["indicators"]
+    assert inds and all("family" in i and "key" in i for i in inds)    # family-grouped picker (D1)
+
+
 def test_apply_env_exclude_list_and_defaults():
     _clear()
     control._apply_env({"exclude_indicators": ["ifvg", "breaker"]})

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_control_cfg.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_control_cfg.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from optimize.dashboard import control
+
+_KEYS = ("WSH_ONLY", "WSH_EXCLUDE", "WSH_REFERENCE", "WSH_MAXENABLED", "WSH_INSTRUMENT",
+         "WSH_IND1MIN", "WSH_TFS", "WSH_NOWARM", "WSH_DD_CAP")
+
+
+def _clear():
+    for k in _KEYS:
+        os.environ.pop(k, None)
+
+
+def test_apply_env_maps_the_new_selections():
+    _clear()
+    control._apply_env({"only_indicators": ["rsi", "macd"], "reference": "ES", "max_enabled": 3,
+                        "instrument": "NQ", "ind_1min": False, "timeframes": ["4h", "1h"],
+                        "cold_start": True, "dd_cap": 0.5})
+    assert os.environ["WSH_ONLY"] == "rsi,macd"
+    assert os.environ["WSH_REFERENCE"] == "ES"
+    assert os.environ["WSH_MAXENABLED"] == "3"
+    assert os.environ["WSH_INSTRUMENT"] == "NQ"
+    assert os.environ["WSH_TFS"] == "4h 1h"
+    assert os.environ["WSH_IND1MIN"] == "0"          # decision-TF (ind_1min False)
+    assert os.environ["WSH_NOWARM"] == "1"           # cold start
+    assert os.environ["WSH_DD_CAP"] == "0.5"
+
+
+def test_apply_env_exclude_list_and_defaults():
+    _clear()
+    control._apply_env({"exclude_indicators": ["ifvg", "breaker"]})
+    assert os.environ["WSH_EXCLUDE"] == "ifvg,breaker"
+    assert os.environ.get("WSH_ONLY", "") == ""       # absent selection ⇒ unset ⇒ remote_wsi.sh omits the flag
+    assert os.environ["WSH_IND1MIN"] == "1"           # default ON (backward-compatible)

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_progress.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_progress.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from optimize.dashboard import progress
+
+
+def test_eta_from_trailing_rate():
+    # 100 trials over 100s ⇒ 1/s ⇒ 60/min; last done=200, target=400 ⇒ 200 remaining ⇒ 200s
+    r = progress.compute_eta([(1000.0, 100), (1100.0, 200)], target=400)
+    assert r["done"] == 200 and r["target"] == 400
+    assert abs(r["rate_per_min"] - 60.0) < 1e-6
+    assert abs(r["eta_seconds"] - 200.0) < 1e-6
+
+
+def test_eta_none_when_no_progress():
+    r = progress.compute_eta([(1000.0, 50), (1100.0, 50)], target=400)
+    assert r["rate_per_min"] == 0.0 and r["eta_seconds"] is None   # rate 0 ⇒ unknown ETA
+
+
+def test_eta_zero_when_done():
+    r = progress.compute_eta([(1000.0, 380), (1100.0, 400)], target=400)
+    assert r["eta_seconds"] == 0.0                                  # already at target ⇒ 0 remaining
+
+
+def test_single_or_empty_sample_is_safe():
+    assert progress.compute_eta([], target=400)["eta_seconds"] is None
+    assert progress.compute_eta([(1000.0, 10)], target=400)["eta_seconds"] is None
+
+
+def test_study_progress_reads_done_and_target(monkeypatch):
+    from optimize.dashboard import control
+    monkeypatch.setattr(control, "status", lambda: {"studies": [
+        {"tf": "1h", "complete": 5, "target": 100},
+        {"tf": "4h", "complete": 123, "target": 41100},
+    ]})
+    sp = control.study_progress("4h")
+    assert sp["done"] == 123 and sp["target"] == 41100
+    assert control.study_progress("4h", target=50000)["target"] == 50000   # explicit target wins

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_queue.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_queue.py
@@ -29,3 +29,22 @@ def test_per_item_trials_mode():
 def test_defaults_single_instrument_and_tf():
     got = queue.expand({"instrument": "NQ", "trials_mode": "auto"})
     assert len(got) == 1 and got[0]["instrument"] == "NQ" and got[0]["timeframe"] == "4h"
+
+
+def test_budget_guard_clamps_trials():
+    # 'one' count above the per-study budget is clamped down.
+    got = queue.expand({"instruments": ["NQ"], "timeframes": ["4h"], "trials_mode": "one",
+                        "trials": 50000, "max_trials": 8000})
+    assert got[0]["trials"] == 8000 and got[0]["auto_trials"] is False
+
+
+def test_budget_guard_bounds_auto():
+    # 'auto' + a budget becomes an explicit bounded count (auto can't be left unbounded under a cap).
+    got = queue.expand({"instruments": ["NQ"], "timeframes": ["4h"], "trials_mode": "auto",
+                        "max_trials": 6000})
+    assert got[0]["trials"] == 6000 and got[0]["auto_trials"] is False
+
+
+def test_no_budget_leaves_trials_untouched():
+    got = queue.expand({"instruments": ["NQ"], "timeframes": ["4h"], "trials_mode": "one", "trials": 5000})
+    assert got[0]["trials"] == 5000

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_queue.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_queue.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from optimize.dashboard import queue
+
+
+def test_matrix_expands_to_per_study_configs():
+    got = queue.expand({"instruments": ["NQ", "ES"], "timeframes": ["4h", "1h"],
+                        "trials_mode": "one", "trials": 5000, "reference": "ES"})
+    keys = {(c["instrument"], c["timeframe"], c["trials"]) for c in got}
+    assert keys == {("NQ", "4h", 5000), ("NQ", "1h", 5000), ("ES", "4h", 5000), ("ES", "1h", 5000)}
+    # per-study cfg carries the shared settings + a single-tf timeframes list for the launcher
+    assert all(c["reference"] == "ES" and c["timeframes"] == [c["timeframe"]] for c in got)
+
+
+def test_auto_trials_mode_sets_flag():
+    got = queue.expand({"instruments": ["NQ"], "timeframes": ["4h"], "trials_mode": "auto"})
+    assert got[0]["auto_trials"] is True and "trials" not in got[0]
+
+
+def test_per_item_trials_mode():
+    got = queue.expand({"instruments": ["NQ", "GC"], "timeframes": ["4h"], "trials_mode": "per",
+                        "per_trials": {"NQ:4h": 8000, "GC:4h": 3000}})
+    by = {c["instrument"]: c["trials"] for c in got}
+    assert by == {"NQ": 8000, "GC": 3000}
+
+
+def test_defaults_single_instrument_and_tf():
+    got = queue.expand({"instrument": "NQ", "trials_mode": "auto"})
+    assert len(got) == 1 and got[0]["instrument"] == "NQ" and got[0]["timeframe"] == "4h"

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_run_presets.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_run_presets.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from optimize.dashboard import run_presets
+
+
+def test_preset_crud_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_presets, "_STORE", tmp_path / "rp.json")
+    run_presets.save("nq-warm", {"instrument": "NQ", "reference": "ES", "timeframes": ["4h"]})
+    run_presets.save("gc-cold", {"instrument": "GC", "cold_start": True})
+    assert run_presets.list_names() == ["gc-cold", "nq-warm"]
+    assert run_presets.get("nq-warm")["reference"] == "ES"
+    run_presets.delete("nq-warm")
+    assert run_presets.list_names() == ["gc-cold"]
+    assert run_presets.get("nq-warm") is None
+
+
+def test_missing_store_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_presets, "_STORE", tmp_path / "none.json")
+    assert run_presets.list_names() == [] and run_presets.get("x") is None

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/.gitignore
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.local
+
+# The repo-root .gitignore ignores *.html; index.html is the SPA entrypoint Vite needs — keep it.
+!index.html

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/index.html
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Optimizer Control Center</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/package-lock.json
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/package-lock.json
@@ -1,0 +1,1128 @@
+{
+  "name": "optimizer-control-center",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "optimizer-control-center",
+      "version": "0.1.0",
+      "dependencies": {
+        "vue": "^3.4.38"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.1.3",
+        "vite": "^5.4.6"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.40",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.40",
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/shared": "3.5.40",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+      "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
+      "dependencies": {
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+      "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
+      "dependencies": {
+        "@vue/reactivity": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+      "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
+      "dependencies": {
+        "@vue/reactivity": "3.5.40",
+        "@vue/runtime-core": "3.5.40",
+        "@vue/shared": "3.5.40",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg=="
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+      "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-sfc": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/server-renderer": "3.5.40",
+        "@vue/shared": "3.5.40"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/package.json
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "optimizer-control-center",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Optimizer Control Center — Vue SPA that drives and reports the parametric-indicator optimizer.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.38"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.3",
+    "vite": "^5.4.6"
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/App.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/App.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { onMounted, onUnmounted } from 'vue'
+import { store } from './store.js'
+import ControlPanel from './components/ControlPanel.vue'
+import SettingsPanel from './components/SettingsPanel.vue'
+import ReportingPanel from './components/ReportingPanel.vue'
+
+let poll = null
+onMounted(async () => {
+  await store.loadConfig()
+  poll = setInterval(() => store.refreshStatus(), 5000)
+})
+onUnmounted(() => poll && clearInterval(poll))
+</script>
+
+<template>
+  <div class="topbar">
+    <h1>Optimizer Control Center</h1>
+    <span class="pill">{{ store.config.indicators.length }} indicators</span>
+    <span class="pill">{{ store.config.instruments.length }} instruments</span>
+    <div class="spacer"></div>
+    <span class="conn" :class="store.conn">{{ store.conn }}</span>
+  </div>
+
+  <div class="columns">
+    <ControlPanel />
+    <SettingsPanel />
+    <ReportingPanel />
+  </div>
+</template>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
@@ -1,0 +1,52 @@
+// Thin fetch wrappers over the control plane REST API (optimize/dashboard/app.py).
+// Every optimizer action the UI can take goes through here — no fetch() elsewhere.
+
+async function j(method, path, body) {
+  const opts = { method, headers: {} }
+  if (body !== undefined) {
+    opts.headers['Content-Type'] = 'application/json'
+    opts.body = JSON.stringify(body)
+  }
+  const r = await fetch(path, opts)
+  if (!r.ok) throw new Error(`${method} ${path} -> ${r.status}`)
+  const ct = r.headers.get('content-type') || ''
+  return ct.includes('application/json') ? r.json() : r.text()
+}
+
+export const api = {
+  // config / status
+  config: () => j('GET', '/api/config'),
+  status: () => j('GET', '/api/status'),
+
+  // planning + lifecycle
+  plan: (cfg) => j('POST', '/api/plan', cfg),
+  run: (cfg) => j('POST', '/api/run', cfg),
+  resume: (cfg) => j('POST', '/api/resume', cfg),
+  stop: () => j('POST', '/api/stop'),
+
+  // live progress / ETA (snapshot poll)
+  liveProgress: (tf, target) =>
+    j('GET', `/api/live/progress?tf=${encodeURIComponent(tf)}&target=${target || 0}`),
+
+  // saved presets
+  presets: () => j('GET', '/api/presets'),
+  presetSave: (name, cfg) => j('POST', `/api/presets/${encodeURIComponent(name)}`, cfg),
+  presetDelete: (name) => j('DELETE', `/api/presets/${encodeURIComponent(name)}`),
+
+  // run queue (instruments × timeframes matrix)
+  queueState: () => j('GET', '/api/queue'),
+  queueLaunch: (cfg) => j('POST', '/api/queue', cfg),
+}
+
+// SSE helper for the log/progress stream (GET /api/progress?tf=...).
+// Returns the EventSource so the caller can .close() it.
+export function streamLogs(tf, onLine) {
+  const es = new EventSource(`/api/progress?tf=${encodeURIComponent(tf)}`)
+  es.onmessage = (e) => {
+    try {
+      const { line } = JSON.parse(e.data)
+      if (line != null) onLine(line)
+    } catch { /* ignore malformed frames */ }
+  }
+  return es
+}

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
@@ -14,9 +14,10 @@ async function j(method, path, body) {
 }
 
 export const api = {
-  // config / status
+  // config / status / health
   config: () => j('GET', '/api/config'),
   status: () => j('GET', '/api/status'),
+  health: () => j('GET', '/api/health'),
 
   // planning + lifecycle
   plan: (cfg) => j('POST', '/api/plan', cfg),

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/CommandPreview.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/CommandPreview.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { store } from '../store.js'
+import { api } from '../api.js'
+
+const plan = ref(null)
+const err = ref('')
+const copied = ref(false)
+let deb = null
+
+// Preview the FIRST (instrument, tf) of the matrix — one representative command; the queue launches
+// one per cell. Includes the current selections so the command reflects the whole cfg.
+const previewCfg = computed(() => {
+  const c = store.launchCfg()
+  c.instrument = (store.cfg.instruments[0]) || 'NQ'
+  c.timeframes = store.cfg.timeframes.length ? [store.cfg.timeframes[0]] : ['4h']
+  return c
+})
+
+function refresh() {
+  clearTimeout(deb)
+  deb = setTimeout(async () => {
+    try { plan.value = await api.plan(previewCfg.value); err.value = '' }
+    catch (e) { err.value = e.message }
+  }, 300)
+}
+watch(previewCfg, refresh, { immediate: true, deep: true })
+
+async function copy() {
+  try { await navigator.clipboard.writeText(plan.value.command); copied.value = true
+    setTimeout(() => (copied.value = false), 1200) } catch { /* ignore */ }
+}
+const dims = computed(() => plan.value?.dims ?? '—')
+const trials = computed(() => plan.value?.recommended_trials ?? '—')
+</script>
+
+<template>
+  <div>
+    <div class="row">
+      <span class="pill">{{ dims }} dims</span>
+      <span class="pill">~{{ trials }} trials (auto)</span>
+      <button v-if="plan?.command" @click="copy">{{ copied ? 'copied ✓' : 'copy' }}</button>
+    </div>
+    <pre class="cmd mono">{{ err ? ('error: ' + err) : (plan?.command || '…') }}</pre>
+    <p class="muted" style="font-size:11px">Representative of the first study; the queue runs one command per matrix cell.</p>
+  </div>
+</template>
+
+<style scoped>
+.cmd { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px;
+  white-space: pre-wrap; word-break: break-all; font-size: 11px; color: var(--fg); margin: 6px 0 4px; }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
@@ -1,0 +1,12 @@
+<script setup>
+// Phase C fills this in (start/stop/resume, progress bar + ETA, health + logs).
+import { store } from '../store.js'
+</script>
+
+<template>
+  <section class="panel">
+    <h2>Control</h2>
+    <p class="muted">Run lifecycle, progress &amp; ETA, health and logs — built in Phase C.</p>
+    <p class="mono muted">status: {{ store.status.ok ? 'reachable' : 'unknown' }}</p>
+  </section>
+</template>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
@@ -1,12 +1,67 @@
 <script setup>
-// Phase C fills this in (start/stop/resume, progress bar + ETA, health + logs).
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { store } from '../store.js'
+import { api } from '../api.js'
+import ProgressBar from './ProgressBar.vue'
+import HealthStrip from './HealthStrip.vue'
+import LogTail from './LogTail.vue'
+
+const busy = ref(false)
+const msg = ref('')
+const prog = ref({ done: 0, target: 0, rate_per_min: 0, eta_seconds: null, feasible: null, elapsed_seconds: 0 })
+let progTimer = null
+
+const running = computed(() => !!store.status.running)
+// Progress + logs follow the first selected timeframe (P1 control panel tracks one study; the
+// full per-study matrix lives in the reporting column in P2).
+const tf = computed(() => (store.cfg.timeframes && store.cfg.timeframes[0]) || '4h')
+
+async function act(fn, label) {
+  busy.value = true; msg.value = ''
+  try {
+    const r = await fn()
+    msg.value = r && r.detail ? `${label}: ${r.detail.slice(-160)}` : `${label} ok`
+    await store.refreshStatus()
+  } catch (e) {
+    msg.value = `${label} failed: ${e.message}`
+  } finally {
+    busy.value = false
+  }
+}
+const start = () => act(() => api.run(store.launchCfg()), 'start')
+const resume = () => act(() => api.resume(store.launchCfg()), 'resume')
+const stop = () => act(() => api.stop(), 'stop')
+
+async function pollProgress() {
+  try { prog.value = await api.liveProgress(tf.value, 0) } catch { /* keep last */ }
+}
+watch(running, (on) => {
+  if (on && !progTimer) { pollProgress(); progTimer = setInterval(pollProgress, 3000) }
+  if (!on && progTimer) { clearInterval(progTimer); progTimer = null; pollProgress() }
+}, { immediate: true })
+onUnmounted(() => progTimer && clearInterval(progTimer))
 </script>
 
 <template>
   <section class="panel">
     <h2>Control</h2>
-    <p class="muted">Run lifecycle, progress &amp; ETA, health and logs — built in Phase C.</p>
-    <p class="mono muted">status: {{ store.status.ok ? 'reachable' : 'unknown' }}</p>
+
+    <div class="row">
+      <button class="primary" :disabled="busy || running" @click="start">▶ Start</button>
+      <button :disabled="busy || running" @click="resume">⤴ Resume</button>
+      <button class="danger" :disabled="busy || !running" @click="stop">■ Stop</button>
+    </div>
+    <p v-if="msg" class="mono muted" style="word-break:break-word">{{ msg }}</p>
+
+    <h3>Progress <span class="pill">{{ tf }}</span></h3>
+    <ProgressBar
+      :done="prog.done" :target="prog.target" :rate-per-min="prog.rate_per_min"
+      :eta-seconds="prog.eta_seconds" :feasible="prog.feasible" :elapsed-seconds="prog.elapsed_seconds" />
+
+    <h3>Health</h3>
+    <HealthStrip />
+
+    <h3>Logs</h3>
+    <LogTail :tf="tf" />
   </section>
 </template>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/HealthStrip.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/HealthStrip.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { onMounted, onUnmounted, ref } from 'vue'
+import { api } from '../api.js'
+
+const h = ref({ cpu_pct: null, mem_pct: null, workers: null, n_studies: 0, running: false })
+let timer = null
+
+async function poll() {
+  try { h.value = await api.health() } catch { /* keep last */ }
+}
+onMounted(() => { poll(); timer = setInterval(poll, 5000) })
+onUnmounted(() => timer && clearInterval(timer))
+
+const fmt = (v, suffix = '') => (v == null ? '—' : v + suffix)
+</script>
+
+<template>
+  <div class="health mono">
+    <span class="chip" :class="{ hot: h.cpu_pct > 90 }">cpu {{ fmt(h.cpu_pct, '%') }}</span>
+    <span class="chip" :class="{ hot: h.mem_pct > 90 }">mem {{ fmt(h.mem_pct, '%') }}</span>
+    <span class="chip">workers {{ fmt(h.workers) }}</span>
+    <span class="chip">studies {{ h.n_studies }}</span>
+    <span class="chip" :class="h.running ? 'run' : ''">{{ h.running ? 'running' : 'idle' }}</span>
+  </div>
+</template>
+
+<style scoped>
+.health { display: flex; gap: 6px; flex-wrap: wrap; }
+.chip { padding: 2px 8px; border-radius: 6px; border: 1px solid var(--border);
+  background: var(--panel-2); font-size: 11px; }
+.chip.hot { color: var(--bad); border-color: var(--bad); }
+.chip.run { color: var(--ok); border-color: var(--ok); }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/IndicatorPicker.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/IndicatorPicker.vue
@@ -1,0 +1,86 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { store } from '../store.js'
+
+// The active selection list is `only_indicators` or `exclude_indicators`, chosen by the mode.
+// mode 'all' = search over everything (no restriction); 'only' = restrict; 'exclude' = all-except.
+const search = ref('')
+const mode = computed({
+  get: () => store.cfg.indicator_mode,
+  set: (v) => { store.cfg.indicator_mode = v },
+})
+const activeList = computed(() =>
+  mode.value === 'exclude' ? store.cfg.exclude_indicators : store.cfg.only_indicators)
+
+const groups = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  const by = {}
+  for (const ind of store.config.indicators) {
+    if (q && !ind.key.toLowerCase().includes(q) && !(ind.family || '').includes(q)) continue
+    ;(by[ind.family || 'other'] ||= []).push(ind)
+  }
+  return Object.entries(by).sort((a, b) => a[0].localeCompare(b[0]))
+})
+
+const isSel = (k) => activeList.value.includes(k)
+function toggle(k) {
+  const l = activeList.value
+  const i = l.indexOf(k)
+  if (i >= 0) l.splice(i, 1); else l.push(k)
+}
+function familyState(members) {
+  const keys = members.map((m) => m.key)
+  const n = keys.filter(isSel).length
+  return n === 0 ? 'none' : n === keys.length ? 'all' : 'some'
+}
+function toggleFamily(members) {
+  const keys = members.map((m) => m.key)
+  const state = familyState(members)
+  const l = activeList.value
+  if (state === 'all') {
+    for (const k of keys) { const i = l.indexOf(k); if (i >= 0) l.splice(i, 1) }
+  } else {
+    for (const k of keys) if (!l.includes(k)) l.push(k)
+  }
+}
+const selectedCount = computed(() => (mode.value === 'all' ? 0 : activeList.value.length))
+</script>
+
+<template>
+  <div>
+    <div class="row">
+      <label><input type="radio" value="all" v-model="mode" /> all</label>
+      <label><input type="radio" value="only" v-model="mode" /> only these</label>
+      <label><input type="radio" value="exclude" v-model="mode" /> all except</label>
+      <span class="pill" v-if="mode !== 'all'">{{ selectedCount }} selected</span>
+    </div>
+    <div class="row" v-if="mode !== 'all'">
+      <input v-model="search" placeholder="search indicator / family…" style="flex:1" />
+    </div>
+
+    <div class="picker" v-if="mode !== 'all'">
+      <details v-for="[fam, members] in groups" :key="fam" open>
+        <summary>
+          <label @click.prevent="toggleFamily(members)">
+            <input type="checkbox"
+                   :checked="familyState(members) === 'all'"
+                   :indeterminate.prop="familyState(members) === 'some'" />
+            <b>{{ fam }}</b> <span class="muted">({{ members.length }})</span>
+          </label>
+        </summary>
+        <label v-for="ind in members" :key="ind.key" class="ind">
+          <input type="checkbox" :checked="isSel(ind.key)" @change="toggle(ind.key)" />
+          <span class="mono">{{ ind.key }}</span>
+        </label>
+      </details>
+    </div>
+    <p v-else class="muted">All {{ store.config.indicators.length }} indicators are in the search
+      (optimizer decides which to enable).</p>
+  </div>
+</template>
+
+<style scoped>
+.picker { max-height: 320px; overflow: auto; border: 1px solid var(--border); border-radius: 6px; padding: 8px; }
+summary { cursor: pointer; padding: 3px 0; }
+.ind { display: flex; gap: 6px; align-items: center; padding: 1px 0 1px 20px; font-size: 12px; }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/LogTail.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/LogTail.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { streamLogs } from '../api.js'
+
+const props = defineProps({ tf: { type: String, default: '4h' } })
+
+const lines = ref([])
+const filter = ref('all')
+const MAX = 400
+let es = null
+
+const FILTERS = {
+  all: () => true,
+  errors: (l) => /error|exception|traceback|fail/i.test(l),
+  pruned: (l) => /prune/i.test(l),
+  feasible: (l) => /feasible/i.test(l),
+}
+const shown = computed(() => lines.value.filter(FILTERS[filter.value] || FILTERS.all).slice(-200))
+
+function subscribe(tf) {
+  if (es) es.close()
+  lines.value = []
+  es = streamLogs(tf, (line) => {
+    lines.value.push(line)
+    if (lines.value.length > MAX) lines.value.splice(0, lines.value.length - MAX)
+  })
+}
+watch(() => props.tf, (tf) => subscribe(tf), { immediate: true })
+onUnmounted(() => es && es.close())
+</script>
+
+<template>
+  <div class="logtail">
+    <div class="row">
+      <label>filter</label>
+      <select v-model="filter">
+        <option value="all">all</option>
+        <option value="errors">errors</option>
+        <option value="pruned">pruned</option>
+        <option value="feasible">feasible</option>
+      </select>
+      <span class="muted mono">{{ shown.length }} lines · {{ tf }}</span>
+    </div>
+    <pre class="log mono">{{ shown.join('\n') || '(no log output yet)' }}</pre>
+  </div>
+</template>
+
+<style scoped>
+.log { background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+  padding: 8px; height: 220px; overflow: auto; white-space: pre-wrap; word-break: break-word;
+  font-size: 11px; color: var(--muted); margin: 6px 0 0; }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/Presets.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/Presets.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+import { store } from '../store.js'
+import { api } from '../api.js'
+
+const names = ref([])
+const presets = ref({})
+const name = ref('')
+const msg = ref('')
+
+async function load() {
+  try { const r = await api.presets(); names.value = r.names || []; presets.value = r.presets || {} }
+  catch (e) { msg.value = e.message }
+}
+onMounted(load)
+
+async function save() {
+  const n = name.value.trim()
+  if (!n) return
+  // Persist the full UI cfg so Apply restores the panel exactly (not just the launch subset).
+  await api.presetSave(n, JSON.parse(JSON.stringify(store.cfg)))
+  msg.value = `saved "${n}"`; name.value = ''
+  await load()
+}
+function apply(n) {
+  const c = presets.value[n]
+  if (!c) return
+  Object.assign(store.cfg, c)
+  msg.value = `applied "${n}"`
+}
+async function del(n) {
+  await api.presetDelete(n)
+  msg.value = `deleted "${n}"`
+  await load()
+}
+</script>
+
+<template>
+  <div>
+    <div class="row">
+      <input v-model="name" placeholder="preset name" style="flex:1" @keyup.enter="save" />
+      <button class="primary" @click="save" :disabled="!name.trim()">Save current</button>
+    </div>
+    <div class="row" v-for="n in names" :key="n">
+      <span class="mono" style="flex:1">{{ n }}</span>
+      <button @click="apply(n)">Apply</button>
+      <button class="danger" @click="del(n)">✕</button>
+    </div>
+    <p v-if="!names.length" class="muted">no saved presets yet</p>
+    <p v-if="msg" class="muted mono">{{ msg }}</p>
+  </div>
+</template>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ProgressBar.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ProgressBar.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  done: { type: Number, default: 0 },
+  target: { type: Number, default: 0 },
+  ratePerMin: { type: Number, default: 0 },
+  etaSeconds: { type: Number, default: null },
+  feasible: { type: Number, default: null },
+  elapsedSeconds: { type: Number, default: 0 },
+})
+
+const pct = computed(() => {
+  if (!props.target) return 0
+  return Math.min(100, Math.round((props.done / props.target) * 1000) / 10)
+})
+
+function humanize(s) {
+  if (s == null) return '—'
+  s = Math.max(0, Math.round(s))
+  const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60
+  if (h) return `${h}h ${m}m`
+  if (m) return `${m}m ${sec}s`
+  return `${sec}s`
+}
+const eta = computed(() => humanize(props.etaSeconds))
+const elapsed = computed(() => humanize(props.elapsedSeconds))
+</script>
+
+<template>
+  <div class="pb">
+    <div class="pb-track"><div class="pb-fill" :style="{ width: pct + '%' }"></div></div>
+    <div class="pb-meta mono">
+      <span>{{ done }}<span class="muted"> / {{ target || '?' }}</span> ({{ pct }}%)</span>
+      <span class="muted">·</span>
+      <span>{{ ratePerMin ? ratePerMin.toFixed(1) : '0' }}/min</span>
+      <span class="muted">·</span>
+      <span>ETA <b>{{ eta }}</b></span>
+      <span class="muted">·</span>
+      <span>elapsed {{ elapsed }}</span>
+      <span v-if="feasible != null" class="muted">·</span>
+      <span v-if="feasible != null">{{ feasible }} feasible</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pb-track { height: 10px; background: var(--panel-2); border: 1px solid var(--border);
+  border-radius: 999px; overflow: hidden; }
+.pb-fill { height: 100%; background: var(--accent); transition: width .4s ease; }
+.pb-meta { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; margin-top: 6px; }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/QueueControls.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/QueueControls.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+import { store } from '../store.js'
+import { api } from '../api.js'
+
+const items = ref([])
+const busy = ref(false)
+const msg = ref('')
+
+async function refresh() {
+  try { const r = await api.queueState(); items.value = r.queue || [] } catch { /* ignore */ }
+}
+onMounted(refresh)
+
+async function launch() {
+  busy.value = true; msg.value = ''
+  try {
+    const cfg = store.launchCfg()
+    if (store.cfg.max_trials) cfg.max_trials = Number(store.cfg.max_trials)     // budget guard (enforced)
+    const r = await api.queueLaunch(cfg)
+    items.value = r.queue || []
+    msg.value = `launched ${items.value.length} studies`
+    await store.refreshStatus()
+  } catch (e) { msg.value = `launch failed: ${e.message}` }
+  finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div>
+    <h3>Budget guard</h3>
+    <div class="row">
+      <label>max trials / study
+        <input type="number" min="0" step="1000" v-model.number="store.cfg.max_trials" style="width:110px" placeholder="none" />
+      </label>
+      <label>max wall-clock (min)
+        <input type="number" min="0" v-model.number="store.cfg.max_wallclock_min" style="width:90px" placeholder="none" />
+        <span class="pill">advisory</span>
+      </label>
+    </div>
+    <p class="muted" style="font-size:11px">Max-trials is enforced (each study is capped &amp; de-auto’d).
+      Wall-clock is advisory in P1 — surfaced, not yet auto-stopped by the watchdog.</p>
+
+    <div class="row">
+      <button class="primary" :disabled="busy" @click="launch">⇉ Launch matrix</button>
+      <button :disabled="busy" @click="refresh">↻ Refresh</button>
+    </div>
+    <p v-if="msg" class="mono muted">{{ msg }}</p>
+
+    <div class="row" v-for="(it, i) in items" :key="i">
+      <span class="mono" style="flex:1">{{ it.instrument }} · {{ it.timeframe }}</span>
+      <span class="pill" :class="it.state === 'launched' ? 'ok' : it.state === 'failed' ? 'bad' : ''">{{ it.state }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pill.ok { color: var(--ok); border-color: var(--ok); }
+.pill.bad { color: var(--bad); border-color: var(--bad); }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ReportingPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ReportingPanel.vue
@@ -1,0 +1,19 @@
+<script setup>
+// Live + final reporting (leaderboard, Pareto, champion detail) is P2/P3.
+// P1 keeps a minimal live view so the column isn't empty.
+import { store } from '../store.js'
+</script>
+
+<template>
+  <section class="panel">
+    <h2>Reporting</h2>
+    <p class="muted">Live figures, Pareto front, and champion leaderboard arrive in P2/P3.</p>
+    <div v-if="store.status.studies && store.status.studies.length">
+      <h3>Studies</h3>
+      <div v-for="s in store.status.studies" :key="s.tf || s.name" class="row mono">
+        <span class="pill">{{ s.tf || s.name }}</span>
+        <span class="muted">{{ s.complete ?? s.done ?? '?' }} trials</span>
+      </div>
+    </div>
+  </section>
+</template>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/RunKnobs.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/RunKnobs.vue
@@ -1,0 +1,88 @@
+<script setup>
+import { computed } from 'vue'
+import { store } from '../store.js'
+
+const cfg = store.cfg
+// per-(inst,tf) trial cells, shown only in 'per' mode — keyed exactly as queue.expand expects (`inst:tf`).
+const perCells = computed(() => {
+  const out = []
+  for (const inst of cfg.instruments) for (const tf of cfg.timeframes) out.push(`${inst}:${tf}`)
+  return out
+})
+</script>
+
+<template>
+  <div>
+    <h3>Trials</h3>
+    <div class="row">
+      <label><input type="radio" value="auto" v-model="cfg.trials_mode" /> auto (∝ dimensions)</label>
+      <label><input type="radio" value="one" v-model="cfg.trials_mode" /> one count</label>
+      <label><input type="radio" value="per" v-model="cfg.trials_mode" /> per study</label>
+    </div>
+    <div class="row" v-if="cfg.trials_mode === 'one'">
+      <label>trials <input type="number" min="0" step="500" v-model.number="cfg.trials" style="width:110px" /></label>
+    </div>
+    <div v-if="cfg.trials_mode === 'per'">
+      <div class="row" v-for="k in perCells" :key="k">
+        <label class="mono" style="width:120px">{{ k }}</label>
+        <input type="number" min="0" step="500" v-model.number="cfg.per_trials[k]" style="width:110px" />
+      </div>
+      <p v-if="!perCells.length" class="muted">pick instruments × timeframes first.</p>
+    </div>
+
+    <h3>Warm / cold start</h3>
+    <div class="row">
+      <label><input type="radio" :value="false" v-model="cfg.cold_start" /> warm (from champion)</label>
+      <label><input type="radio" :value="true" v-model="cfg.cold_start" /> cold (fresh)</label>
+    </div>
+
+    <h3>Indicator frame</h3>
+    <div class="row">
+      <label><input type="radio" :value="true" v-model="cfg.ind_1min" /> 1-minute indicators</label>
+      <label><input type="radio" :value="false" v-model="cfg.ind_1min" /> decision-TF</label>
+    </div>
+
+    <h3>Engine &amp; sampler</h3>
+    <div class="row">
+      <label>engine
+        <select v-model="cfg.engine">
+          <option v-for="e in store.config.engines" :key="e" :value="e">{{ e }}</option>
+        </select>
+      </label>
+      <label>sampler
+        <select v-model="cfg.sampler">
+          <option v-for="s in store.config.samplers" :key="s" :value="s">{{ s }}</option>
+        </select>
+      </label>
+    </div>
+    <div class="row" v-if="cfg.engine === 'two_stage'">
+      <label>stage-B
+        <select v-model="cfg.stage_b">
+          <option value="">—</option>
+          <option v-for="s in store.config.stage_b" :key="s" :value="s">{{ s }}</option>
+        </select>
+      </label>
+    </div>
+
+    <h3>Search knobs</h3>
+    <div class="row">
+      <label><input type="checkbox" v-model="cfg.split_sltp" /> split long/short SL·TP</label>
+    </div>
+    <div class="row">
+      <label>reference
+        <select v-model="cfg.reference">
+          <option value="">none</option>
+          <option v-for="i in store.config.instruments" :key="i" :value="i">{{ i }}</option>
+        </select>
+      </label>
+      <label>K-cap (max enabled)
+        <input type="number" min="0" v-model.number="cfg.max_enabled" style="width:80px" />
+      </label>
+    </div>
+    <div class="row">
+      <label>DD·P/L cap
+        <input type="number" min="0" step="0.05" v-model.number="cfg.dd_cap" style="width:90px" placeholder="default" />
+      </label>
+    </div>
+  </div>
+</template>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/RunMatrix.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/RunMatrix.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { computed } from 'vue'
+import { store } from '../store.js'
+
+function toggle(list, v) {
+  const i = list.indexOf(v)
+  if (i >= 0) list.splice(i, 1); else list.push(v)
+}
+const cells = computed(() => {
+  const out = []
+  for (const inst of store.cfg.instruments)
+    for (const tf of store.cfg.timeframes) out.push(`${inst} · ${tf}`)
+  return out
+})
+</script>
+
+<template>
+  <div>
+    <h3>Instruments</h3>
+    <div class="row">
+      <label v-for="inst in store.config.instruments" :key="inst" class="tag">
+        <input type="checkbox" :checked="store.cfg.instruments.includes(inst)"
+               @change="toggle(store.cfg.instruments, inst)" /> {{ inst }}
+      </label>
+    </div>
+
+    <h3>Timeframes</h3>
+    <div class="row">
+      <label v-for="tf in store.config.timeframes" :key="tf" class="tag">
+        <input type="checkbox" :checked="store.cfg.timeframes.includes(tf)"
+               @change="toggle(store.cfg.timeframes, tf)" /> {{ tf }}
+      </label>
+    </div>
+
+    <h3>Studies to launch <span class="pill">{{ cells.length }}</span></h3>
+    <div class="grid">
+      <span v-for="c in cells" :key="c" class="cell mono">{{ c }}</span>
+      <span v-if="!cells.length" class="muted">select ≥1 instrument and ≥1 timeframe</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tag { border: 1px solid var(--border); border-radius: 6px; padding: 3px 8px; font-size: 12px; }
+.grid { display: flex; flex-wrap: wrap; gap: 6px; }
+.cell { border: 1px solid var(--accent); border-radius: 6px; padding: 3px 8px; font-size: 11px; }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/SettingsPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/SettingsPanel.vue
@@ -1,0 +1,15 @@
+<script setup>
+// Phase D fills this in (indicator+family picker, instruments×tf matrix, run knobs,
+// command preview, presets, run queue + budget guard).
+import { store } from '../store.js'
+</script>
+
+<template>
+  <section class="panel">
+    <h2>Settings</h2>
+    <p class="muted">Indicator/family selection, instruments × timeframes, run knobs,
+      command preview, presets, and the run queue — built in Phase D.</p>
+    <p class="mono muted">{{ store.config.indicators.length }} indicators across
+      {{ new Set(store.config.indicators.map(i => i.family)).size }} families loaded.</p>
+  </section>
+</template>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/SettingsPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/SettingsPanel.vue
@@ -1,15 +1,27 @@
 <script setup>
-// Phase D fills this in (indicator+family picker, instruments×tf matrix, run knobs,
-// command preview, presets, run queue + budget guard).
-import { store } from '../store.js'
+import IndicatorPicker from './IndicatorPicker.vue'
+import RunMatrix from './RunMatrix.vue'
+import RunKnobs from './RunKnobs.vue'
+import CommandPreview from './CommandPreview.vue'
+import Presets from './Presets.vue'
+import QueueControls from './QueueControls.vue'
 </script>
 
 <template>
   <section class="panel">
     <h2>Settings</h2>
-    <p class="muted">Indicator/family selection, instruments × timeframes, run knobs,
-      command preview, presets, and the run queue — built in Phase D.</p>
-    <p class="mono muted">{{ store.config.indicators.length }} indicators across
-      {{ new Set(store.config.indicators.map(i => i.family)).size }} families loaded.</p>
+
+    <details open><summary class="sec">Indicators &amp; families</summary><IndicatorPicker /></details>
+    <details open><summary class="sec">Instruments × timeframes</summary><RunMatrix /></details>
+    <details><summary class="sec">Run knobs</summary><RunKnobs /></details>
+    <details open><summary class="sec">Command preview</summary><CommandPreview /></details>
+    <details><summary class="sec">Presets</summary><Presets /></details>
+    <details><summary class="sec">Run queue</summary><QueueControls /></details>
   </section>
 </template>
+
+<style scoped>
+details { border-top: 1px solid var(--border); padding: 8px 0; }
+.sec { cursor: pointer; font-size: 12px; text-transform: uppercase; letter-spacing: .5px;
+  color: var(--muted); font-weight: 600; margin-bottom: 6px; }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/main.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './style.css'
+
+createApp(App).mount('#app')

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
@@ -1,0 +1,75 @@
+import { reactive } from 'vue'
+import { api } from './api.js'
+
+// Single reactive store shared by every panel.
+//  - `config`  : server-provided bounds/choices/indicator-schema (read-only, from /api/config)
+//  - `cfg`     : the run-config the user is assembling (POSTed to /api/plan|run|queue)
+//  - `status`  : latest /api/status snapshot (drives button enable-state + health strip)
+//  - `conn`    : control-plane connection state for the top bar
+export const store = reactive({
+  config: {
+    samplers: [], engines: [], stage_b: [], timeframes: [], instruments: [],
+    bounds: {}, indicators: [], presets: [], trials_per_dim: 0,
+  },
+  cfg: {
+    // selections (all optional — absent keys ⇒ optimizer defaults, byte-identical to a bare launch)
+    only_indicators: [], exclude_indicators: [], indicator_mode: 'all', // 'all' | 'only' | 'exclude'
+    instruments: [], timeframes: [],
+    trials_mode: 'auto', trials: 0, per_trials: {},
+    reference: '', max_enabled: null,
+    engine: 'single', sampler: '', stage_b: '',
+    split_sltp: false, ind_1min: true, cold_start: false, dd_cap: null,
+    max_wallclock_min: null,
+  },
+  status: { ok: false, studies: [] },
+  conn: 'connecting', // 'connecting' | 'online' | 'offline'
+  loaded: false,
+
+  async loadConfig() {
+    try {
+      const c = await api.config()
+      // config() also embeds a status snapshot under `status`
+      this.status = c.status || this.status
+      for (const k of ['samplers', 'engines', 'stage_b', 'timeframes', 'instruments',
+                       'bounds', 'indicators', 'presets', 'trials_per_dim']) {
+        if (c[k] !== undefined) this.config[k] = c[k]
+      }
+      // sensible first-run defaults derived from the server
+      if (!this.cfg.sampler && this.config.samplers.length) this.cfg.sampler = this.config.samplers[0]
+      this.conn = 'online'
+      this.loaded = true
+    } catch (e) {
+      this.conn = 'offline'
+    }
+  },
+
+  async refreshStatus() {
+    try {
+      this.status = await api.status()
+      this.conn = 'online'
+    } catch {
+      this.conn = 'offline'
+    }
+  },
+
+  // The subset of cfg actually sent to the backend: strip empty selections so the launch stays
+  // byte-identical to a bare optimizer run unless the user opted into something.
+  launchCfg() {
+    const c = this.cfg
+    const out = {
+      instruments: c.instruments.length ? c.instruments : undefined,
+      timeframes: c.timeframes.length ? c.timeframes : undefined,
+      trials_mode: c.trials_mode,
+      engine: c.engine, sampler: c.sampler || undefined, stage_b: c.stage_b || undefined,
+      split_sltp: c.split_sltp, ind_1min: c.ind_1min, cold_start: c.cold_start,
+      reference: c.reference || undefined,
+      max_enabled: c.max_enabled || undefined,
+      dd_cap: c.dd_cap || undefined,
+    }
+    if (c.trials_mode === 'one') out.trials = Number(c.trials) || 0
+    if (c.trials_mode === 'per') out.per_trials = c.per_trials
+    if (c.indicator_mode === 'only' && c.only_indicators.length) out.only_indicators = c.only_indicators
+    if (c.indicator_mode === 'exclude' && c.exclude_indicators.length) out.exclude_indicators = c.exclude_indicators
+    return out
+  },
+})

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/style.css
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/style.css
@@ -1,0 +1,64 @@
+:root {
+  --bg: #0e1116;
+  --panel: #161b22;
+  --panel-2: #1c2230;
+  --border: #2a313c;
+  --fg: #d7dde5;
+  --muted: #8b949e;
+  --accent: #3b82f6;
+  --ok: #3fb950;
+  --warn: #d29922;
+  --bad: #f85149;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+* { box-sizing: border-box; }
+html, body, #app { height: 100%; margin: 0; }
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+.topbar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 16px; border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+.topbar h1 { font-size: 15px; margin: 0; font-weight: 600; letter-spacing: .2px; }
+.topbar .spacer { flex: 1; }
+.conn { font-size: 12px; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--border); }
+.conn.online { color: var(--ok); border-color: var(--ok); }
+.conn.offline { color: var(--bad); border-color: var(--bad); }
+.conn.connecting { color: var(--muted); }
+
+.columns {
+  display: grid;
+  grid-template-columns: 320px 1fr 380px;
+  gap: 12px; padding: 12px;
+  height: calc(100% - 49px);
+}
+@media (max-width: 1200px) { .columns { grid-template-columns: 1fr; height: auto; } }
+
+.panel {
+  background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+  padding: 14px; overflow: auto;
+}
+.panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .6px; color: var(--muted); margin: 0 0 12px; }
+.panel h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); margin: 16px 0 8px; }
+
+button {
+  font: inherit; cursor: pointer; border-radius: 6px; padding: 7px 14px;
+  border: 1px solid var(--border); background: var(--panel-2); color: var(--fg);
+}
+button:hover:not(:disabled) { border-color: var(--accent); }
+button:disabled { opacity: .45; cursor: not-allowed; }
+button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+button.danger { background: var(--bad); border-color: var(--bad); color: #fff; }
+
+input, select { font: inherit; background: var(--panel-2); color: var(--fg);
+  border: 1px solid var(--border); border-radius: 6px; padding: 5px 8px; }
+label { font-size: 13px; }
+.row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 6px 0; }
+.mono { font-family: var(--mono); font-size: 12px; }
+.muted { color: var(--muted); }
+.pill { display: inline-block; padding: 1px 7px; border-radius: 999px; border: 1px solid var(--border);
+  font-size: 11px; color: var(--muted); }

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/vite.config.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/vite.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+// The control plane serves the built SPA from web/dist as static files mounted at '/'.
+// `base: './'` keeps asset URLs relative so it works behind the VPN IP without a fixed host.
+// The dev proxy lets `npm run dev` talk to a locally-running control plane on 8350.
+export default defineConfig({
+  plugins: [vue()],
+  base: './',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/api': { target: 'http://localhost:8350', changeOrigin: true },
+    },
+  },
+})

--- a/subprojects/Parametric-Indicators/optimize/server/remote_wsi.sh
+++ b/subprojects/Parametric-Indicators/optimize/server/remote_wsi.sh
@@ -48,11 +48,16 @@ SPLIT_ARG="${WSH_SPLIT:+--split-sltp}"                 # set WSH_SPLIT=1 to sear
 SAMPLER_ARG="${WSH_SAMPLER:+--sampler $WSH_SAMPLER}"   # optimizer brain (P2): nsga3*(default)|nsga2|tpe|motpe|gp; unset ⇒ nsga3 (unchanged)
 OBJ_ARG="${WSH_OBJECTIVE:+--objective $WSH_OBJECTIVE}" # α: winrate*(default)|decision_pause; unset ⇒ winrate (unchanged)
 EXCL_ARG="${WSH_EXCLUDE:+--exclude-indicators $WSH_EXCLUDE}"  # α: e.g. ifvg,breaker,cisd reverts to wsh4-era 15
+ONLY_ARG="${WSH_ONLY:+--only-indicators $WSH_ONLY}"    # control-center: restrict the search to these indicators
+REF_ARG="${WSH_REFERENCE:+--reference $WSH_REFERENCE}" # control-center: cross-series reference instrument (#17)
+MAXEN_ARG="${WSH_MAXENABLED:+--max-enabled $WSH_MAXENABLED}"  # control-center: cap simultaneously-enabled indicators
+NOWARM_ARG="${WSH_NOWARM:+--no-warm-start}"           # control-center: cold start (skip champion warm-start)
+IND1MIN_ARG="--ind-1min"; [ "${WSH_IND1MIN:-1}" = "0" ] && IND1MIN_ARG=""  # default ON; WSH_IND1MIN=0 ⇒ decision-TF
 DDCAP_ARG="${WSH_DD_CAP:+--dd-pnl-cap $WSH_DD_CAP}"    # α: relax the DD≤cap·P/L feasibility (e.g. 0.5) for shorter pauses
 INSTRUMENT="${WSH_INSTRUMENT:-NQ}"                     # NQ (default) or ES; non-NQ → suffixed studies/champions
 INST_ARG=""; [ "$INSTRUMENT" != "NQ" ] && INST_ARG="--instrument $INSTRUMENT"
 RSUF=""; [ "$INSTRUMENT" != "NQ" ] && RSUF="_$INSTRUMENT"   # study/db filename suffix mirrored into launch.sh + readers
-IND_ARGS="--ind-1min --study-prefix $PREFIX $SPLIT_ARG $SAMPLER_ARG $OBJ_ARG $EXCL_ARG $DDCAP_ARG $INST_ARG" # indicators read the 1-minute frame
+IND_ARGS="$IND1MIN_ARG --study-prefix $PREFIX $SPLIT_ARG $SAMPLER_ARG $OBJ_ARG $EXCL_ARG $ONLY_ARG $REF_ARG $MAXEN_ARG $NOWARM_ARG $DDCAP_ARG $INST_ARG"
 
 SSH_OPTS=(-p "$SRV_PORT" -i "$SRV_KEY" -o IdentitiesOnly=yes -o BatchMode=yes \
           -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 \


### PR DESCRIPTION
## Optimizer Control Center — P1 (control + settings + progress/ETA)

Closes #23. Part of epic #22. Replaces terminal launching of the optimizer with a Vue SPA served by the FastAPI control plane. **No scoring-engine change** — all additions are dashboard / control / config / queue.

### What's in P1
**Backend (Phase A, TDD)**
- `schema()` tags every indicator with its `family` (11 families over 165 indicators)
- cfg → optimizer CLI wiring (`only`/`exclude`/`reference`/`max-enabled`/`instrument`/`tf`/`ind-1min`/`cold-start`) — **byte-identical to a bare launch when nothing is opted into**
- `/api/live/progress` with trailing-rate ETA · `/api/presets` CRUD · `/api/queue` matrix expansion (+`max_trials` budget clamp) · `/api/health` · `/api/plan` now returns the exact `optimizer.py` command
- `config()` also exposes the instrument list

**Frontend (Phases B–D)**
- Vite + Vue 3 SPA under `optimize/dashboard/web/`, 3-column shell (Control / Settings / Reporting), mounted at `/` (StaticFiles) below `/api/*`; `run_dashboard.sh` builds it first
- **Control:** start / resume / stop · progress bar + live ETA · health strip · filterable SSE log tail
- **Settings:** indicator + family picker (select a whole school) · instruments × timeframes matrix · trials three-way (auto / one / per-study) + all knobs · copyable command preview · saved presets · run queue + budget guard

### Guardrails (Phase E)
| Check | Result |
|---|---|
| `perf/check_golden.py` (all TFs) | ✅ 6/6 MATCH |
| `optimize/test_indicator_parity.py 4h` | ✅ 0 mismatch (incl. cross-series w/ reference) |
| VPN bind (no `0.0.0.0`) | ✅ all binds use `$DASH_BIND_IP` |
| `optimize/dashboard/` unit suite | ✅ 49 passed |
| End-to-end API smoke (config→plan→preset→queue) | ✅ PASS |

### Live acceptance — user's step (needs the server + VPN)
A real launch can't be exercised from CI/local (no VPN server reachable). On the server, over VPN:
1. `bash optimize/dashboard/run_dashboard.sh` (builds the SPA, binds the private IP)
2. Open `http://<DASH_BIND_IP>:8350/` → top bar shows **165 indicators / 9 instruments / online**
3. Settings → pick a family (e.g. `oscillator`) + a few individual indicators; pick NQ × 4h; set reference=ES, trials=one/6000, cold start → the **command preview** updates to the exact `optimizer.py …` line
4. Control → **Start** → progress bar advances, ETA decreases, health shows workers; logs stream (try the `feasible` filter) → **Stop** → idle
5. Capture a screenshot/gif for the record

### Follow-ups (not in P1)
- P2 live figures (Pareto/scatter drawn live), P3 leaderboard/reports/adopt-gate — separate plans under #22
- Wall-clock budget auto-stop is **advisory** in P1 (surfaced, not yet enforced by the watchdog); max-trials **is** enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
