### PR TITLE
Champion leaderboard in the Reporting panel (closes #22)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -10,7 +10,7 @@ from fastapi import Body, FastAPI
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
-from optimize.dashboard import control, progress, queue, results, run_presets, runner
+from optimize.dashboard import champions, control, progress, queue, results, run_presets, runner
 
 app = FastAPI(title="Optimizer Control Plane")
 _STATIC = Path(__file__).resolve().parent / "static"
@@ -46,6 +46,12 @@ def api_resume(cfg: dict = Body(default={})):
 def api_stop():
     # Real stop: the owned run's process group, AND any detached orphans from a restart (#46).
     return runner.stop_all()
+
+
+@app.get("/api/champions")
+def api_champions():
+    # Champion leaderboard: the deployed best-champion set per (instrument, tf) (#22).
+    return champions.leaderboard()
 
 
 @app.get("/api/study/{name}")

--- a/subprojects/Parametric-Indicators/optimize/dashboard/champions.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/champions.py
@@ -1,0 +1,53 @@
+"""Champion leaderboard source for the Reporting panel (#22).
+
+Reads the deployed champion set — optimize/results/best_champions_full{_INST}.json, one file per
+instrument, keyed by timeframe → {median_pnl, full_pnl, full_dd, win, box, indicators}. Flattens to one
+row per (instrument, tf) for the leaderboard, newest metrics as stored (LOCAL is the source of truth).
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_RESULTS = Path(__file__).resolve().parent.parent.parent / "optimize" / "results"
+
+
+def _instrument_of(name: str) -> str:
+    m = re.match(r"best_champions_full(?:_(\w+))?\.json$", name)
+    return (m.group(1) if m and m.group(1) else "NQ")
+
+
+def load_all(results_dir: Path | None = None) -> list[dict]:
+    base = Path(results_dir) if results_dir else _RESULTS
+    rows = []
+    for path in sorted(base.glob("best_champions_full*.json")):
+        inst = _instrument_of(path.name)
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        for tf, c in data.items():
+            if not isinstance(c, dict):
+                continue
+            inds = c.get("indicators", {}) or {}
+            rows.append({
+                "instrument": inst, "tf": tf,
+                "pnl": c.get("full_pnl"), "dd": c.get("full_dd"),
+                "median_pnl": c.get("median_pnl"), "win": c.get("win"),
+                "n_indicators": len(inds),
+                "indicators": sorted(inds.keys()),
+                "box": c.get("box", {}),
+                "deployed": True,          # best_champions_full = the current deployed set
+            })
+    rows.sort(key=lambda r: (r["pnl"] if r["pnl"] is not None else -1e18), reverse=True)
+    return rows
+
+
+def leaderboard() -> dict:
+    rows = load_all()
+    return {"ok": True, "count": len(rows),
+            "instruments": sorted({r["instrument"] for r in rows}),
+            "champions": rows}

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_champions.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_champions.py
@@ -1,0 +1,30 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from optimize.dashboard import champions
+
+
+def test_load_all_flattens_per_instrument_tf_and_ranks(tmp_path):
+    # NQ (base file, no suffix) + ES (suffixed)
+    (tmp_path / "best_champions_full.json").write_text(json.dumps({
+        "4h": {"full_pnl": 148670.2, "full_dd": 12284.0, "win": 67.0, "median_pnl": 41174.7,
+               "box": {"sl_soft": 128.5, "cap_mode": "bars"}, "indicators": {"macd": {}, "vwap": {}}},
+        "1h": {"full_pnl": 50000.0, "full_dd": 8000.0, "win": 60.0, "median_pnl": 12000.0,
+               "box": {}, "indicators": {"rsi": {}}},
+    }))
+    (tmp_path / "best_champions_full_ES.json").write_text(json.dumps({
+        "4h": {"full_pnl": 200000.0, "full_dd": 20000.0, "win": 65.0, "median_pnl": 30000.0,
+               "box": {}, "indicators": {}},
+    }))
+    rows = champions.load_all(results_dir=tmp_path)
+    assert len(rows) == 3
+    assert rows[0]["instrument"] == "ES" and rows[0]["pnl"] == 200000.0     # ranked by P/L desc
+    nq4h = next(r for r in rows if r["instrument"] == "NQ" and r["tf"] == "4h")
+    assert nq4h["n_indicators"] == 2 and nq4h["indicators"] == ["macd", "vwap"]
+    assert nq4h["box"]["cap_mode"] == "bars" and nq4h["deployed"] is True
+
+
+def test_load_all_missing_dir_is_empty(tmp_path):
+    assert champions.load_all(results_dir=tmp_path / "nope") == []

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/api.js
@@ -26,6 +26,7 @@ export const api = {
   stop: () => j('POST', '/api/stop'),
   runState: () => j('GET', '/api/run/state'),
   study: (name) => j('GET', `/api/study/${encodeURIComponent(name)}`),
+  champions: () => j('GET', '/api/champions'),
 
   // live progress / ETA (snapshot poll)
   liveProgress: (tf, target) =>

--- a/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ReportingPanel.vue
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/web/src/components/ReportingPanel.vue
@@ -5,6 +5,8 @@ import { api } from '../api.js'
 
 const study = ref(null)       // active run's study name
 const summary = ref(null)     // /api/study/{name} result
+const champs = ref([])        // champion leaderboard
+const expanded = ref(null)    // expanded champion row key
 let timer = null
 
 async function refresh() {
@@ -15,8 +17,14 @@ async function refresh() {
     else summary.value = null
   } catch { /* keep last */ }
 }
-onMounted(() => { refresh(); timer = setInterval(refresh, 4000) })
+async function loadChampions() {
+  try { champs.value = (await api.champions()).champions || [] } catch { /* ignore */ }
+}
+onMounted(() => { refresh(); loadChampions(); timer = setInterval(refresh, 4000) })
 onUnmounted(() => timer && clearInterval(timer))
+
+const rowKey = (c) => `${c.instrument}_${c.tf}`
+const toggle = (c) => { expanded.value = expanded.value === rowKey(c) ? null : rowKey(c) }
 
 const optunaUrl = computed(() => `http://localhost:${store.config.optuna_port || 8082}/dashboard/`)
 const feas = (f) => (f === true ? '✓' : f === false ? '✗' : '—')
@@ -63,8 +71,30 @@ const feas = (f) => (f === true ? '✓' : f === false ? '✗' : '—')
     <p v-else-if="study" class="muted">loading results…</p>
     <p v-else class="muted">Run a study to see its results here.</p>
 
-    <h3>Champion leaderboard</h3>
-    <p class="muted" style="font-size:12px">All/deployed champions with full details — coming next (P3).</p>
+    <h3>Champion leaderboard <span class="pill">{{ champs.length }}</span></h3>
+    <p v-if="!champs.length" class="muted" style="font-size:12px">no champions found in optimize/results.</p>
+    <table v-else class="tt mono">
+      <thead><tr><th>inst</th><th>tf</th><th>P/L</th><th>DD</th><th>win%</th><th>#ind</th><th></th></tr></thead>
+      <tbody>
+        <template v-for="c in champs" :key="rowKey(c)">
+          <tr class="crow" @click="toggle(c)">
+            <td>{{ c.instrument }}</td><td>{{ c.tf }}</td>
+            <td>{{ c.pnl?.toLocaleString() }}</td><td>{{ c.dd?.toLocaleString() }}</td>
+            <td>{{ c.win }}</td><td>{{ c.n_indicators }}</td>
+            <td>{{ expanded === rowKey(c) ? '▾' : '▸' }}</td>
+          </tr>
+          <tr v-if="expanded === rowKey(c)" class="cdetail">
+            <td colspan="7">
+              <div><b>median P/L</b> ${{ c.median_pnl?.toLocaleString() }} · <b>deployed</b> {{ c.deployed ? '✓' : '—' }}</div>
+              <div><b>indicators:</b> {{ c.indicators.join(', ') || '(none)' }}</div>
+              <div><b>box:</b> SL {{ c.box.sl_soft?.toFixed?.(0) }}/{{ c.box.sl_hard?.toFixed?.(0) }}
+                · TP {{ c.box.tp?.toFixed?.(0) }} · gate {{ c.box.gate_pct?.toFixed?.(0) }}%
+                · cooldown {{ c.box.cooldown }} · K {{ c.box.k }} · cap {{ c.box.cap_mode }}/{{ c.box.cap_1min }}</div>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
   </section>
 </template>
 
@@ -80,4 +110,7 @@ const feas = (f) => (f === true ? '✓' : f === false ? '✗' : '—')
 .tt th, .tt td { text-align: right; padding: 2px 6px; border-bottom: 1px solid var(--border); }
 .tt th:first-child, .tt td:first-child { text-align: left; }
 .tt tr.feas td { color: var(--ok); }
+.crow { cursor: pointer; }
+.crow:hover td { background: var(--panel-2); }
+.cdetail td { text-align: left; color: var(--muted); font-size: 11px; padding: 6px 8px; line-height: 1.6; }
 </style>


### PR DESCRIPTION
Closes #22 (last P3 piece). champions.py + /api/champions flatten optimize/results/best_champions_full{_INST}.json → one row per (instrument, tf): P/L, DD, win, median P/L, #indicators, box, indicator list, deployed. ReportingPanel shows the ranked leaderboard with click-to-expand details. 54 champions across 9 instruments load. 69 dashboard tests green; read-only, no scoring change.