### PR TITLE
Launch-matrix queue on the owned-subprocess driver (closes #36)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -121,12 +121,18 @@ def api_preset_delete(name: str):
 
 @app.post("/api/queue")
 def api_queue_launch(cfg: dict = Body(default={})):
-    return {"queue": queue.launch(cfg, control.start)}
+    # Owned fleet (#36): one owned optimizer subprocess per (instrument, tf) cell (capped, live, stoppable).
+    return {"queue": runner.fleet_launch(cfg)}
 
 
 @app.get("/api/queue")
 def api_queue_state():
-    return {"queue": queue.state()}
+    return {"queue": runner.fleet_state()}
+
+
+@app.post("/api/queue/stop")
+def api_queue_stop():
+    return runner.fleet_stop()
 
 
 @app.post("/api/bundle")

--- a/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
@@ -226,3 +226,62 @@ class RunManager:
 
 
 _MGR = RunManager()
+
+
+# ── fleet: the Launch-matrix queue as OWNED runs (#36) ────────────────────────────────────────────
+# One owned optimizer subprocess per (instrument, timeframe) cell — same live/stop guarantees as the
+# single Run button, just many at once, capped so the box isn't oversubscribed.
+_FLEET: list[dict] = []                          # [{run: RunManager|None, item: {...}}]
+
+
+def _worker_cap() -> int:
+    return max(1, (os.cpu_count() or 4) - 2)      # leave 2 cores for OS/Postgres (mirrors remote_wsi guard)
+
+
+def fleet_launch(cfg: dict) -> list[dict]:
+    """Expand instruments×timeframes and launch ONE owned run per cell, up to the worker cap. Cells beyond
+    the cap are 'deferred' (surfaced, never silently dropped — relaunch after the running ones finish)."""
+    from optimize.dashboard import queue as q
+    global _FLEET
+    fleet_stop()                                  # stop any prior fleet first
+    _FLEET = []
+    cap = _worker_cap()
+    for i, c in enumerate(q.expand(cfg)):
+        item = {"instrument": c.get("instrument"), "timeframe": c.get("timeframe"), "state": "pending"}
+        if i >= cap:
+            item.update(state="deferred",
+                        detail=f"exceeds worker cap ({cap}); relaunch after the running cells finish")
+            _FLEET.append({"run": None, "item": item})
+            continue
+        r = RunManager()
+        res = r.start(c)
+        if res.get("ok"):
+            item.update(state="running", study=res.get("study"), target=res.get("target"))
+        else:
+            item.update(state="failed", detail=res.get("detail", ""))
+            r = None
+        _FLEET.append({"run": r, "item": item})
+    return fleet_state()
+
+
+def fleet_state() -> list[dict]:
+    out = []
+    for e in _FLEET:
+        it = dict(e["item"])
+        r = e["run"]
+        if r is not None:
+            st = r.state()
+            it["running"] = st["running"]
+            it["returncode"] = st["returncode"]
+            it["target"] = st["target"]
+            if st["running"]:
+                it["done"] = r.done_count()
+            elif it.get("state") == "running":       # transitioned running → done since last poll
+                it["state"] = "finished" if st["returncode"] == 0 else "stopped"
+        out.append(it)
+    return out
+
+
+def fleet_stop() -> dict:
+    n = sum(1 for e in _FLEET if e["run"] is not None and (e["run"].stop() or True))
+    return {"ok": True, "stopped": n}

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
@@ -80,3 +80,34 @@ def test_lifecycle_owned_process_starts_streams_and_stops(monkeypatch):
 
 def test_stop_when_nothing_running_is_safe():
     assert runner.RunManager().stop()["ok"] is True
+
+
+# ── fleet (Launch-matrix queue on owned runs, #36) ────────────────────────────────────────────────
+_FAKE = [sys.executable, "-u", "-c", "import time; print('go', flush=True); time.sleep(30)"]
+
+
+def _fake_fleet(monkeypatch):
+    monkeypatch.setattr(runner, "build_command", lambda cfg, tf: _FAKE)
+    monkeypatch.setattr(runner, "target_trials", lambda cfg: 10)
+    monkeypatch.setattr(runner.RunManager, "done_count", lambda self: 0)   # avoid trial_count.py subprocess
+
+
+def test_fleet_launches_one_owned_run_per_cell(monkeypatch):
+    _fake_fleet(monkeypatch)
+    q = runner.fleet_launch({"instruments": ["NQ", "ES"], "timeframes": ["4h"], "trials_mode": "auto"})
+    assert len(q) == 2
+    assert {(i["instrument"], i["timeframe"]) for i in q} == {("NQ", "4h"), ("ES", "4h")}
+    assert all(i["state"] == "running" and i["running"] for i in q)
+    st = runner.fleet_stop()
+    assert st["ok"] and st["stopped"] == 2
+    time.sleep(0.3)
+    assert all(not i["running"] for i in runner.fleet_state())
+
+
+def test_fleet_defers_cells_beyond_worker_cap(monkeypatch):
+    _fake_fleet(monkeypatch)
+    monkeypatch.setattr(runner, "_worker_cap", lambda: 1)                 # force a tiny cap
+    q = runner.fleet_launch({"instruments": ["NQ", "ES", "GC"], "timeframes": ["4h"], "trials_mode": "auto"})
+    states = [i["state"] for i in q]
+    assert states.count("running") == 1 and states.count("deferred") == 2  # cap enforced + surfaced
+    runner.fleet_stop()

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
@@ -35,9 +35,10 @@ export const api = {
   presetSave: (name, cfg) => j('POST', `/api/presets/${encodeURIComponent(name)}`, cfg),
   presetDelete: (name) => j('DELETE', `/api/presets/${encodeURIComponent(name)}`),
 
-  // run queue (instruments × timeframes matrix)
+  // run queue = owned fleet (instruments × timeframes matrix)
   queueState: () => j('GET', '/api/queue'),
   queueLaunch: (cfg) => j('POST', '/api/queue', cfg),
+  queueStop: () => j('POST', '/api/queue/stop'),
 }
 
 // SSE helper for the legacy log/progress stream (GET /api/progress?tf=...).

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/QueueControls.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/QueueControls.vue
@@ -1,29 +1,42 @@
 <script setup>
-import { onMounted, ref } from 'vue'
+import { onUnmounted, onMounted, ref } from 'vue'
 import { store } from '../store.js'
 import { api } from '../api.js'
 
 const items = ref([])
 const busy = ref(false)
 const msg = ref('')
+let poll = null
 
 async function refresh() {
   try { const r = await api.queueState(); items.value = r.queue || [] } catch { /* ignore */ }
 }
-onMounted(refresh)
+onMounted(() => { refresh(); poll = setInterval(refresh, 3000) })
+onUnmounted(() => poll && clearInterval(poll))
 
 async function launch() {
   busy.value = true; msg.value = ''
   try {
     const cfg = store.launchCfg()
-    if (store.cfg.max_trials) cfg.max_trials = Number(store.cfg.max_trials)     // budget guard (enforced)
+    if (store.cfg.max_trials) cfg.max_trials = Number(store.cfg.max_trials)   // budget guard (enforced in expand)
     const r = await api.queueLaunch(cfg)
     items.value = r.queue || []
-    msg.value = `launched ${items.value.length} studies`
-    await store.refreshStatus()
+    const running = items.value.filter(i => i.state === 'running').length
+    const deferred = items.value.filter(i => i.state === 'deferred').length
+    msg.value = `launched ${running} owned run(s)` + (deferred ? ` · ${deferred} deferred (worker cap)` : '')
   } catch (e) { msg.value = `launch failed: ${e.message}` }
   finally { busy.value = false }
 }
+
+async function stopAll() {
+  busy.value = true
+  try { const r = await api.queueStop(); msg.value = `stopped ${r.stopped} run(s)`; await refresh() }
+  catch (e) { msg.value = `stop failed: ${e.message}` }
+  finally { busy.value = false }
+}
+
+const pct = (it) => (it.target ? Math.min(100, Math.round((it.done || 0) / it.target * 100)) : 0)
+const anyRunning = () => items.value.some(i => i.running)
 </script>
 
 <template>
@@ -38,23 +51,34 @@ async function launch() {
         <span class="pill">advisory</span>
       </label>
     </div>
-    <p class="muted" style="font-size:11px">Max-trials is enforced (each study is capped &amp; de-auto’d).
-      Wall-clock is advisory in P1 — surfaced, not yet auto-stopped by the watchdog.</p>
+    <p class="muted" style="font-size:11px">Each matrix cell launches its OWN optimizer subprocess (capped at
+      cores−2; extra cells are deferred, not dropped). Max-trials is enforced; wall-clock is advisory in P1.</p>
 
     <div class="row">
       <button class="primary" :disabled="busy" @click="launch">⇉ Launch matrix</button>
-      <button :disabled="busy" @click="refresh">↻ Refresh</button>
+      <button class="danger" :disabled="busy || !anyRunning()" @click="stopAll">■ Stop all</button>
+      <button :disabled="busy" @click="refresh">↻</button>
     </div>
     <p v-if="msg" class="mono muted">{{ msg }}</p>
 
-    <div class="row" v-for="(it, i) in items" :key="i">
-      <span class="mono" style="flex:1">{{ it.instrument }} · {{ it.timeframe }}</span>
-      <span class="pill" :class="it.state === 'launched' ? 'ok' : it.state === 'failed' ? 'bad' : ''">{{ it.state }}</span>
+    <div v-for="(it, i) in items" :key="i" class="qitem">
+      <div class="row" style="margin:2px 0">
+        <span class="mono" style="flex:1">{{ it.instrument }} · {{ it.timeframe }}</span>
+        <span class="pill" :class="it.state">{{ it.state }}</span>
+        <span v-if="it.target" class="muted mono">{{ it.done || 0 }}/{{ it.target }}</span>
+      </div>
+      <div v-if="it.state === 'running'" class="bar"><div class="fill" :style="{ width: pct(it) + '%' }"></div></div>
     </div>
+    <p v-if="!items.length" class="muted">no matrix launched yet</p>
   </div>
 </template>
 
 <style scoped>
-.pill.ok { color: var(--ok); border-color: var(--ok); }
-.pill.bad { color: var(--bad); border-color: var(--bad); }
+.qitem { border-top: 1px solid var(--border); padding: 4px 0; }
+.pill.running { color: var(--ok); border-color: var(--ok); }
+.pill.finished { color: var(--accent); border-color: var(--accent); }
+.pill.failed, .pill.stopped { color: var(--bad); border-color: var(--bad); }
+.pill.deferred { color: var(--warn); border-color: var(--warn); }
+.bar { height: 5px; background: var(--panel-2); border-radius: 999px; overflow: hidden; margin-top: 2px; }
+.fill { height: 100%; background: var(--accent); transition: width .4s ease; }
 </style>


### PR DESCRIPTION
Closes #36. The Run button used the owned driver (#28) but the queue still used fire-and-forget remote_wsi.sh. Now each matrix cell is its own owned optimizer subprocess.

- **runner:** `fleet_launch` (one RunManager per instrument×tf cell, capped at cores−2; overflow cells **deferred** + surfaced, never silently dropped), `fleet_state` (per-cell running/done/target), `fleet_stop` (stop-all).
- **app.py:** `/api/queue` POST→fleet_launch, GET→fleet_state, new `/api/queue/stop`.
- **QueueControls.vue:** per-cell status pills + progress bars, Stop-all, deferred cells shown.

Same live/stop guarantees as the single Run, many at once. Tests: fleet launch/stop + cap-defer; 61 dashboard tests green. UI/control only, no scoring change (golden 6/6 re-checked).