### PR TITLE
fix: fleet honors per-cell trials + budget guard (#36)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
@@ -81,10 +81,24 @@ def study_name(cfg: dict, tf: str) -> str:
     return f"{study_prefix(cfg)}_{tf}" + ("" if inst == "NQ" else f"_{inst}")
 
 
-def target_trials(cfg: dict) -> int:
+def _explicit_trials(cfg: dict, tf: str) -> int | None:
+    """The explicit trial count this cfg pins, or None for auto. Handles BOTH the raw Run cfg
+    (trials_mode/trials/per_trials) AND a queue.expand()-ed cell (auto_trials + trials)."""
+    if "auto_trials" in cfg:                          # already-expanded cell (from the fleet/queue)
+        return None if cfg["auto_trials"] else (int(cfg.get("trials") or 0) or None)
+    mode = cfg.get("trials_mode", "auto")
+    if mode == "one":
+        return int(cfg.get("trials") or 0) or None
+    if mode == "per":
+        return int((cfg.get("per_trials") or {}).get(f"{cfg.get('instrument')}:{tf}", 0)) or None
+    return None
+
+
+def target_trials(cfg: dict, tf: str = "4h") -> int:
     from optimize import optimizer as OPT
-    if cfg.get("trials_mode") == "one" and cfg.get("trials"):
-        return int(cfg["trials"])
+    n = _explicit_trials(cfg, tf)
+    if n is not None:
+        return n
     return OPT.recommended_trials(bool(cfg.get("split_sltp")),
                                   int(cfg.get("trials_per_dim", OPT.TRIALS_PER_DIM)))
 
@@ -93,14 +107,8 @@ def build_command(cfg: dict, tf: str) -> list[str]:
     """The optimizer.py argv equivalent to this cfg (mirrors remote_wsi.sh IND_ARGS)."""
     cmd = [_python(), "-u", "optimize/optimizer.py", str(tf), "--folds", "5", "--min-trades", "5",
            "--study-prefix", study_prefix(cfg)]
-    mode = cfg.get("trials_mode", "auto")
-    if mode == "one" and int(cfg.get("trials") or 0):
-        cmd += ["--trials", str(int(cfg["trials"]))]
-    elif mode == "per":
-        n = int((cfg.get("per_trials") or {}).get(f"{cfg.get('instrument')}:{tf}", 0))
-        cmd += (["--trials", str(n)] if n else ["--auto-trials"])
-    else:
-        cmd += ["--auto-trials"]
+    n = _explicit_trials(cfg, tf)
+    cmd += (["--trials", str(n)] if n is not None else ["--auto-trials"])
     if cfg.get("ind_1min", True):
         cmd.append("--ind-1min")
     if cfg.get("split_sltp"):
@@ -156,7 +164,7 @@ class RunManager:
         cmd = build_command(cfg, tf)
         self.prefix = study_prefix(cfg)
         self.study = study_name(cfg, tf)
-        self.tf, self.cfg, self.target = tf, cfg, target_trials(cfg)
+        self.tf, self.cfg, self.target = tf, cfg, target_trials(cfg, tf)
         self.lines.clear()
         self._total = 0
         self.proc = subprocess.Popen(cmd, cwd=str(_PI), env=_child_env(cfg),

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
@@ -48,6 +48,25 @@ def test_auto_mode_uses_auto_trials():
     assert "--auto-trials" in cmd and "--trials" not in cmd
 
 
+def test_expanded_cell_trials_are_honored():
+    # a queue.expand()-ed cell carries auto_trials/trials (NOT trials_mode) — the fleet must honor them
+    from optimize.dashboard import queue
+    cell = queue.expand({"instruments": ["NQ"], "timeframes": ["4h"], "trials_mode": "one", "trials": 8})[0]
+    assert "trials_mode" not in cell and cell["auto_trials"] is False and cell["trials"] == 8
+    cmd = runner.build_command(cell, "4h")
+    assert "--trials 8" in " ".join(cmd) and "--auto-trials" not in cmd     # was the bug: ran auto
+    assert runner.target_trials(cell, "4h") == 8
+
+
+def test_expanded_cell_budget_clamp_is_honored():
+    from optimize.dashboard import queue
+    cell = queue.expand({"instruments": ["NQ"], "timeframes": ["4h"], "trials_mode": "auto",
+                         "max_trials": 5000})[0]
+    cmd = runner.build_command(cell, "4h")
+    assert "--trials 5000" in " ".join(cmd)          # budget guard actually reaches the command
+    assert runner.target_trials(cell, "4h") == 5000
+
+
 def test_start_rejects_invalid_cfg():
     mgr = runner.RunManager()
     r = mgr.start({})
@@ -61,7 +80,7 @@ def test_lifecycle_owned_process_starts_streams_and_stops(monkeypatch):
             "print('trial 1 done', flush=True)\n"
             "time.sleep(30)\n"]
     monkeypatch.setattr(runner, "build_command", lambda cfg, tf: fake)
-    monkeypatch.setattr(runner, "target_trials", lambda cfg: 100)
+    monkeypatch.setattr(runner, "target_trials", lambda cfg, tf=None: 100)
     mgr = runner.RunManager()
     r = mgr.start({"instrument": "NQ", "timeframes": ["4h"], "trials_mode": "auto"})
     assert r["ok"] is True and r["pid"] > 0
@@ -88,7 +107,7 @@ _FAKE = [sys.executable, "-u", "-c", "import time; print('go', flush=True); time
 
 def _fake_fleet(monkeypatch):
     monkeypatch.setattr(runner, "build_command", lambda cfg, tf: _FAKE)
-    monkeypatch.setattr(runner, "target_trials", lambda cfg: 10)
+    monkeypatch.setattr(runner, "target_trials", lambda cfg, tf=None: 10)
     monkeypatch.setattr(runner.RunManager, "done_count", lambda self: 0)   # avoid trial_count.py subprocess
 
 


### PR DESCRIPTION
Follow-up to #36 (caught in live verify): the fleet ignored trials-count/budget because build_command/target_trials only read trials_mode, but queue.expand converts that to auto_trials/trials per cell. New _explicit_trials handles both shapes. Tests added; 63 dashboard green; control-only.