### PR TITLE
Control Center: own the optimizer run in Python — live stream, real stop, per-selection study (closes #28)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -10,7 +10,7 @@ from fastapi import Body, FastAPI
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
-from optimize.dashboard import control, progress, queue, run_presets
+from optimize.dashboard import control, progress, queue, run_presets, runner
 
 app = FastAPI(title="Optimizer Control Plane")
 _STATIC = Path(__file__).resolve().parent / "static"
@@ -32,7 +32,9 @@ def api_plan(cfg: dict = Body(default={})):
 
 @app.post("/api/run")
 def api_run(cfg: dict = Body(default={})):
-    return control.start(cfg)
+    # Owned-subprocess driver (#28): validates mandatory fields, launches a per-selection study as a
+    # process the control plane owns, returns IMMEDIATELY (non-blocking). Errors → {ok:False, errors}.
+    return runner._MGR.start(cfg)
 
 
 @app.post("/api/resume")
@@ -42,7 +44,32 @@ def api_resume(cfg: dict = Body(default={})):
 
 @app.post("/api/stop")
 def api_stop():
-    return control.stop()
+    # Real stop: signal the owned process group (SIGTERM→SIGKILL). No pkill on unowned workers.
+    return runner._MGR.stop()
+
+
+@app.get("/api/run/state")
+def api_run_state():
+    st = runner._MGR.state()
+    if st.get("pid"):                                        # a run exists (active or just finished)
+        done = runner._MGR.done_count()
+        st["progress"] = progress.live(st.get("tf") or "run", done, st.get("target") or 0, time.time())
+    return st
+
+
+@app.get("/api/run/logs")
+def api_run_logs():
+    def gen():
+        cursor = 0
+        while True:
+            cursor, new = runner._MGR.lines_since(cursor)
+            for ln in new:
+                yield f"data: {json.dumps({'line': ln})}\n\n"
+            if not runner._MGR.running() and not new:
+                yield f"data: {json.dumps({'done': True, 'returncode': runner._MGR.state()['returncode']})}\n\n"
+                return
+            time.sleep(1)
+    return StreamingResponse(gen(), media_type="text/event-stream")
 
 
 @app.get("/api/status")

--- a/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
@@ -189,11 +189,16 @@ class RunManager:
             return {"ok": True, "detail": f"already exited (rc={self.proc.returncode})"}
         try:
             pgid = os.getpgid(self.proc.pid)
-            os.killpg(pgid, signal.SIGTERM)          # real stop: signal the whole owned group
+            os.killpg(pgid, signal.SIGTERM)          # graceful stop of the whole owned group
             try:
-                self.proc.wait(timeout=8)
+                self.proc.wait(timeout=4)
             except subprocess.TimeoutExpired:
+                pass
+            # Sweep the group with SIGKILL so fold/loky worker stragglers don't linger after Stop.
+            try:
                 os.killpg(pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
             return {"ok": True, "detail": "stopped"}
         except ProcessLookupError:
             return {"ok": True, "detail": "already gone"}

--- a/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
@@ -1,0 +1,223 @@
+"""Control-plane-OWNED optimizer runner (#28).
+
+Drives `optimize/optimizer.py` as a subprocess the control plane owns (`Popen`, its own process
+group) — the opposite of the fire-and-forget `remote_wsi.sh` launch (detached `setsid` workers). Because
+the plane holds the handle it can: stream live stdout, STOP for real (kill the group), and give each
+distinct selection its OWN study (so runs actually execute instead of reusing a target-met study).
+
+Pure helpers (`validate`, `study_prefix`, `build_command`) are unit-tested; the process lifecycle is
+tested with a fake command so no real optimizer runs.
+"""
+from __future__ import annotations
+
+import collections
+import hashlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_PI = _HERE.parent.parent                        # Parametric-Indicators root (cwd for the child)
+
+
+def _python() -> str:
+    """The interpreter to run the optimizer with. On the server, the venv from REMOTE_VENV; tests may
+    pin WSH_RUNNER_PYTHON; otherwise the current interpreter."""
+    p = os.environ.get("WSH_RUNNER_PYTHON")
+    if p:
+        return p
+    venv = os.environ.get("REMOTE_VENV")
+    if venv and (Path(venv) / "bin" / "python3").exists():
+        return str(Path(venv) / "bin" / "python3")
+    return sys.executable
+
+
+# ── pure helpers ────────────────────────────────────────────────────────────────────────────────
+def validate(cfg: dict) -> list[str]:
+    """Return the list of missing/invalid mandatory fields. Empty ⇒ OK to run."""
+    missing = []
+    if not cfg.get("instrument"):
+        missing.append("instrument")
+    tfs = cfg.get("timeframes") or ([cfg["timeframe"]] if cfg.get("timeframe") else [])
+    if not tfs:
+        missing.append("timeframe")
+    if cfg.get("trials_mode", "auto") == "one" and not int(cfg.get("trials") or 0):
+        missing.append("trials")
+    im = cfg.get("indicator_mode", "all")
+    if im == "only" and not cfg.get("only_indicators"):
+        missing.append("only_indicators")
+    if im == "exclude" and not cfg.get("exclude_indicators"):
+        missing.append("exclude_indicators")
+    return missing
+
+
+def study_prefix(cfg: dict) -> str:
+    """A stable prefix unique to this SELECTION (instrument + indicators + knobs). Two different configs
+    ⇒ two different studies ⇒ a fresh run each time (never silently reuses a target-met study)."""
+    canon = {
+        "inst": cfg.get("instrument", "NQ"),
+        "only": sorted(cfg.get("only_indicators") or []),
+        "excl": sorted(cfg.get("exclude_indicators") or []),
+        "mode": cfg.get("indicator_mode", "all"),
+        "split": bool(cfg.get("split_sltp")),
+        "ref": cfg.get("reference") or "",
+        "maxen": int(cfg.get("max_enabled") or 0),
+        "ind1min": bool(cfg.get("ind_1min", True)),
+        "sampler": cfg.get("sampler") or "nsga3",
+        "cold": bool(cfg.get("cold_start")),
+        "dd": str(cfg.get("dd_cap") or ""),
+    }
+    h = hashlib.sha1(json.dumps(canon, sort_keys=True).encode()).hexdigest()[:8]
+    return f"cc{h}"
+
+
+def study_name(cfg: dict, tf: str) -> str:
+    """Mirror optimizer.py: f'{prefix}_{tf}{_study_suffix(instrument)}' (suffix empty for NQ)."""
+    inst = str(cfg.get("instrument", "NQ"))
+    return f"{study_prefix(cfg)}_{tf}" + ("" if inst == "NQ" else f"_{inst}")
+
+
+def target_trials(cfg: dict) -> int:
+    from optimize import optimizer as OPT
+    if cfg.get("trials_mode") == "one" and cfg.get("trials"):
+        return int(cfg["trials"])
+    return OPT.recommended_trials(bool(cfg.get("split_sltp")),
+                                  int(cfg.get("trials_per_dim", OPT.TRIALS_PER_DIM)))
+
+
+def build_command(cfg: dict, tf: str) -> list[str]:
+    """The optimizer.py argv equivalent to this cfg (mirrors remote_wsi.sh IND_ARGS)."""
+    cmd = [_python(), "-u", "optimize/optimizer.py", str(tf), "--folds", "5", "--min-trades", "5",
+           "--study-prefix", study_prefix(cfg)]
+    mode = cfg.get("trials_mode", "auto")
+    if mode == "one" and int(cfg.get("trials") or 0):
+        cmd += ["--trials", str(int(cfg["trials"]))]
+    elif mode == "per":
+        n = int((cfg.get("per_trials") or {}).get(f"{cfg.get('instrument')}:{tf}", 0))
+        cmd += (["--trials", str(n)] if n else ["--auto-trials"])
+    else:
+        cmd += ["--auto-trials"]
+    if cfg.get("ind_1min", True):
+        cmd.append("--ind-1min")
+    if cfg.get("split_sltp"):
+        cmd.append("--split-sltp")
+    if cfg.get("sampler"):
+        cmd += ["--sampler", str(cfg["sampler"])]
+    if cfg.get("exclude_indicators"):
+        cmd += ["--exclude-indicators", ",".join(map(str, cfg["exclude_indicators"]))]
+    if cfg.get("only_indicators"):
+        cmd += ["--only-indicators", ",".join(map(str, cfg["only_indicators"]))]
+    if cfg.get("reference"):
+        cmd += ["--reference", str(cfg["reference"])]
+    if cfg.get("max_enabled"):
+        cmd += ["--max-enabled", str(int(cfg["max_enabled"]))]
+    if cfg.get("cold_start"):
+        cmd.append("--no-warm-start")
+    if cfg.get("dd_cap") not in (None, ""):
+        cmd += ["--dd-pnl-cap", str(cfg["dd_cap"])]
+    inst = str(cfg.get("instrument", "NQ"))
+    if inst != "NQ":
+        cmd += ["--instrument", inst]
+    return cmd
+
+
+def _child_env(cfg: dict) -> dict:
+    env = dict(os.environ)                       # inherits WSH_DATA_BASE/WSG_DATA_ROOT/WSH_STORAGE_URL from dashboard.env
+    env["WSI_INSTRUMENT"] = str(cfg.get("instrument", "NQ"))
+    return env
+
+
+# ── owned run manager (single active run) ─────────────────────────────────────────────────────────
+class RunManager:
+    def __init__(self):
+        self.proc: subprocess.Popen | None = None
+        self.study = self.tf = self.prefix = None
+        self.cfg: dict | None = None
+        self.target = 0
+        self.lines: collections.deque = collections.deque(maxlen=2000)
+        self._total = 0                              # monotonic count of lines ever produced (for SSE cursor)
+        self._reader: threading.Thread | None = None
+
+    def running(self) -> bool:
+        return self.proc is not None and self.proc.poll() is None
+
+    def start(self, cfg: dict) -> dict:
+        missing = validate(cfg)
+        if missing:
+            return {"ok": False, "errors": missing,
+                    "detail": "missing required fields: " + ", ".join(missing)}
+        if self.running():
+            return {"ok": False, "detail": f"a run is already active (study {self.study}); stop it first"}
+        tf = str((cfg.get("timeframes") or [cfg.get("timeframe")])[0])
+        cmd = build_command(cfg, tf)
+        self.prefix = study_prefix(cfg)
+        self.study = study_name(cfg, tf)
+        self.tf, self.cfg, self.target = tf, cfg, target_trials(cfg)
+        self.lines.clear()
+        self._total = 0
+        self.proc = subprocess.Popen(cmd, cwd=str(_PI), env=_child_env(cfg),
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                     text=True, bufsize=1, start_new_session=True)
+        self._reader = threading.Thread(target=self._pump, daemon=True)
+        self._reader.start()
+        return {"ok": True, "study": self.study, "tf": tf, "pid": self.proc.pid,
+                "target": self.target, "command": " ".join(cmd)}
+
+    def _pump(self):
+        try:
+            for line in self.proc.stdout:            # blocks until the child writes / closes
+                self.lines.append(line.rstrip("\n"))
+                self._total += 1
+        except Exception:
+            pass
+
+    def lines_since(self, cursor: int) -> tuple[int, list[str]]:
+        """Return (new_cursor, new_lines) for absolute cursor `cursor` — drives the SSE log stream
+        without duplicating or skipping even as the bounded buffer drops old lines."""
+        first = self._total - len(self.lines)        # absolute index of lines[0]
+        start = max(0, cursor - first)
+        return self._total, list(self.lines)[start:]
+
+    def stop(self) -> dict:
+        if self.proc is None:
+            return {"ok": True, "detail": "nothing running"}
+        if self.proc.poll() is not None:
+            return {"ok": True, "detail": f"already exited (rc={self.proc.returncode})"}
+        try:
+            pgid = os.getpgid(self.proc.pid)
+            os.killpg(pgid, signal.SIGTERM)          # real stop: signal the whole owned group
+            try:
+                self.proc.wait(timeout=8)
+            except subprocess.TimeoutExpired:
+                os.killpg(pgid, signal.SIGKILL)
+            return {"ok": True, "detail": "stopped"}
+        except ProcessLookupError:
+            return {"ok": True, "detail": "already gone"}
+
+    def state(self) -> dict:
+        rc = None if self.proc is None else self.proc.poll()
+        return {"running": self.running(), "study": self.study, "tf": self.tf,
+                "prefix": self.prefix, "pid": (self.proc.pid if self.proc else None),
+                "returncode": rc, "target": self.target, "log_lines": len(self.lines)}
+
+    def tail(self, n: int = 300) -> list[str]:
+        return list(self.lines)[-n:]
+
+    def done_count(self) -> int:
+        """Completed-trial count for the active study, via the existing trial_count.py (store-aware)."""
+        if not self.prefix or not self.tf:
+            return 0
+        try:
+            r = subprocess.run([_python(), "optimize/trial_count.py", self.tf, "--prefix", self.prefix],
+                               cwd=str(_PI), env=_child_env(self.cfg or {}),
+                               capture_output=True, text=True, timeout=20)
+            return int("".join(ch for ch in r.stdout if ch.isdigit()) or 0)
+        except Exception:
+            return 0
+
+
+_MGR = RunManager()

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_app.py
@@ -25,16 +25,27 @@ def test_plan_endpoint(monkeypatch):
     assert r.status_code == 200 and r.json()["recommended_trials"] == 5600
 
 
-def test_run_delegates(monkeypatch):
+def test_run_delegates_to_owned_runner(monkeypatch):
     seen = {}
-    monkeypatch.setattr(APP.control, "start", lambda cfg: seen.update({"cfg": cfg}) or {"ok": True, "launched": True})
-    r = client.post("/api/run", json={"sampler": "gp", "engine": "single"})
+    monkeypatch.setattr(APP.runner._MGR, "start", lambda cfg: seen.update({"cfg": cfg}) or {"ok": True, "pid": 42})
+    r = client.post("/api/run", json={"instrument": "NQ", "timeframes": ["4h"], "sampler": "gp"})
     assert r.status_code == 200 and r.json()["ok"] and seen["cfg"]["sampler"] == "gp"
 
 
+def test_run_reports_missing_fields(monkeypatch):
+    # real runner validation: an empty cfg returns ok:False + the missing fields (not a 500)
+    r = client.post("/api/run", json={})
+    assert r.status_code == 200 and r.json()["ok"] is False and "instrument" in r.json()["errors"]
+
+
 def test_stop_endpoint(monkeypatch):
-    monkeypatch.setattr(APP.control, "stop", lambda: {"ok": True})
+    monkeypatch.setattr(APP.runner._MGR, "stop", lambda: {"ok": True, "detail": "stopped"})
     assert client.post("/api/stop").json()["ok"]
+
+
+def test_run_state_endpoint():
+    st = client.get("/api/run/state").json()
+    assert "running" in st and "study" in st
 
 
 def test_resume_endpoint(monkeypatch):

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
@@ -1,0 +1,82 @@
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from optimize.dashboard import runner
+
+
+def test_validate_flags_missing_mandatory():
+    assert set(runner.validate({})) >= {"instrument", "timeframe"}
+    assert runner.validate({"instrument": "NQ", "timeframes": ["4h"], "trials_mode": "auto"}) == []
+    # 'one' mode needs a trials count
+    assert "trials" in runner.validate({"instrument": "NQ", "timeframes": ["4h"], "trials_mode": "one"})
+    # only/exclude modes need a selection
+    assert "only_indicators" in runner.validate(
+        {"instrument": "NQ", "timeframes": ["4h"], "indicator_mode": "only", "only_indicators": []})
+
+
+def test_study_prefix_is_selection_unique():
+    a = {"instrument": "NQ", "only_indicators": ["rsi"], "indicator_mode": "only"}
+    b = {"instrument": "NQ", "only_indicators": ["rsi", "macd"], "indicator_mode": "only"}
+    c = {"instrument": "ES", "only_indicators": ["rsi"], "indicator_mode": "only"}
+    assert runner.study_prefix(a) != runner.study_prefix(b)      # different indicators → different study
+    assert runner.study_prefix(a) != runner.study_prefix(c)      # different instrument → different study
+    assert runner.study_prefix(a) == runner.study_prefix(dict(a))  # stable for the same selection
+    assert runner.study_prefix(a).startswith("cc")
+
+
+def test_study_name_mirrors_optimizer():
+    cfg = {"instrument": "ES", "only_indicators": ["rsi"], "indicator_mode": "only"}
+    nm = runner.study_name(cfg, "4h")
+    assert nm == f"{runner.study_prefix(cfg)}_4h_ES"
+    assert runner.study_name({"instrument": "NQ"}, "1h") == f"{runner.study_prefix({'instrument':'NQ'})}_1h"
+
+
+def test_build_command_reflects_selection():
+    cmd = runner.build_command({"instrument": "GC", "timeframes": ["1h"], "trials_mode": "one",
+                                "trials": 8000, "only_indicators": ["rsi", "macd"], "indicator_mode": "only",
+                                "reference": "ES", "split_sltp": True, "cold_start": True, "max_enabled": 3}, "1h")
+    s = " ".join(cmd)
+    assert "optimize/optimizer.py 1h" in s and "--study-prefix cc" in s
+    assert "--trials 8000" in s and "--only-indicators rsi,macd" in s and "--reference ES" in s
+    assert "--split-sltp" in s and "--no-warm-start" in s and "--max-enabled 3" in s and "--instrument GC" in s
+
+
+def test_auto_mode_uses_auto_trials():
+    cmd = runner.build_command({"instrument": "NQ", "timeframes": ["4h"], "trials_mode": "auto"}, "4h")
+    assert "--auto-trials" in cmd and "--trials" not in cmd
+
+
+def test_start_rejects_invalid_cfg():
+    mgr = runner.RunManager()
+    r = mgr.start({})
+    assert r["ok"] is False and "instrument" in r["errors"]
+
+
+def test_lifecycle_owned_process_starts_streams_and_stops(monkeypatch):
+    """Real Popen lifecycle with a FAKE command (no optimizer): start → running + logs → stop → dead."""
+    fake = [sys.executable, "-u", "-c",
+            "import time,sys\n"
+            "print('trial 1 done', flush=True)\n"
+            "time.sleep(30)\n"]
+    monkeypatch.setattr(runner, "build_command", lambda cfg, tf: fake)
+    monkeypatch.setattr(runner, "target_trials", lambda cfg: 100)
+    mgr = runner.RunManager()
+    r = mgr.start({"instrument": "NQ", "timeframes": ["4h"], "trials_mode": "auto"})
+    assert r["ok"] is True and r["pid"] > 0
+    # give it a moment to print + be seen as running
+    for _ in range(50):
+        if mgr.tail() and mgr.running():
+            break
+        time.sleep(0.1)
+    assert mgr.running() is True
+    assert any("trial 1 done" in ln for ln in mgr.tail())
+    st = mgr.stop()
+    assert st["ok"] is True
+    time.sleep(0.3)
+    assert mgr.running() is False           # real stop — the owned process group is gone
+
+
+def test_stop_when_nothing_running_is_safe():
+    assert runner.RunManager().stop()["ok"] is True

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
@@ -19,11 +19,12 @@ export const api = {
   status: () => j('GET', '/api/status'),
   health: () => j('GET', '/api/health'),
 
-  // planning + lifecycle
+  // planning + lifecycle (run = owned subprocess driver, #28)
   plan: (cfg) => j('POST', '/api/plan', cfg),
   run: (cfg) => j('POST', '/api/run', cfg),
   resume: (cfg) => j('POST', '/api/resume', cfg),
   stop: () => j('POST', '/api/stop'),
+  runState: () => j('GET', '/api/run/state'),
 
   // live progress / ETA (snapshot poll)
   liveProgress: (tf, target) =>
@@ -39,8 +40,7 @@ export const api = {
   queueLaunch: (cfg) => j('POST', '/api/queue', cfg),
 }
 
-// SSE helper for the log/progress stream (GET /api/progress?tf=...).
-// Returns the EventSource so the caller can .close() it.
+// SSE helper for the legacy log/progress stream (GET /api/progress?tf=...).
 export function streamLogs(tf, onLine) {
   const es = new EventSource(`/api/progress?tf=${encodeURIComponent(tf)}`)
   es.onmessage = (e) => {
@@ -49,5 +49,19 @@ export function streamLogs(tf, onLine) {
       if (line != null) onLine(line)
     } catch { /* ignore malformed frames */ }
   }
+  return es
+}
+
+// SSE for the OWNED run's live stdout (GET /api/run/logs). onLine per line; onDone at exit.
+export function streamRunLogs(onLine, onDone) {
+  const es = new EventSource('/api/run/logs')
+  es.onmessage = (e) => {
+    try {
+      const d = JSON.parse(e.data)
+      if (d.line != null) onLine(d.line)
+      if (d.done) { onDone && onDone(d.returncode); es.close() }
+    } catch { /* ignore */ }
+  }
+  es.onerror = () => es.close()
   return es
 }

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
@@ -1,45 +1,55 @@
 <script setup>
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { store } from '../store.js'
-import { api } from '../api.js'
+import { api, streamRunLogs } from '../api.js'
 import ProgressBar from './ProgressBar.vue'
 import HealthStrip from './HealthStrip.vue'
-import LogTail from './LogTail.vue'
 
 const busy = ref(false)
 const msg = ref('')
-const prog = ref({ done: 0, target: 0, rate_per_min: 0, eta_seconds: null, feasible: null, elapsed_seconds: 0 })
-let progTimer = null
+const run = ref({ running: false, study: null, tf: null, pid: null, returncode: null, target: 0,
+                  progress: { done: 0, target: 0, rate_per_min: 0, eta_seconds: null, elapsed_seconds: 0 } })
+const logLines = ref([])
+let stateTimer = null
+let logEs = null
 
-const running = computed(() => !!store.status.running)
-// Progress + logs follow the first selected timeframe (P1 control panel tracks one study; the
-// full per-study matrix lives in the reporting column in P2).
-const tf = computed(() => (store.cfg.timeframes && store.cfg.timeframes[0]) || '4h')
+const missing = computed(() => store.runMissing())
+const canRun = computed(() => missing.value.length === 0 && !run.value.running && !busy.value)
 
-async function act(fn, label) {
+async function pollState() {
+  try { run.value = await api.runState() } catch { /* keep last */ }
+}
+
+async function start() {
   busy.value = true; msg.value = ''
   try {
-    const r = await fn()
-    msg.value = r && r.detail ? `${label}: ${r.detail.slice(-160)}` : `${label} ok`
-    await store.refreshStatus()
-  } catch (e) {
-    msg.value = `${label} failed: ${e.message}`
-  } finally {
-    busy.value = false
-  }
+    const r = await api.run(store.runCfg())
+    if (!r.ok) { msg.value = r.detail || 'could not start'; return }
+    msg.value = `started ${r.study} (pid ${r.pid}) → target ${r.target}`
+    logLines.value = []
+    if (logEs) logEs.close()
+    logEs = streamRunLogs(
+      (ln) => { logLines.value.push(ln); if (logLines.value.length > 500) logLines.value.splice(0, 200) },
+      (rc) => { msg.value += ` — finished (rc ${rc})`; pollState() },
+    )
+    await pollState()
+  } catch (e) { msg.value = `start failed: ${e.message}` }
+  finally { busy.value = false }
 }
-const start = () => act(() => api.run(store.launchCfg()), 'start')
-const resume = () => act(() => api.resume(store.launchCfg()), 'resume')
-const stop = () => act(() => api.stop(), 'stop')
 
-async function pollProgress() {
-  try { prog.value = await api.liveProgress(tf.value, 0) } catch { /* keep last */ }
+async function stop() {
+  busy.value = true
+  try { const r = await api.stop(); msg.value = r.detail || 'stopped'; await pollState() }
+  catch (e) { msg.value = `stop failed: ${e.message}` }
+  finally { busy.value = false }
 }
-watch(running, (on) => {
-  if (on && !progTimer) { pollProgress(); progTimer = setInterval(pollProgress, 3000) }
-  if (!on && progTimer) { clearInterval(progTimer); progTimer = null; pollProgress() }
-}, { immediate: true })
-onUnmounted(() => progTimer && clearInterval(progTimer))
+
+// poll owned-run state every 2s
+stateTimer = setInterval(pollState, 2000)
+pollState()
+onUnmounted(() => { if (stateTimer) clearInterval(stateTimer); if (logEs) logEs.close() })
+
+const shownLog = computed(() => logLines.value.slice(-200).join('\n') || '(no output yet)')
 </script>
 
 <template>
@@ -47,21 +57,37 @@ onUnmounted(() => progTimer && clearInterval(progTimer))
     <h2>Control</h2>
 
     <div class="row">
-      <button class="primary" :disabled="busy || running" @click="start">▶ Start</button>
-      <button :disabled="busy || running" @click="resume">⤴ Resume</button>
-      <button class="danger" :disabled="busy || !running" @click="stop">■ Stop</button>
+      <button class="primary" :disabled="!canRun" @click="start">▶ Run</button>
+      <button class="danger" :disabled="busy || !run.running" @click="stop">■ Stop</button>
+      <span v-if="run.running" class="pill run">running</span>
     </div>
+
+    <p v-if="missing.length" class="missing">
+      ⚠ Select before running: <b>{{ missing.join(', ') }}</b>
+    </p>
     <p v-if="msg" class="mono muted" style="word-break:break-word">{{ msg }}</p>
 
-    <h3>Progress <span class="pill">{{ tf }}</span></h3>
-    <ProgressBar
-      :done="prog.done" :target="prog.target" :rate-per-min="prog.rate_per_min"
-      :eta-seconds="prog.eta_seconds" :feasible="prog.feasible" :elapsed-seconds="prog.elapsed_seconds" />
+    <template v-if="run.study">
+      <h3>Progress <span class="pill">{{ run.study }}</span></h3>
+      <ProgressBar
+        :done="run.progress?.done || 0" :target="run.progress?.target || run.target"
+        :rate-per-min="run.progress?.rate_per_min || 0" :eta-seconds="run.progress?.eta_seconds"
+        :elapsed-seconds="run.progress?.elapsed_seconds || 0" />
+      <p class="mono muted" v-if="!run.running && run.returncode != null">exited (rc {{ run.returncode }})</p>
+    </template>
 
     <h3>Health</h3>
     <HealthStrip />
 
-    <h3>Logs</h3>
-    <LogTail :tf="tf" />
+    <h3>Live output</h3>
+    <pre class="log mono">{{ shownLog }}</pre>
   </section>
 </template>
+
+<style scoped>
+.missing { color: var(--warn); font-size: 13px; margin: 6px 0; }
+.pill.run { color: var(--ok); border-color: var(--ok); }
+.log { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px;
+  height: 240px; overflow: auto; white-space: pre-wrap; word-break: break-word; font-size: 11px;
+  color: var(--muted); margin: 6px 0 0; }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
@@ -72,4 +72,25 @@ export const store = reactive({
     if (c.indicator_mode === 'exclude' && c.exclude_indicators.length) out.exclude_indicators = c.exclude_indicators
     return out
   },
+
+  // The single-study cfg for the Run button (owned driver): first selected instrument + timeframe.
+  runCfg() {
+    const c = this.launchCfg()
+    c.instrument = this.cfg.instruments[0] || ''
+    c.timeframes = this.cfg.timeframes.length ? [this.cfg.timeframes[0]] : []
+    c.indicator_mode = this.cfg.indicator_mode
+    return c
+  },
+
+  // Mandatory fields missing for a run (mirrors runner.validate on the backend) — gates the Run button.
+  runMissing() {
+    const c = this.runCfg()
+    const m = []
+    if (!c.instrument) m.push('instrument')
+    if (!c.timeframes.length) m.push('timeframe')
+    if (c.trials_mode === 'one' && !(Number(c.trials) > 0)) m.push('trials count')
+    if (this.cfg.indicator_mode === 'only' && !this.cfg.only_indicators.length) m.push('≥1 indicator (only)')
+    if (this.cfg.indicator_mode === 'exclude' && !this.cfg.exclude_indicators.length) m.push('≥1 indicator (exclude)')
+    return m
+  },
 })


### PR DESCRIPTION
Closes #28. Fixes the freeze / no-live-feedback / can't-stop / same-`wsh4_4h`-for-every-option bugs found driving the live dashboard.

## Change
Replaces the fire-and-forget `remote_wsi.sh` launch (detached `setsid` workers) for the **Run** button with a control-plane-**owned** subprocess:
- **runner.py** — `RunManager` drives `optimizer.py` via `Popen` in its own process group: non-blocking start, live stdout capture, **Stop = SIGTERM→SIGKILL group sweep** (real, immediate), and a **per-selection study name** (`cc<hash>_<tf>[_inst]`) so each config is a fresh study instead of reusing a target-met `wsh4_4h`.
- **Mandatory-field validation** — server rejects + client gates the Run button (shows what's missing).
- **app.py** — `/api/run` → owned runner (returns at once), `/api/stop` → killpg, new `/api/run/state` (running + store-backed progress/ETA) and `/api/run/logs` (SSE of owned stdout, monotonic cursor).
- **ControlPanel.vue** rebuilt around it.

## Verified live on the server (localhost:8350)
- empty cfg → `{ok:false, errors:[instrument,timeframe]}`
- start NQ/4h/2-trials → non-blocking, study `cc07ac9b51_4h`, ran to `done:2/2`, rc 0
- live `/api/run/logs` streamed the optimizer plan + trials
- Stop mid-100-trial run → `running:false`, rc −15, **0 optimizer procs left immediately**

Tests: 8 runner (incl. real Popen start→stream→stop) + updated app tests; **59 dashboard tests green**. No scoring-engine change (golden 6/6 re-checked).

Part of epic #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)