### PR TITLE
fix(instruments): lazy registry load — unbreaks control-plane import off-server (closes #26)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/instruments.py
+++ b/subprojects/Parametric-Indicators/optimize/instruments.py
@@ -35,7 +35,12 @@ def _load_registry():
     return mod.REGISTRY
 
 
-_REGISTRY = _load_registry()
+@functools.lru_cache(maxsize=1)
+def _registry():
+    """Lazily load the no-mix registry (cached). Deferred so merely importing this module for the static
+    TOKENS/POINT_VALUE — as the dashboard control plane does — has NO import-time filesystem dependency;
+    the registry file is only read the first time a non-NQ instrument is actually resolved."""
+    return _load_registry()
 
 
 def is_valid(token: str) -> bool:
@@ -51,7 +56,7 @@ def resolve_paths(token: str, tf: str) -> tuple[str, str, str]:
     ES → the ALL_STOCKS registry."""
     if token == "NQ":
         return (str(_RAW / f"NQ_{tf}.csv"), str(_RAW / "NQ_1m.csv"), str(_BOX_CSV))
-    inst = _REGISTRY[token]
+    inst = _registry()[token]
     return (inst.candle_csv(tf), inst.candle_csv("1m"), inst.box_csv)
 
 

--- a/subprojects/Parametric-Indicators/optimize/test_instruments.py
+++ b/subprojects/Parametric-Indicators/optimize/test_instruments.py
@@ -17,6 +17,22 @@ def test_tokens_and_point_values():
     assert not I.is_valid("QQQ-RTH")
 
 
+def test_import_has_no_registry_filesystem_dependency():
+    """Regression (#26): importing instruments for the static TOKENS/POINT_VALUE must NOT read the
+    no-mix registry file — the control plane imports it just for the token list. Run in a subprocess
+    with a bogus WSH_DATA_BASE so the registry path is invalid; import + TOKENS + NQ must still work."""
+    import subprocess
+    root = str(Path(__file__).resolve().parents[1])
+    code = ("from optimize import instruments as I;"
+            "assert I.TOKENS[0]=='NQ' and len(I.TOKENS)==9;"
+            "assert I.point_value('NQ')==20.0;"
+            "assert I.resolve_paths('NQ','4h')[0].endswith('NQ_4h.csv');"
+            "print('ok')")
+    env = {**os.environ, "WSH_DATA_BASE": "/nonexistent/registry/path", "PYTHONPATH": root}
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0 and "ok" in r.stdout, r.stderr
+
+
 def test_resolve_paths_nq_matches_current_data_module():
     dec, mn, box = I.resolve_paths("NQ", "4h")
     assert dec == str(D._RAW / "NQ_4h.csv")


### PR DESCRIPTION
Closes #26. Surfaced deploying the control center (#22/#23) to the server.

`optimize/instruments.py` loaded the no-mix registry from the filesystem **at import time**, just to expose the static `TOKENS`/`POINT_VALUE`. The control plane's `config()` imports the module for the token list (#23), which triggered the read and failed on the server (path/env not present) → `uvicorn` couldn't load the app.

**Fix:** `_REGISTRY` (used in one place — `resolve_paths` for non-NQ) becomes a cached `_registry()` loaded on first non-NQ resolution. Importing the module now has no filesystem side effect. Behavior-preserving — NQ never touches the registry.

**Verify:** new regression test imports with a bogus `WSH_DATA_BASE` and asserts `TOKENS` + NQ `resolve_paths` still work; 55 instruments+dashboard tests green; golden 6/6 re-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)