### PR TITLE
Detect + stop detached orphan runs across restarts (closes #46)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -44,8 +44,8 @@ def api_resume(cfg: dict = Body(default={})):
 
 @app.post("/api/stop")
 def api_stop():
-    # Real stop: signal the owned process group (SIGTERM→SIGKILL). No pkill on unowned workers.
-    return runner._MGR.stop()
+    # Real stop: the owned run's process group, AND any detached orphans from a restart (#46).
+    return runner.stop_all()
 
 
 @app.get("/api/study/{name}")
@@ -57,9 +57,23 @@ def api_study(name: str):
 @app.get("/api/run/state")
 def api_run_state():
     st = runner._MGR.state()
-    if st.get("pid"):                                        # a run exists (active or just finished)
+    if st.get("pid"):                                        # an OWNED run exists (active or just finished)
         done = runner._MGR.done_count()
         st["progress"] = progress.live(st.get("tf") or "run", done, st.get("target") or 0, time.time())
+        st["detached"] = False
+        return st
+    # No owned run — surface a DETACHED orphan (a run still alive after a restart) so the UI isn't
+    # misleadingly idle. Its progress comes from the store; Stop (stop_all) can kill it.
+    orphans = runner.detached_runs()
+    if orphans:
+        o = orphans[0]
+        done = runner.done_count_for(o.get("prefix"), o.get("tf"))
+        return {"running": True, "detached": True, "study": o.get("study"), "tf": o.get("tf"),
+                "prefix": o.get("prefix"), "pid": o.get("pid"), "target": 0, "returncode": None,
+                "progress": progress.live(o.get("tf") or "run", done, 0, time.time()),
+                "detached_count": len(orphans)}
+    st["detached"] = False
+    st["detached_count"] = 0
     return st
 
 

--- a/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
@@ -293,3 +293,80 @@ def fleet_state() -> list[dict]:
 def fleet_stop() -> dict:
     n = sum(1 for e in _FLEET if e["run"] is not None and (e["run"].stop() or True))
     return {"ok": True, "stopped": n}
+
+
+# ── detached orphans: cc-runs still alive after a control-plane restart (#46) ──────────────────────
+# start_new_session=True detaches owned optimizer children from the control plane, so a restart loses
+# the handle. We recover them by scanning the process table for cc-prefixed optimizer runs.
+import re as _re
+
+
+def _parse_ps(text: str) -> list[dict]:
+    """Parse `ps -eo pid,pgid,args` output → cc-prefixed optimizer runs [{pid,pgid,study,prefix,tf,instrument}]."""
+    runs = []
+    for line in text.splitlines():
+        if "optimize/optimizer.py" not in line or "--study-prefix cc" not in line:
+            continue
+        toks = line.split()
+        try:
+            pid, pgid = int(toks[0]), int(toks[1])
+        except (ValueError, IndexError):
+            continue
+        m = _re.search(r"--study-prefix (cc\w+)", line)
+        prefix = m.group(1) if m else None
+        tf = next((toks[i + 1] for i, t in enumerate(toks) if t.endswith("optimizer.py") and i + 1 < len(toks)), None)
+        mi = _re.search(r"--instrument (\w+)", line)
+        inst = mi.group(1) if mi else "NQ"
+        study = (f"{prefix}_{tf}" + ("" if inst == "NQ" else f"_{inst}")) if (prefix and tf) else None
+        runs.append({"pid": pid, "pgid": pgid, "prefix": prefix, "tf": tf, "instrument": inst, "study": study})
+    return runs
+
+
+def scan_cc_runs() -> list[dict]:
+    try:
+        out = subprocess.run(["ps", "-eo", "pid,pgid,args"], capture_output=True, text=True, timeout=10).stdout
+    except Exception:
+        return []
+    return _parse_ps(out)
+
+
+def _owned_pids() -> set:
+    pids = set()
+    if _MGR.proc is not None:
+        pids.add(_MGR.proc.pid)
+    for e in _FLEET:
+        r = e.get("run")
+        if r is not None and r.proc is not None:
+            pids.add(r.proc.pid)
+    return pids
+
+
+def detached_runs() -> list[dict]:
+    """cc-optimizer processes alive but NOT owned by this control plane (orphans from a restart)."""
+    owned = _owned_pids()
+    return [r for r in scan_cc_runs() if r["pid"] not in owned]
+
+
+def stop_all() -> dict:
+    """Stop the owned primary run AND kill any detached orphans, so the UI's Stop always clears runs."""
+    _MGR.stop()
+    killed = 0
+    for r in detached_runs():
+        try:
+            os.killpg(r["pgid"], signal.SIGKILL)
+            killed += 1
+        except (ProcessLookupError, PermissionError):
+            pass
+    return {"ok": True, "detail": f"stopped owned run + {killed} detached orphan(s)"}
+
+
+def done_count_for(prefix: str, tf: str) -> int:
+    """Completed-trial count for a study by prefix+tf (store-aware) — used for detached-orphan progress."""
+    if not prefix or not tf:
+        return 0
+    try:
+        r = subprocess.run([_python(), "optimize/trial_count.py", tf, "--prefix", prefix],
+                           cwd=str(_PI), env=_child_env({}), capture_output=True, text=True, timeout=20)
+        return int("".join(c for c in r.stdout if c.isdigit()) or 0)
+    except Exception:
+        return 0

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_runner.py
@@ -130,3 +130,30 @@ def test_fleet_defers_cells_beyond_worker_cap(monkeypatch):
     states = [i["state"] for i in q]
     assert states.count("running") == 1 and states.count("deferred") == 2  # cap enforced + surfaced
     runner.fleet_stop()
+
+
+# ── detached orphans (#46) ────────────────────────────────────────────────────────────────────────
+_PS = """  PID  PGID COMMAND
+ 12345 12345 /venv/bin/python3 -u optimize/optimizer.py 4h --folds 5 --study-prefix ccabc123 --auto-trials --ind-1min
+ 12346 12300 /venv/bin/python3 -u optimize/optimizer.py 15m --study-prefix ccdef456 --trials 8 --instrument ES
+ 99999 99999 sshd: idle
+ 55555 55555 /venv/bin/python3 optimize/optimizer.py 1h --trials 5
+"""
+
+
+def test_parse_ps_finds_only_cc_runs():
+    runs = runner._parse_ps(_PS)
+    assert len(runs) == 2                                     # sshd + non-cc optimizer ignored
+    a, b = runs
+    assert a["pid"] == 12345 and a["prefix"] == "ccabc123" and a["tf"] == "4h" and a["study"] == "ccabc123_4h"
+    assert b["pgid"] == 12300 and b["instrument"] == "ES" and b["study"] == "ccdef456_15m_ES"
+
+
+def test_detached_runs_excludes_owned(monkeypatch):
+    monkeypatch.setattr(runner, "scan_cc_runs", lambda: [
+        {"pid": 111, "pgid": 111, "prefix": "cc1", "tf": "4h", "instrument": "NQ", "study": "cc1_4h"},
+        {"pid": 222, "pgid": 222, "prefix": "cc2", "tf": "1h", "instrument": "NQ", "study": "cc2_1h"},
+    ])
+    monkeypatch.setattr(runner, "_owned_pids", lambda: {111})   # 111 is owned → only 222 is a detached orphan
+    d = runner.detached_runs()
+    assert len(d) == 1 and d[0]["pid"] == 222

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ControlPanel.vue
@@ -75,7 +75,11 @@ const shownLog = computed(() => logLines.value.slice(-200).join('\n') || '(no ou
       <span v-if="run.running" class="pill run">running</span>
     </div>
 
-    <p v-if="missing.length" class="missing">
+    <p v-if="run.detached" class="detached">
+      ⚠ A run is still active from before a restart (detached): <b>{{ run.study }}</b>
+      — reconnected from the process table. Hit <b>Stop</b> to clear it.
+    </p>
+    <p v-if="missing.length && !run.detached" class="missing">
       ⚠ Select before running: <b>{{ missing.join(', ') }}</b>
     </p>
     <p v-if="msg" class="mono muted" style="word-break:break-word">{{ msg }}</p>
@@ -99,6 +103,8 @@ const shownLog = computed(() => logLines.value.slice(-200).join('\n') || '(no ou
 
 <style scoped>
 .missing { color: var(--warn); font-size: 13px; margin: 6px 0; }
+.detached { color: var(--warn); font-size: 12px; margin: 6px 0; border: 1px solid var(--warn);
+  border-radius: 6px; padding: 6px 8px; }
 .pill.run { color: var(--ok); border-color: var(--ok); }
 .log { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px;
   height: 240px; overflow: auto; white-space: pre-wrap; word-break: break-word; font-size: 11px;


### PR DESCRIPTION
start_new_session detaches owned optimizer children, so a control-plane restart orphaned running runs (found a 14h ghost) — UI showed idle while the optimizer ran on. Now: scan_cc_runs/detached_runs/stop_all + /api/run/state surfaces a **detached** orphan (with store progress) and /api/stop kills it; ControlPanel shows a banner. 67 tests green; control-only, no scoring change.