### PR TITLE
Reporting v1: run results + optuna-dashboard link + big-run guard (closes #43)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -10,7 +10,7 @@ from fastapi import Body, FastAPI
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
-from optimize.dashboard import control, progress, queue, run_presets, runner
+from optimize.dashboard import control, progress, queue, results, run_presets, runner
 
 app = FastAPI(title="Optimizer Control Plane")
 _STATIC = Path(__file__).resolve().parent / "static"
@@ -46,6 +46,12 @@ def api_resume(cfg: dict = Body(default={})):
 def api_stop():
     # Real stop: signal the owned process group (SIGTERM→SIGKILL). No pkill on unowned workers.
     return runner._MGR.stop()
+
+
+@app.get("/api/study/{name}")
+def api_study(name: str):
+    # Reporting: a study's results (Pareto/best/feasibility) read from the store (#43).
+    return results.study_summary(name)
 
 
 @app.get("/api/run/state")

--- a/subprojects/Parametric-Indicators/optimize/dashboard/control.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/control.py
@@ -52,7 +52,8 @@ def config() -> dict:
     return {"samplers": list(OPT.SAMPLER_CHOICES), "engines": ["single", "two_stage"],
             "stage_b": ["cmaes", "gp"], "timeframes": TIMEFRAMES, "instruments": list(INST.TOKENS),
             "bounds": bounds, "indicators": library.schema().get("indicators", []), "presets": pl,
-            "trials_per_dim": OPT.TRIALS_PER_DIM}
+            "trials_per_dim": OPT.TRIALS_PER_DIM,
+            "optuna_port": int(os.environ.get("DASH_OPTUNA_PORT", 8082))}   # live Pareto/graphs (separate tunnel)
 
 
 def plan(cfg: dict) -> dict:

