### PR TITLE
systemd service for optuna-dashboard (#20)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/serve_optuna_dashboard.sh
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/serve_optuna_dashboard.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# optuna-dashboard launcher (live Pareto / optimization history / param importance for every study).
+# Reads the SAME Postgres the optimizer writes to. Bound to DASH_BIND_IP (localhost/VPN, never public).
+# Run by wsh-optuna-dashboard.service so it survives reboots. Reads optimize/dashboard/dashboard.env.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$HERE/dashboard.env"
+[ -f "$ENV_FILE" ] || { echo "missing $ENV_FILE (copy dashboard.env.example)"; exit 1; }
+set -a; source "$ENV_FILE"; set +a
+: "${REMOTE_VENV:?set REMOTE_VENV in dashboard.env}"
+: "${WSH_STORAGE_URL:?WSH_STORAGE_URL unset (dashboard.env should source pg.env)}"
+exec "$REMOTE_VENV/bin/optuna-dashboard" "$WSH_STORAGE_URL" \
+  --host "${DASH_BIND_IP:-127.0.0.1}" --port "${DASH_OPTUNA_PORT:-8082}"

--- a/subprojects/Parametric-Indicators/optimize/dashboard/wsh-optuna-dashboard.service
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/wsh-optuna-dashboard.service
@@ -1,0 +1,20 @@
+# systemd unit for optuna-dashboard (live Pareto/history/graphs) — issue #43/#20.
+# Install (needs sudo):
+#   sudo cp optimize/dashboard/wsh-optuna-dashboard.service /etc/systemd/system/
+#   sudo systemctl daemon-reload && sudo systemctl enable --now wsh-optuna-dashboard
+# Bound to DASH_BIND_IP (localhost) — reach it via an SSH tunnel on DASH_OPTUNA_PORT.
+[Unit]
+Description=optuna-dashboard for the Optimizer Control Center (live Pareto/history)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=dev
+WorkingDirectory=/home/dev/Mulham/code/subprojects/Parametric-Indicators
+ExecStart=/bin/bash /home/dev/Mulham/code/subprojects/Parametric-Indicators/optimize/dashboard/serve_optuna_dashboard.sh
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Reboot-durable optuna-dashboard: serve_optuna_dashboard.sh + wsh-optuna-dashboard.service (localhost bind, DASH_OPTUNA_PORT, Restart=on-failure). Completes #20. No app change.