### PR TITLE
Silence off-grid param + Vortex NaN optimizer warnings (closes #32)

### DIFF
--- a/subprojects/Parametric-Indicators/indicators/lib_tier2.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_tier2.py
@@ -93,7 +93,7 @@ SCHEMA = {
     "td_combo": {"label": "TD Combo (perfected setup)", "mode": "both", "params": []},
     "kalman": {"label": "Kalman trend", "mode": "confirm",
                "params": [{"name": "q", "default": 0.001, "min": 0.0001, "max": 1.0, "step": 0.0001},
-                          {"name": "r", "default": 0.1, "min": 0.001, "max": 10.0, "step": 0.01}]},
+                          {"name": "r", "default": 0.1, "min": 0.001, "max": 10.0, "step": 0.001}]},
     "ou_halflife": {"label": "OU half-life (veto no-reversion)", "mode": "veto",
                     "params": [{"name": "n", "default": 50, "min": 10, "max": 300, "step": 1}]},
 }

--- a/subprojects/Parametric-Indicators/indicators/lib_trend.py
+++ b/subprojects/Parametric-Indicators/indicators/lib_trend.py
@@ -74,7 +74,8 @@ class Vortex(StanceIndicator):
     def stance(self, ctx):
         n = int(self.config.params.get("n", 14))
         vp, vm = T.vortex(ctx.high, ctx.low, ctx.close, n)
-        return _sign_stance(vp - vm)
+        with np.errstate(invalid="ignore"):        # NaN/inf on warm-up/zero-range bars → neutral vote (no noisy RuntimeWarning)
+            return _sign_stance(vp - vm)
     def warmup_bars(self): return int(self.config.params.get("n", 14))
 
 
@@ -299,7 +300,7 @@ SCHEMA = {
     "qqe": {"label": "QQE", "mode": "confirm",
             "params": [{"name": "n", "default": 14, "min": 2, "max": 100, "step": 1},
                        {"name": "sf", "default": 5, "min": 1, "max": 50, "step": 1},
-                       {"name": "f", "default": 4.236, "min": 1.0, "max": 8.0, "step": 0.1}]},
+                       {"name": "f", "default": 4.236, "min": 1.0, "max": 8.0, "step": 0.001}]},
     "elder_ray": {"label": "Elder Ray", "mode": "confirm",
                   "params": [{"name": "n", "default": 13, "min": 2, "max": 100, "step": 1}]},
     "elder_impulse": {"label": "Elder Impulse", "mode": "confirm",

--- a/subprojects/Parametric-Indicators/indicators/test_param_grids.py
+++ b/subprojects/Parametric-Indicators/indicators/test_param_grids.py
@@ -1,0 +1,33 @@
+"""Guard against off-grid float params (#32): Optuna warns when a stepped FloatDistribution's range
+isn't divisible by step, or when a fixed/warm-start value isn't on the grid. Every stepped float param's
+range AND default must sit on its own grid so no such warning is ever emitted."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from indicators import library
+
+
+def _stepped_floats():
+    for key, spec in library.SCHEMA.items():
+        for p in spec.get("params", []):
+            lo, hi, st = p.get("min"), p.get("max"), p.get("step")
+            if None in (lo, hi, st) or not isinstance(st, float):
+                continue
+            yield key, p, float(lo), float(hi), float(st)
+
+
+def _on_grid(x, lo, st):
+    n = (x - lo) / st
+    return abs(n - round(n)) < 1e-9
+
+
+def test_every_float_range_is_divisible_by_step():
+    bad = [(k, p["name"], lo, hi, st) for k, p, lo, hi, st in _stepped_floats() if not _on_grid(hi, lo, st)]
+    assert not bad, f"range not divisible by step: {bad}"
+
+
+def test_every_float_default_is_on_grid():
+    bad = [(k, p["name"], p["default"], lo, st)
+           for k, p, lo, hi, st in _stepped_floats() if not _on_grid(float(p["default"]), lo, st)]
+    assert not bad, f"default off its step grid: {bad}"


### PR DESCRIPTION
Closes #32. Every trial logged Optuna warnings; systematic scan found exactly two off-grid float **defaults**:
- `qqe.f = 4.236` on step 0.1
- `kalman.r = 0.1` on `[0.001, 10.0]` step 0.01 (this also made the range indivisible → truncated to 9.991)

**Fix:** make those two steps finer (`0.1→0.001`, `0.01→0.001`). The meaningful defaults land on-grid, the range divides evenly, and **every previously-valid value stays valid** (the coarse grid is a subset of the fine grid at the same offset) — so no champion or warm-start seed breaks, and no optimizer-side seed-snapping is needed.

**Vortex:** wrap `vp − vm` in `np.errstate(invalid='ignore')` — NaN/inf warm-up bars still map to a neutral vote (identical result), just without the `RuntimeWarning`.

Search-grid + warning-only — no compute change. **Parity 4h: qqe/kalman/vortex 0 mismatch, full sweep OK; golden 6/6.** New regression test asserts no stepped float param has an off-grid range or default.