### PR TITLE
fix: /api/config no longer embeds the slow status query (closes #41)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -20,9 +20,9 @@ _BUNDLES: dict[str, str] = {}
 
 @app.get("/api/config")
 def api_config():
-    cfg = control.config()
-    cfg["status"] = control.status()
-    return cfg
+    # Config only (instant). Status is intentionally NOT embedded — control.status() runs the slow
+    # `stats --json` Postgres query (~13s); the UI polls /api/status separately so the page renders now.
+    return control.config()
 
 
 @app.post("/api/plan")

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_app.py
@@ -12,11 +12,12 @@ import optimize.dashboard.app as APP
 client = TestClient(APP.app)
 
 
-def test_config_endpoint(monkeypatch):
+def test_config_endpoint_is_status_free(monkeypatch):
+    # /api/config must NOT embed the slow status query (#41) — it returns config only.
     monkeypatch.setattr(APP.control, "config", lambda: {"samplers": ["nsga3", "gp"], "engines": ["single"]})
-    monkeypatch.setattr(APP.control, "status", lambda: {"ok": True, "studies": []})
+    monkeypatch.setattr(APP.control, "status", lambda: (_ for _ in ()).throw(AssertionError("status must not be called")))
     r = client.get("/api/config")
-    assert r.status_code == 200 and "samplers" in r.json() and "status" in r.json()
+    assert r.status_code == 200 and "samplers" in r.json() and "status" not in r.json()
 
 
 def test_plan_endpoint(monkeypatch):

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
@@ -28,8 +28,6 @@ export const store = reactive({
   async loadConfig() {
     try {
       const c = await api.config()
-      // config() also embeds a status snapshot under `status`
-      this.status = c.status || this.status
       for (const k of ['samplers', 'engines', 'stage_b', 'timeframes', 'instruments',
                        'bounds', 'indicators', 'presets', 'trials_per_dim']) {
         if (c[k] !== undefined) this.config[k] = c[k]
@@ -38,17 +36,22 @@ export const store = reactive({
       if (!this.cfg.sampler && this.config.samplers.length) this.cfg.sampler = this.config.samplers[0]
       this.conn = 'online'
       this.loaded = true
+      this.refreshStatus()        // fire the (slow) status poll async — never blocks the page render (#41)
     } catch (e) {
       this.conn = 'offline'
     }
   },
 
   async refreshStatus() {
+    if (this._statusInFlight) return       // the status query is slow (~13s) — don't pile up overlapping polls
+    this._statusInFlight = true
     try {
       this.status = await api.status()
       this.conn = 'online'
     } catch {
       this.conn = 'offline'
+    } finally {
+      this._statusInFlight = false
     }
   },
 


### PR DESCRIPTION
The control-center page took ~13s to load because /api/config appended control.status() (the ~13s stats --json Postgres query). config() itself is instant. Return config only; the UI polls /api/status separately (loadConfig now fires that async so it never blocks render; refreshStatus guards overlap). Measured 13s→0.014s. 63 dashboard tests green; UI-only.