### PR TITLE
Indicators: leading/lagging/filter classification + dashboard cadence grouping (closes #30)

### DIFF
--- a/subprojects/Parametric-Indicators/docs/extra-indicators/INDICATOR-LEADING-LAGGING.md
+++ b/subprojects/Parametric-Indicators/docs/extra-indicators/INDICATOR-LEADING-LAGGING.md
@@ -1,0 +1,209 @@
+# Indicators split: Leading vs Lagging (165-indicator library)
+
+**Status:** proposal for review (issue #30). Classify the whole library on the *leading ↔ lagging* axis, first as this document; once you approve it, we mirror the grouping into the dashboard indicator picker (next to the existing **family** grouping).
+
+---
+
+## 1. The two definitions (plain language)
+
+- **Lagging indicator** — *follows* price. It is built from an average / cumulative sum / trailing calculation of **past** prices, so it turns **after** the move has already begun. Its job is **confirmation** ("the trend is real, and up"). Trade-off: reliable, but late. → *Moving averages, MACD, ADX, Supertrend, Bollinger…*
+- **Leading indicator** — tries to *precede* price. It reacts to the **rate of change / stretch / cycle phase** of price and fires **before or at** the turn, so it can **anticipate** ("momentum is fading — a reversal is near"). Trade-off: early, but noisier / more false signals. → *RSI, Stochastic, pivots, order blocks, Awesome Oscillator…*
+
+**Rule of thumb used here:** classify by the indicator's **core mechanism**, not by how a trader happens to use it.
+- Averages / cumulative sums / trailing stops / regression on past bars → **Lagging**.
+- Momentum (rate-of-change), overbought/oversold oscillators, pre-drawn price levels, cycle/phase and reversal detectors, mean-reversion, volume-flow divergence → **Leading**.
+
+## 2. The honest caveat: a third, non-directional axis
+
+A large block of this library does **not** predict *direction* at all — it measures **regime / volatility / relationship**, and in this system those are wired as **veto filters** ("don't trade when it's too choppy / decoupled"). They sit on the *lagging* side by construction (computed from past bars), but calling them "lagging **direction** signals" is misleading. They are flagged **⚙ Filter** below.
+
+Two more markers:
+- **◑ Hybrid** — genuinely debatable; placed in the group its *core* leans toward, with a one-line reason.
+- Volume indicators are marked **Leading** by the accumulation/distribution convention (volume is said to precede price), but in practice most act as **confirming** tools — treat that group's "Leading" label as "leading-or-confirming."
+
+**So the practical picture is three buckets, not two:** **Leading**, **Lagging**, and **⚙ Filter/Regime** (non-directional). Section 6 recommends how to present that in the dashboard.
+
+---
+
+## 3. Quick reference — the two groups (flat lists)
+
+### 🟢 LEADING (anticipate the turn)
+`rsi` `stochastic` `mfi` `cci` `obv` · `order_block` `fvg` `ifvg` `breaker` `cisd`
+`rsi_cutler` `rsi_connors` `stoch_rsi` `kdj` `williams_r` `cmo` `ultimate_osc` `smi` `rmi` `cmo_chande_dmi` `wavetrend` `pgo` `psy` `momentum` `roc` `disparity` `bias` `balance_of_power` `tsi` `rvgi` `fisher` `derivative_osc` `ergodic_osc`
+`qqe`◑ `elder_ray`◑ · `rvi_dorsey`
+`ad_line` `cmf` `chaikin_osc` `pvt` `tvi` `nvi` `pvi` `eom` `force_index` `klinger` `vol_osc` `demand_index` `twiggs_mf` `wvad` `bw_mfi` `vzo`
+`ichimoku_cloud` `pivot_floor` `pivot_woodie` `pivot_demark` `pivot_camarilla` `pivot_fib` `cpr`
+`fractals` `awesome_osc`◑ `accel_osc` `elliott_wave_osc`◑
+`zscore` `demarker` `td_rei`
+`roofing`◑ `bandpass` `laguerre_rsi` `schaff_trend_cycle` `cyber_cycle` `center_of_gravity` `sinewave` `hilbert_cycle` `td_sequential` `td_combo` `ou_halflife`◑
+`rolling_beta` `cointegration` `pca_factor`◑
+
+### 🔵 LAGGING (confirm the trend)
+`ema_trend` `sma_trend` `macd`◑ `vwap` `keltner` `bollinger`⚙ `adx`⚙ `structure_trend`
+`wma` `rma` `dema` `tema` `tma` `hma` `zlema` `sine_wma` `lsma` `vwma` `kama` `vidya` `alma` `t3` `mcginley` `evwma` `gmma` `ma_envelope` `ma_displaced`
+`ppo` `apo` `di_cross` `aroon`◑ `aroon_osc`◑ `psar` `vortex` `supertrend` `trix`◑ `kst` `coppock` `dpo`◑ `trend_intensity` `linreg_slope` `linreg_channel` `chandelier`⚙ `chande_kroll`⚙ `elder_impulse`◑ `asi` `expma` `dma` `bbi`
+`donchian`◑ `anchored_vwap` `ichimoku_tk_cross` `ichimoku_chikou` `alligator` `gator`
+`super_smoother` `frama` `mama_fama`◑ `jma` `emd`◑ `kalman`
+
+### ⚙ FILTER / REGIME (non-directional — sit on the lagging side, but gate rather than point)
+Volatility: `atr_norm` `stddev` `hist_vol` `parkinson` `garman_klass` `rogers_satchell` `yang_zhang` `ulcer` `vol_ratio` `starc` `accel_bands` `proj_bands` `chaikin_vol` `mass_index`◑ `choppiness`◑ `ttm_squeeze`◑
+Statistical/regime: `hurst_exp` `dfa` `autocorr` `linreg_r2` `efficiency_ratio` `garch_ewma` `rolling_corr` `volume_ratio_asia`
+
+*(If you want a strict two-way split for the dashboard, the ⚙ Filter set folds into **Lagging**; §6.)*
+
+---
+
+## 4. Full breakdown, by family (traceable)
+
+`class`: **L**=Leading · **G**=laGging · **⚙**=Filter/regime · **◑**=hybrid (note).
+
+### builtin (18)
+| key | label | class | why |
+|---|---|---|---|
+| ema_trend | EMA trend | G | moving average |
+| sma_trend | SMA trend | G | moving average |
+| macd | MACD | G ◑ | MA difference (lag); histogram *divergence* can lead |
+| vwap | VWAP | G | cumulative volume-weighted average (a reference level) |
+| keltner | Keltner | G | EMA + ATR bands |
+| obv | OBV | L | volume-flow; accumulation precedes price / diverges early |
+| cci | CCI breakout | L | momentum oscillator (deviation from mean) |
+| rsi | RSI | L | momentum / overbought-oversold |
+| stochastic | Stochastic | L | position-in-range momentum |
+| mfi | MFI | L | volume-weighted RSI |
+| bollinger | Bollinger (veto) | G ⚙ | SMA + σ bands; squeeze *can* anticipate expansion |
+| adx | ADX (veto) | G ⚙ | trend-**strength** filter, non-directional |
+| structure_trend | Structure trend (SMC) | G | trend structure confirms after the swing |
+| order_block | Order block (SMC) | L | pre-drawn supply/demand zone → anticipates reaction |
+| fvg | Fair value gap (SMC) | L | imbalance zone price is expected to revisit |
+| ifvg | Inverse FVG (SMC) | L | flipped imbalance → anticipatory |
+| breaker | Breaker block (SMC) | L | failed OB → reversal zone |
+| cisd | CISD delivery shift (SMC) | L | change-in-state-of-delivery → early reversal cue |
+
+### ma — moving averages (19) — **all Lagging by definition**
+`wma` `rma` `dema` `tema` `tma` `hma` `zlema` `sine_wma` `lsma` `vwma` `kama` `vidya` `alma` `t3` `mcginley` `evwma` `gmma` `ma_envelope`(⚙ on its overextension-veto side) `ma_displaced` → **G**.
+*Note:* the adaptive / "reduced-lag" ones (`hma`, `zlema`, `t3`, `kama`, `vidya`, `alma`, `dema`, `tema`) still **lag** — they just lag *less*. They are not leading.
+
+### oscillator (23) — **all Leading**
+`rsi_cutler` `rsi_connors` `stoch_rsi` `kdj` `williams_r` `cmo` `ultimate_osc` `smi` `rmi` `cmo_chande_dmi` `wavetrend` `pgo` `psy` `momentum` `roc` `disparity` `bias` `balance_of_power` `tsi`◑ `rvgi` `fisher` `derivative_osc` `ergodic_osc`◑ → **L**.
+*◑ note:* `tsi` and `ergodic_osc` are **double-smoothed** momentum — leading in intent, but the smoothing adds lag.
+
+### trend (24) — mostly Lagging
+| key | label | class | why |
+|---|---|---|---|
+| ppo / apo | PPO / APO | G | MACD-family (MA difference) |
+| di_cross | DMI ±DI cross | G | directional movement, smoothed |
+| aroon / aroon_osc | Aroon / Aroon Osc | G ◑ | trend-family, but flags new trends relatively early |
+| psar | Parabolic SAR | G | trailing stop-and-reverse |
+| vortex | Vortex | G | trend via true-range sums |
+| supertrend | Supertrend | G | ATR trailing trend |
+| trix | TRIX | G ◑ | triple-smoothed (very lagging); zero-cross/divergence can lead |
+| kst | Know Sure Thing | G | summed, smoothed ROC |
+| coppock | Coppock Curve | G | long, smoothed momentum |
+| dpo | Detrended Price Osc | G ◑ | detrended **cycle** tool; centered/displaced, not real-time predictive |
+| trend_intensity | Trend Intensity | G ⚙ | strength gauge |
+| linreg_slope / linreg_channel | Lin-Reg slope / channel | G / G⚙ | regression on past bars |
+| chandelier / chande_kroll | Chandelier / Chande-Kroll | G ⚙ | ATR trailing **stops** |
+| qqe | QQE | **L** ◑ | RSI core (leading) wrapped in a smoothed ATR band |
+| elder_ray | Elder Ray | **L** ◑ | bull/bear power (price − EMA); diverges ahead of turns |
+| elder_impulse | Elder Impulse | G ◑ | EMA + MACD state → trend/momentum blend |
+| asi | Accum. Swing Index | G | cumulative swing → trend |
+| expma / dma / bbi | EXPMA / DMA / BBI | G | MA crosses / averages of MAs |
+
+### volatility (18) — **⚙ Filter/regime** (non-directional), lagging by construction
+`atr_norm` `stddev` `hist_vol` `parkinson` `garman_klass` `rogers_satchell` `yang_zhang` `ulcer` `vol_ratio` `starc` `accel_bands` `proj_bands` `chaikin_vol` → **G⚙** (measure realized range; used as vetoes).
+`mass_index`◑ `choppiness`◑ `ttm_squeeze`◑ → **G⚙**, but **anticipatory**: they are used to *pre-empt* a volatility **expansion** (a leading use, for volatility not direction).
+`donchian` → **G ◑** (channel midline lags; a channel **breakout** is an early/leading trigger).
+`rvi_dorsey` (Relative Volatility Index) → **L** (a volatility-based *momentum oscillator*).
+
+### volume (18) — **Leading-or-confirming** (accumulation precedes price)
+`ad_line` `cmf` `chaikin_osc` `pvt` `tvi` `nvi` `pvi` `eom`◑ `force_index` `klinger` `vol_osc`◑ `demand_index` `twiggs_mf` `wvad` `bw_mfi`◑ `vzo` → **L** (flow / divergence).
+`anchored_vwap` → **G** (cumulative average from an anchor — a lagging reference level).
+`volume_ratio_asia` → **⚙** (session-relative volume → regime filter).
+
+### levels (9) — pre-drawn price levels → mostly Leading
+| key | label | class | why |
+|---|---|---|---|
+| ichimoku_tk_cross | Tenkan/Kijun cross | G | midpoint-MA cross → lags |
+| ichimoku_cloud | Kumo cloud | **L** | spans projected **26 bars forward** → forward-looking |
+| ichimoku_chikou | Chikou span | G | lagging span (price shifted 26 **back**) |
+| pivot_floor / woodie / demark / camarilla / fib | pivots | **L** | levels computed **before** the session for expected S/R |
+| cpr | Central Pivot Range | **L** | next-session value area, pre-drawn |
+
+### bill_williams (6)
+| key | label | class | why |
+|---|---|---|---|
+| alligator | Alligator | G | three smoothed MAs |
+| gator | Gator Osc | G | Alligator-derived (MA convergence) |
+| fractals | Williams Fractals | **L** | local reversal pivots |
+| awesome_osc | Awesome Osc | **L** ◑ | momentum (MA-of-median difference) |
+| accel_osc | Accelerator Osc | **L** | acceleration of momentum → leads AO |
+| elliott_wave_osc | Elliott Wave Osc | **L** ◑ | MA-difference momentum used to time waves |
+
+### quant (8)
+| key | label | class | why |
+|---|---|---|---|
+| zscore | Z-Score | **L** | standardized stretch → mean-reversion signal |
+| demarker | DeMarker | **L** | exhaustion oscillator |
+| td_rei | TD Range Expansion Index | **L** | range-expansion → reversal timing |
+| hurst_exp | Hurst Exponent | ⚙ | persistence/regime (trending vs mean-reverting) |
+| dfa | DFA exponent | ⚙ | detrended-fluctuation regime measure |
+| autocorr | Autocorrelation | ⚙ | serial-dependence regime filter |
+| linreg_r2 | Lin-Reg R² | ⚙ | trend-**quality** (how linear), non-directional |
+| efficiency_ratio | Kaufman Efficiency Ratio | ⚙ | trend efficiency (signal/noise) filter |
+
+### dsp — Ehlers / cycle / signal-processing (18)
+| key | label | class | why |
+|---|---|---|---|
+| super_smoother | SuperSmoother | G | low-lag smoother (still an average) |
+| frama | Fractal Adaptive MA | G | adaptive MA |
+| mama_fama | MESA Adaptive MA | G ◑ | adaptive MA (low-lag, but MA) |
+| jma | Jurik MA | G | low-lag smoother |
+| kalman | Kalman trend | G | recursive state estimate of the mean |
+| emd | Ehlers EMD | G ◑ | decomposition → trend **and** cycle mode |
+| roofing | Roofing filter | **L** ◑ | band-passes the tradeable **cycle** |
+| bandpass | Band-Pass | **L** | isolates the dominant cycle |
+| laguerre_rsi | Laguerre RSI | **L** | fast, low-lag RSI |
+| schaff_trend_cycle | Schaff Trend Cycle | **L** | cycle-normalized MACD → early turns |
+| cyber_cycle | Cyber Cycle | **L** | cycle-component extractor |
+| center_of_gravity | Center of Gravity | **L** | near-zero-lag turning-point oscillator |
+| sinewave | Sine Wave | **L** | cycle **phase** → calls the turn ahead of price |
+| hilbert_cycle | Hilbert dominant cycle | **L** ⚙ | measures the cycle (used as a veto) |
+| td_sequential | TD Sequential | **L** | counts toward an exhaustion **reversal** |
+| td_combo | TD Combo | **L** | perfected reversal count |
+| ou_halflife | OU half-life | **L** ◑ | mean-reversion speed → anticipates reversion (veto here) |
+| garch_ewma | EWMA/GARCH vol | ⚙ | volatility **forecast** filter |
+
+### cross_series (4) — relational (need a reference instrument)
+| key | label | class | why |
+|---|---|---|---|
+| rolling_beta | Cross-beta lead | **L** | uses the reference's move to lead this instrument |
+| cointegration | Pair spread z-score | **L** | spread mean-reversion → anticipatory |
+| pca_factor | PCA common factor | **L** ◑ | common-factor direction (leading-ish) |
+| rolling_corr | Cross-correlation | ⚙ | decoupling **filter** (veto), non-directional |
+
+---
+
+## 5. Counts
+
+| Bucket | Count | Notes |
+|---|---:|---|
+| 🟢 Leading | **80** | oscillators (23) + volume-flow (16) + leading builtin/SMC (10) + dsp cycle/reversal (11) + levels (7) + bill-williams momentum (4) + quant osc (3) + cross-series (3) + `qqe`/`elder_ray` (2) + `rvi_dorsey` (1) |
+| 🔵 Lagging | **61** | all MAs (19) + trend-followers (22) + lagging builtin (8) + dsp smoothers (6) + `alligator`/`gator` (2) + `ichimoku` tk/chikou (2) + `donchian` (1) + `anchored_vwap` (1) |
+| ⚙ Filter / Regime | **24** | volatility vetoes (16) + statistical/regime (`hurst_exp` `dfa` `autocorr` `linreg_r2` `efficiency_ratio` = 5) + `garch_ewma` + `volume_ratio_asia` + `rolling_corr` |
+| **Total** | **165** | 80 + 61 + 24 |
+
+*(Exact members are the tables above. Note: the `G⚙` items — `bollinger` `adx` `trend_intensity` `linreg_channel` `chandelier` `chande_kroll` — are counted under **Lagging**; they're MA/ATR/stop-based and directional-ish, so they stay lagging even though they act as vetoes. The 24 in the Filter bucket are the *purely* non-directional ones.)*
+
+## 6. Recommendation for the dashboard (when you approve)
+
+Two viable groupings for the indicator picker:
+
+- **Option A — strict two groups (as you asked):** **Leading** and **Lagging**, with the ⚙ Filter/regime set folded into **Lagging** (they are computed from past data and used as confirmation/vetoes). Simple; matches "leading vs lagging."
+- **Option B — three groups (more honest):** **Leading**, **Lagging**, **Filter/Regime**. The third bucket is exactly the volatility + statistical vetoes; separating them makes it obvious they gate rather than point. *(Recommended — it also maps cleanly onto how the optimizer already treats them as vetoes.)*
+
+Either way: keep the existing **family** grouping too, and add lead/lag as a second toggle/tag (an indicator has both a family *and* a lead/lag class), so you can select e.g. "all Leading oscillators" or "Lagging MAs only."
+
+**Open questions for you:**
+1. Option **A** (2 groups) or **B** (3 groups, recommended)?
+2. Any specific ◑-hybrids you want moved (e.g. treat `qqe`/`elder_ray` as Lagging with their trend family, or `donchian` as Leading for breakouts)?
+3. Should volume be labelled **Leading** (accumulation-precedes-price convention) or a separate **Confirming** tag?

--- a/subprojects/Parametric-Indicators/docs/extra-indicators/INDICATOR-LEADING-LAGGING.md
+++ b/subprojects/Parametric-Indicators/docs/extra-indicators/INDICATOR-LEADING-LAGGING.md
@@ -1,6 +1,6 @@
 # Indicators split: Leading vs Lagging (165-indicator library)
 
-**Status:** proposal for review (issue #30). Classify the whole library on the *leading ↔ lagging* axis, first as this document; once you approve it, we mirror the grouping into the dashboard indicator picker (next to the existing **family** grouping).
+**Status:** ✅ APPROVED + WIRED (issue #30). Decision: **three groups** (Leading / Lagging / **Filter-Regime**), hybrids kept as classified below, volume labelled **Leading**. The classification is emitted by `library.schema()` as a `lead_lag` field per indicator (`leading`/`lagging`/`filter`) and the dashboard indicator picker can now **group by cadence** and **filter by cadence** (a per-row badge shows each indicator's class), alongside the existing **family** grouping.
 
 ---
 

--- a/subprojects/Parametric-Indicators/indicators/library.py
+++ b/subprojects/Parametric-Indicators/indicators/library.py
@@ -386,11 +386,58 @@ for _m in _SCHOOLS:
     for _k in _m.SCHEMA:
         _KEY_FAMILY[_k] = _fam
 
+# Signal cadence per key — leading (anticipate the turn) / lagging (confirm the trend) /
+# filter (non-directional regime/volatility veto). See docs/extra-indicators/INDICATOR-LEADING-LAGGING.md
+# (issue #30). Everything not listed defaults to "lagging". Counts: leading 80, filter 24, lagging 61.
+_LEADING = {
+    # builtin momentum + SMC zones
+    "obv", "cci", "rsi", "stochastic", "mfi",
+    "order_block", "fvg", "ifvg", "breaker", "cisd",
+    # oscillators (all 23)
+    "rsi_cutler", "rsi_connors", "stoch_rsi", "kdj", "williams_r", "cmo", "ultimate_osc", "smi",
+    "rmi", "cmo_chande_dmi", "wavetrend", "pgo", "psy", "momentum", "roc", "disparity", "bias",
+    "balance_of_power", "tsi", "rvgi", "fisher", "derivative_osc", "ergodic_osc",
+    # momentum-core trend hybrids + volatility-momentum
+    "qqe", "elder_ray", "rvi_dorsey",
+    # volume flow / divergence
+    "ad_line", "cmf", "chaikin_osc", "pvt", "tvi", "nvi", "pvi", "eom", "force_index", "klinger",
+    "vol_osc", "demand_index", "twiggs_mf", "wvad", "bw_mfi", "vzo",
+    # pre-drawn levels
+    "ichimoku_cloud", "pivot_floor", "pivot_woodie", "pivot_demark", "pivot_camarilla", "pivot_fib", "cpr",
+    # bill williams momentum / reversal
+    "fractals", "awesome_osc", "accel_osc", "elliott_wave_osc",
+    # quant oscillators
+    "zscore", "demarker", "td_rei",
+    # dsp cycle / reversal / mean-reversion
+    "roofing", "bandpass", "laguerre_rsi", "schaff_trend_cycle", "cyber_cycle", "center_of_gravity",
+    "sinewave", "hilbert_cycle", "td_sequential", "td_combo", "ou_halflife",
+    # cross-series predictive
+    "rolling_beta", "cointegration", "pca_factor",
+}
+_FILTER = {
+    # volatility vetoes (non-directional)
+    "atr_norm", "stddev", "hist_vol", "parkinson", "garman_klass", "rogers_satchell", "yang_zhang",
+    "ulcer", "vol_ratio", "starc", "accel_bands", "proj_bands", "chaikin_vol", "mass_index",
+    "choppiness", "ttm_squeeze",
+    # statistical / regime
+    "hurst_exp", "dfa", "autocorr", "linreg_r2", "efficiency_ratio", "garch_ewma",
+    "volume_ratio_asia", "rolling_corr",
+}
+
+
+def _lead_lag(key: str) -> str:
+    if key in _LEADING:
+        return "leading"
+    if key in _FILTER:
+        return "filter"
+    return "lagging"
+
 
 def schema():
-    """UI schema for every registered indicator (key + family + label + default mode + tunable params).
+    """UI schema for every registered indicator (key + family + lead_lag + label + default mode + params).
     Plus the shared enums. The frontend builds the whole indicator panel from this — no hardcoding."""
-    inds = [dict(key=k, family=_KEY_FAMILY.get(k, "builtin"), **SCHEMA[k]) for k in REGISTRY]
+    inds = [dict(key=k, family=_KEY_FAMILY.get(k, "builtin"), lead_lag=_lead_lag(k), **SCHEMA[k])
+            for k in REGISTRY]
     return {"indicators": inds, "modes": list(MODES), "retrace_units": list(RETRACE_UNITS),
             "retrace_default": {"amount": 0.0, "unit": "atr_mult"}, "wait_default": 0, "k_default": 1,
             "gen_params": [{"name": "swing_l", "default": 2, "min": 1, "max": 20, "step": 1},

--- a/subprojects/Parametric-Indicators/indicators/test_schema_family.py
+++ b/subprojects/Parametric-Indicators/indicators/test_schema_family.py
@@ -22,3 +22,22 @@ def test_family_assignment_is_correct():
     assert fam["cointegration"] == "cross_series"
     assert fam["super_smoother"] == "dsp"
     assert fam["ema_trend"] == "builtin"      # one of the 18 originals
+
+
+def test_every_indicator_has_a_lead_lag_class():
+    inds = library.schema()["indicators"]
+    ll = {i["key"]: i["lead_lag"] for i in inds}
+    assert all(v in ("leading", "lagging", "filter") for v in ll.values())
+    from collections import Counter
+    c = Counter(ll.values())
+    assert c == {"leading": 80, "lagging": 61, "filter": 24}, dict(c)   # doc #30 counts
+
+
+def test_lead_lag_spot_checks():
+    ll = {i["key"]: i["lead_lag"] for i in library.schema()["indicators"]}
+    assert ll["ema_trend"] == "lagging" and ll["wma"] == "lagging"        # moving averages
+    assert ll["rsi"] == "leading" and ll["stoch_rsi"] == "leading"        # oscillators
+    assert ll["order_block"] == "leading" and ll["pivot_floor"] == "leading"
+    assert ll["qqe"] == "leading" and ll["elder_ray"] == "leading"        # momentum-core hybrids
+    assert ll["atr_norm"] == "filter" and ll["hurst_exp"] == "filter"     # regime/vol vetoes
+    assert ll["supertrend"] == "lagging" and ll["donchian"] == "lagging"

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/IndicatorPicker.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/IndicatorPicker.vue
@@ -2,9 +2,11 @@
 import { computed, ref } from 'vue'
 import { store } from '../store.js'
 
-// The active selection list is `only_indicators` or `exclude_indicators`, chosen by the mode.
-// mode 'all' = search over everything (no restriction); 'only' = restrict; 'exclude' = all-except.
+// Active selection list = only_indicators or exclude_indicators, chosen by mode.
 const search = ref('')
+const groupBy = ref('family')                       // 'family' | 'lead_lag'
+const classOn = ref({ leading: true, lagging: true, filter: true })   // cadence filter (narrows the list)
+
 const mode = computed({
   get: () => store.cfg.indicator_mode,
   set: (v) => { store.cfg.indicator_mode = v },
@@ -12,15 +14,27 @@ const mode = computed({
 const activeList = computed(() =>
   mode.value === 'exclude' ? store.cfg.exclude_indicators : store.cfg.only_indicators)
 
+const LL_LABEL = { leading: '🟢 Leading', lagging: '🔵 Lagging', filter: '⚙ Filter / Regime' }
+const LL_ORDER = { leading: 0, lagging: 1, filter: 2 }
+
 const groups = computed(() => {
   const q = search.value.trim().toLowerCase()
   const by = {}
   for (const ind of store.config.indicators) {
+    const ll = ind.lead_lag || 'lagging'
+    if (!classOn.value[ll]) continue                              // cadence filter
     if (q && !ind.key.toLowerCase().includes(q) && !(ind.family || '').includes(q)) continue
-    ;(by[ind.family || 'other'] ||= []).push(ind)
+    const gkey = groupBy.value === 'lead_lag' ? ll : (ind.family || 'other')
+    ;(by[gkey] ||= []).push(ind)
   }
-  return Object.entries(by).sort((a, b) => a[0].localeCompare(b[0]))
+  const entries = Object.entries(by)
+  if (groupBy.value === 'lead_lag')
+    entries.sort((a, b) => LL_ORDER[a[0]] - LL_ORDER[b[0]])
+  else
+    entries.sort((a, b) => a[0].localeCompare(b[0]))
+  return entries
 })
+const groupLabel = (g) => (groupBy.value === 'lead_lag' ? (LL_LABEL[g] || g) : g)
 
 const isSel = (k) => activeList.value.includes(k)
 function toggle(k) {
@@ -33,11 +47,10 @@ function familyState(members) {
   const n = keys.filter(isSel).length
   return n === 0 ? 'none' : n === keys.length ? 'all' : 'some'
 }
-function toggleFamily(members) {
+function toggleGroup(members) {
   const keys = members.map((m) => m.key)
-  const state = familyState(members)
   const l = activeList.value
-  if (state === 'all') {
+  if (familyState(members) === 'all') {
     for (const k of keys) { const i = l.indexOf(k); if (i >= 0) l.splice(i, 1) }
   } else {
     for (const k of keys) if (!l.includes(k)) l.push(k)
@@ -54,26 +67,38 @@ const selectedCount = computed(() => (mode.value === 'all' ? 0 : activeList.valu
       <label><input type="radio" value="exclude" v-model="mode" /> all except</label>
       <span class="pill" v-if="mode !== 'all'">{{ selectedCount }} selected</span>
     </div>
-    <div class="row" v-if="mode !== 'all'">
-      <input v-model="search" placeholder="search indicator / family…" style="flex:1" />
-    </div>
 
-    <div class="picker" v-if="mode !== 'all'">
-      <details v-for="[fam, members] in groups" :key="fam" open>
-        <summary>
-          <label @click.prevent="toggleFamily(members)">
-            <input type="checkbox"
-                   :checked="familyState(members) === 'all'"
-                   :indeterminate.prop="familyState(members) === 'some'" />
-            <b>{{ fam }}</b> <span class="muted">({{ members.length }})</span>
+    <template v-if="mode !== 'all'">
+      <div class="row">
+        <input v-model="search" placeholder="search indicator / family…" style="flex:1" />
+      </div>
+      <div class="row">
+        <label class="muted">group by</label>
+        <label><input type="radio" value="family" v-model="groupBy" /> family</label>
+        <label><input type="radio" value="lead_lag" v-model="groupBy" /> cadence</label>
+        <span class="sep"></span>
+        <label class="ll leading"><input type="checkbox" v-model="classOn.leading" /> leading</label>
+        <label class="ll lagging"><input type="checkbox" v-model="classOn.lagging" /> lagging</label>
+        <label class="ll filter"><input type="checkbox" v-model="classOn.filter" /> filter</label>
+      </div>
+
+      <div class="picker">
+        <details v-for="[g, members] in groups" :key="g" open>
+          <summary>
+            <label @click.prevent="toggleGroup(members)">
+              <input type="checkbox" :checked="familyState(members) === 'all'"
+                     :indeterminate.prop="familyState(members) === 'some'" />
+              <b>{{ groupLabel(g) }}</b> <span class="muted">({{ members.length }})</span>
+            </label>
+          </summary>
+          <label v-for="ind in members" :key="ind.key" class="ind">
+            <input type="checkbox" :checked="isSel(ind.key)" @change="toggle(ind.key)" />
+            <span class="mono">{{ ind.key }}</span>
+            <span class="badge" :class="ind.lead_lag">{{ (ind.lead_lag || 'lagging')[0].toUpperCase() }}</span>
           </label>
-        </summary>
-        <label v-for="ind in members" :key="ind.key" class="ind">
-          <input type="checkbox" :checked="isSel(ind.key)" @change="toggle(ind.key)" />
-          <span class="mono">{{ ind.key }}</span>
-        </label>
-      </details>
-    </div>
+        </details>
+      </div>
+    </template>
     <p v-else class="muted">All {{ store.config.indicators.length }} indicators are in the search
       (optimizer decides which to enable).</p>
   </div>
@@ -83,4 +108,12 @@ const selectedCount = computed(() => (mode.value === 'all' ? 0 : activeList.valu
 .picker { max-height: 320px; overflow: auto; border: 1px solid var(--border); border-radius: 6px; padding: 8px; }
 summary { cursor: pointer; padding: 3px 0; }
 .ind { display: flex; gap: 6px; align-items: center; padding: 1px 0 1px 20px; font-size: 12px; }
+.sep { width: 1px; height: 16px; background: var(--border); margin: 0 4px; }
+.ll { font-size: 12px; }
+.ll.leading { color: var(--ok); } .ll.lagging { color: var(--accent); } .ll.filter { color: var(--warn); }
+.badge { margin-left: auto; font-size: 10px; width: 15px; height: 15px; line-height: 15px; text-align: center;
+  border-radius: 3px; border: 1px solid var(--border); color: var(--muted); }
+.badge.leading { color: var(--ok); border-color: var(--ok); }
+.badge.lagging { color: var(--accent); border-color: var(--accent); }
+.badge.filter { color: var(--warn); border-color: var(--warn); }
 </style>


### PR DESCRIPTION
Closes #30. Splits the 165-indicator library on the leading↔lagging axis.

**Decision (approved):** three groups — **Leading (80) / Lagging (61) / Filter-Regime (24)**; volume labelled Leading; hybrids as classified. Full reasoning + per-family tables in `docs/extra-indicators/INDICATOR-LEADING-LAGGING.md`.

**Backend:** `library.schema()` emits a `lead_lag` field per indicator (`leading`/`lagging`/`filter`).
**Dashboard:** the indicator picker gains a **group-by Family|Cadence** toggle, **cadence filter** chips, and a per-row cadence **badge** — so you can select e.g. all Leading oscillators or Lagging MAs, alongside the existing family grouping.

Tests: cadence counts (80/61/24) + spot-checks; 63 dashboard+schema tests green. UI-only, no scoring-engine change (golden 6/6 re-checked).