--- a/subprojects/Parametric-Indicators/optimize/dashboard/results.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/results.py
@@ -1,0 +1,55 @@
+"""Read a study's results from the optimizer store for the Reporting panel (#43).
+
+Multi-objective values are [median-fold P/L, -worst-DD, win%]. Feasibility (DD ≤ cap·P/L) is decided by
+the optimizer's own constraints_func, whose values Optuna persists in trial system-attrs — we read those
+rather than re-deriving the cap (avoids a silent-default mismatch if a run used a custom --dd-pnl-cap).
+"""
+from __future__ import annotations
+
+
+def _load(name: str):
+    import optuna
+    from optimize import storage as S
+    url = S.storage_url(None)
+    return optuna.load_study(
+        study_name=name,
+        storage=optuna.storages.RDBStorage(url=url, engine_kwargs=S.engine_kwargs(url)),
+    )
+
+
+def _feasible(trial):
+    """True/False from the optimizer's stored constraint values (feasible ⇔ all ≤ 0); None if unknown."""
+    for k, v in trial.system_attrs.items():
+        if "constraint" in k.lower() and isinstance(v, (list, tuple)) and v:
+            return all(c <= 0 for c in v)
+    return None
+
+
+def study_summary(name: str, top: int = 12) -> dict:
+    import optuna
+    try:
+        st = _load(name)
+    except Exception as e:
+        return {"ok": False, "name": name, "detail": str(e)[:200]}
+    complete = [t for t in st.trials if t.state == optuna.trial.TrialState.COMPLETE and t.values]
+    pruned = sum(1 for t in st.trials if t.state == optuna.trial.TrialState.PRUNED)
+    rows = []
+    for t in complete:
+        v = t.values
+        rows.append({
+            "trial": t.number,
+            "pnl": round(v[0], 1),
+            "dd": round(-v[1], 1) if len(v) > 1 else None,
+            "win": round(v[2], 2) if len(v) > 2 else None,
+            "feasible": _feasible(t),
+        })
+    rows.sort(key=lambda r: (r["pnl"] if r["pnl"] is not None else -1e18), reverse=True)
+    feas = [r for r in rows if r["feasible"]]
+    return {
+        "ok": True, "name": name,
+        "total": len(st.trials), "complete": len(complete), "pruned": pruned,
+        "feasible_count": len(feas),
+        "best_pnl": rows[0] if rows else None,
+        "best_feasible": feas[0] if feas else None,
+        "top": rows[:top],
+    }

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_results.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_results.py
@@ -1,0 +1,40 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from optimize.dashboard import results
+
+
+class _T:
+    def __init__(self, number, values, state, constraints=None):
+        self.number, self.values, self.state = number, values, state
+        self.system_attrs = {"nsga3:generation": 0}
+        if constraints is not None:
+            self.system_attrs["constraints"] = constraints
+
+
+def test_study_summary_parses_ranks_and_reads_feasibility(monkeypatch):
+    import optuna
+    C, P = optuna.trial.TrialState.COMPLETE, optuna.trial.TrialState.PRUNED
+    trials = [
+        _T(0, [1000.0, -5000.0, 55.0], C, constraints=[1.0]),    # infeasible (constraint > 0)
+        _T(1, [3000.0, -400.0, 70.0], C, constraints=[-1.0]),    # feasible, best P/L
+        _T(2, [2000.0, -100.0, 60.0], C, constraints=[-1.0]),    # feasible
+        _T(3, None, P),                                          # pruned
+    ]
+    monkeypatch.setattr(results, "_load", lambda name: types.SimpleNamespace(trials=trials))
+    s = results.study_summary("x")
+    assert s["ok"] and s["complete"] == 3 and s["pruned"] == 1
+    assert s["best_pnl"]["trial"] == 1                            # ranked by P/L
+    assert s["feasible_count"] == 2 and s["best_feasible"]["trial"] == 1
+    assert s["top"][0]["pnl"] == 3000.0 and s["top"][0]["feasible"] is True
+    assert any(r["feasible"] is False for r in s["top"])         # infeasible trial surfaced too
+
+
+def test_study_summary_unknown_study_is_safe(monkeypatch):
+    def boom(name):
+        raise KeyError("no such study")
+    monkeypatch.setattr(results, "_load", boom)
+    r = results.study_summary("nope")
+    assert r["ok"] is False and "detail" in r

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
@@ -25,6 +25,7 @@ export const api = {
   resume: (cfg) => j('POST', '/api/resume', cfg),
   stop: () => j('POST', '/api/stop'),
   runState: () => j('GET', '/api/run/state'),
+  study: (name) => j('GET', `/api/study/${encodeURIComponent(name)}`),
 
   // live progress / ETA (snapshot poll)
   liveProgress: (tf, target) =>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
@@ -21,6 +21,19 @@ async function pollState() {
 }
 
 async function start() {
+  // Big-run guard: an auto run is the FULL search (can be ~47k trials ≈ days). Confirm first.
+  if (store.cfg.trials_mode === 'auto') {
+    try {
+      const plan = await api.plan(store.runCfg())
+      const n = plan?.recommended_trials || 0
+      if (n > 20000 && !confirm(
+        `Auto mode runs the FULL search: ~${n.toLocaleString()} trials (${plan.dims} dims). ` +
+        `At ~200 trials/min that's roughly ${Math.round(n / 200 / 60)} h — it can take days. ` +
+        `Use "one count" for a short run instead.\n\nLaunch the full ${n.toLocaleString()}-trial run anyway?`)) {
+        return
+      }
+    } catch { /* if the plan call fails, don't block the run */ }
+  }
   busy.value = true; msg.value = ''
   try {
     const r = await api.run(store.runCfg())

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ReportingPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ReportingPanel.vue
@@ -1,19 +1,83 @@
 <script setup>
-// Live + final reporting (leaderboard, Pareto, champion detail) is P2/P3.
-// P1 keeps a minimal live view so the column isn't empty.
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { store } from '../store.js'
+import { api } from '../api.js'
+
+const study = ref(null)       // active run's study name
+const summary = ref(null)     // /api/study/{name} result
+let timer = null
+
+async function refresh() {
+  try {
+    const st = await api.runState()
+    study.value = st.study
+    if (st.study) summary.value = await api.study(st.study)
+    else summary.value = null
+  } catch { /* keep last */ }
+}
+onMounted(() => { refresh(); timer = setInterval(refresh, 4000) })
+onUnmounted(() => timer && clearInterval(timer))
+
+const optunaUrl = computed(() => `http://localhost:${store.config.optuna_port || 8082}/dashboard/`)
+const feas = (f) => (f === true ? '✓' : f === false ? '✗' : '—')
 </script>
 
 <template>
   <section class="panel">
     <h2>Reporting</h2>
-    <p class="muted">Live figures, Pareto front, and champion leaderboard arrive in P2/P3.</p>
-    <div v-if="store.status.studies && store.status.studies.length">
-      <h3>Studies</h3>
-      <div v-for="s in store.status.studies" :key="s.tf || s.name" class="row mono">
-        <span class="pill">{{ s.tf || s.name }}</span>
-        <span class="muted">{{ s.complete ?? s.done ?? '?' }} trials</span>
-      </div>
+
+    <h3>Live graphs (optuna-dashboard)</h3>
+    <p class="muted" style="font-size:12px">Pareto front, optimization history &amp; param importance for every study.
+      Tunnel the optuna port, then open it:</p>
+    <div class="row">
+      <a class="btn" :href="optunaUrl" target="_blank" rel="noopener">Open optuna-dashboard ↗</a>
     </div>
+    <pre class="tip mono">ssh -L {{ store.config.optuna_port || 8082 }}:127.0.0.1:{{ store.config.optuna_port || 8082 }} amd-trading</pre>
+
+    <h3>Active run result <span v-if="study" class="pill">{{ study }}</span></h3>
+    <template v-if="summary && summary.ok">
+      <div class="row mono" style="font-size:12px">
+        <span class="pill">{{ summary.complete }} complete</span>
+        <span class="pill">{{ summary.pruned }} pruned</span>
+        <span class="pill" :class="summary.feasible_count ? 'ok' : ''">{{ summary.feasible_count }} feasible</span>
+      </div>
+      <div v-if="summary.best_feasible" class="best">
+        <b>Best feasible</b> · trial {{ summary.best_feasible.trial }} ·
+        P/L <b>${{ summary.best_feasible.pnl.toLocaleString() }}</b> ·
+        DD ${{ summary.best_feasible.dd?.toLocaleString() }} · win {{ summary.best_feasible.win }}%
+      </div>
+      <p v-else class="muted" style="font-size:12px">No feasible champion yet
+        (DD ≤ cap·P/L) — needs more trials.</p>
+
+      <h3>Top trials by P/L</h3>
+      <table class="tt mono">
+        <thead><tr><th>#</th><th>P/L</th><th>DD</th><th>win%</th><th>feas</th></tr></thead>
+        <tbody>
+          <tr v-for="r in summary.top" :key="r.trial" :class="{ feas: r.feasible }">
+            <td>{{ r.trial }}</td><td>{{ r.pnl?.toLocaleString() }}</td>
+            <td>{{ r.dd?.toLocaleString() }}</td><td>{{ r.win }}</td><td>{{ feas(r.feasible) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
+    <p v-else-if="study" class="muted">loading results…</p>
+    <p v-else class="muted">Run a study to see its results here.</p>
+
+    <h3>Champion leaderboard</h3>
+    <p class="muted" style="font-size:12px">All/deployed champions with full details — coming next (P3).</p>
   </section>
 </template>
+
+<style scoped>
+.btn { display: inline-block; padding: 6px 12px; border: 1px solid var(--accent); border-radius: 6px;
+  color: var(--accent); text-decoration: none; font-size: 13px; }
+.btn:hover { background: var(--panel-2); }
+.tip { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px;
+  font-size: 11px; color: var(--muted); margin: 6px 0; white-space: pre-wrap; word-break: break-all; }
+.pill.ok { color: var(--ok); border-color: var(--ok); }
+.best { border: 1px solid var(--ok); border-radius: 6px; padding: 8px; margin: 8px 0; font-size: 12px; }
+.tt { width: 100%; border-collapse: collapse; font-size: 11px; }
+.tt th, .tt td { text-align: right; padding: 2px 6px; border-bottom: 1px solid var(--border); }
+.tt th:first-child, .tt td:first-child { text-align: left; }
+.tt tr.feas td { color: var(--ok); }
+</style>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/store.js
@@ -9,7 +9,7 @@ import { api } from './api.js'
 export const store = reactive({
   config: {
     samplers: [], engines: [], stage_b: [], timeframes: [], instruments: [],
-    bounds: {}, indicators: [], presets: [], trials_per_dim: 0,
+    bounds: {}, indicators: [], presets: [], trials_per_dim: 0, optuna_port: 8082,
   },
   cfg: {
     // selections (all optional — absent keys ⇒ optimizer defaults, byte-identical to a bare launch)
@@ -29,7 +29,7 @@ export const store = reactive({
     try {
       const c = await api.config()
       for (const k of ['samplers', 'engines', 'stage_b', 'timeframes', 'instruments',
-                       'bounds', 'indicators', 'presets', 'trials_per_dim']) {
+                       'bounds', 'indicators', 'presets', 'trials_per_dim', 'optuna_port']) {
         if (c[k] !== undefined) this.config[k] = c[k]
       }
       // sensible first-run defaults derived from the server


### PR DESCRIPTION
Closes #43 (tasks #20/#21/#23). The Reporting panel was a stub — a run produced nothing visible. Now:
- **/api/study/{name}** (results.py) reads the store → complete/pruned/**feasible** counts, best-by-P/L, best FEASIBLE champion, top trials. Feasibility from the optimizer's stored constraint values (no hardcoded cap).
- **ReportingPanel**: live results table for the active study + link to **optuna-dashboard** (now running :8082, port via config).
- **Big-run guard**: auto-mode Run confirms before the ~47k-trial (~days) full search, showing the ETA — fixes the 'hangs forever' surprise.

65 dashboard tests green; UI/read-only, no scoring change. Champion leaderboard (#22) is the follow-up.