### PR TITLE
Control plane: systemd service for reboot-survival (closes #35)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/serve_control_plane.sh
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/serve_control_plane.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Control-plane-ONLY launcher (the FastAPI app that serves the SPA + drives the owned optimizer runs).
+# Deliberately does NOT start optuna-dashboard or the Telegram bot (run_dashboard.sh does that, and would
+# clash on :8081). This is what the systemd unit (wsh-control-plane.service) execs, so the control plane
+# survives reboots + auto-restarts. Reads optimize/dashboard/dashboard.env (gitignored) for bind IP + env.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$HERE/dashboard.env"
+[ -f "$ENV_FILE" ] || { echo "missing $ENV_FILE (copy dashboard.env.example)"; exit 1; }
+set -a; source "$ENV_FILE"; set +a
+: "${REMOTE_VENV:?set REMOTE_VENV in dashboard.env}"
+cd "$HERE/../.."                                    # Parametric-Indicators root (import base + child cwd)
+exec "$REMOTE_VENV/bin/uvicorn" optimize.dashboard.app:app \
+  --host "${DASH_BIND_IP:-127.0.0.1}" --port "${DASH_CONTROL_PORT:-8350}"

--- a/subprojects/Parametric-Indicators/optimize/dashboard/wsh-control-plane.service
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/wsh-control-plane.service
@@ -1,0 +1,25 @@
+# systemd unit for the Optimizer Control Center control plane (issue #35).
+# Install on the server (needs sudo):
+#   sudo cp optimize/dashboard/wsh-control-plane.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now wsh-control-plane
+# Status / logs:  systemctl status wsh-control-plane   ·   journalctl -u wsh-control-plane -f
+# Adjust User / paths below if the deploy location differs from the reference server.
+[Unit]
+Description=Optimizer Control Center — FastAPI control plane (owned optimizer runs)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=dev
+WorkingDirectory=/home/dev/Mulham/code/subprojects/Parametric-Indicators
+ExecStart=/home/dev/Mulham/code/subprojects/Parametric-Indicators/optimize/dashboard/serve_control_plane.sh
+Restart=on-failure
+RestartSec=3
+# Owned optimizer children run in their own process groups (start_new_session=True); KillMode=process
+# stops only the uvicorn process on restart and lets in-flight runs be resumed from the Postgres store.
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #35. Adds `serve_control_plane.sh` (control-plane-ONLY launcher, sources dashboard.env, no optuna/bot clash) and `wsh-control-plane.service` (User=dev, localhost bind, Restart=on-failure, KillMode=process so owned runs resume from Postgres). Install via sudo + enable at boot. No app/scoring change.