### PR TITLE
Finished owned run no longer masks orphan detection (closes #49)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/app.py
@@ -63,13 +63,13 @@ def api_study(name: str):
 @app.get("/api/run/state")
 def api_run_state():
     st = runner._MGR.state()
-    if st.get("pid"):                                        # an OWNED run exists (active or just finished)
+    if st.get("running"):                                    # owned run ACTIVELY running → report it
         done = runner._MGR.done_count()
         st["progress"] = progress.live(st.get("tf") or "run", done, st.get("target") or 0, time.time())
         st["detached"] = False
         return st
-    # No owned run — surface a DETACHED orphan (a run still alive after a restart) so the UI isn't
-    # misleadingly idle. Its progress comes from the store; Stop (stop_all) can kill it.
+    # Owned run is idle/finished — a DETACHED orphan (another run still alive after a restart) takes
+    # precedence so the UI isn't misleadingly idle. (Bugfix #49: a finished _MGR run must NOT mask orphans.)
     orphans = runner.detached_runs()
     if orphans:
         o = orphans[0]
@@ -78,6 +78,10 @@ def api_run_state():
                 "prefix": o.get("prefix"), "pid": o.get("pid"), "target": 0, "returncode": None,
                 "progress": progress.live(o.get("tf") or "run", done, 0, time.time()),
                 "detached_count": len(orphans)}
+    # Neither running nor orphaned — return the last owned (finished) run's state so its result stays visible.
+    if st.get("pid"):
+        st["progress"] = progress.live(st.get("tf") or "run", runner._MGR.done_count(),
+                                       st.get("target") or 0, time.time())
     st["detached"] = False
     st["detached_count"] = 0
     return st

--- a/subprojects/Parametric-Indicators/optimize/dashboard/test_app.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/test_app.py
@@ -49,6 +49,26 @@ def test_run_state_endpoint():
     assert "running" in st and "study" in st
 
 
+def test_run_state_surfaces_orphan_even_when_owned_run_finished(monkeypatch):
+    # #49: a FINISHED owned run must NOT mask a detached orphan
+    monkeypatch.setattr(APP.runner._MGR, "state",
+                        lambda: {"running": False, "pid": 100, "returncode": 0, "study": "ccold_4h", "tf": "4h", "target": 2})
+    monkeypatch.setattr(APP.runner, "detached_runs",
+                        lambda: [{"pid": 200, "pgid": 200, "prefix": "ccnew", "tf": "1h", "instrument": "NQ", "study": "ccnew_1h"}])
+    monkeypatch.setattr(APP.runner, "done_count_for", lambda prefix, tf: 5)
+    d = client.get("/api/run/state").json()
+    assert d["running"] is True and d["detached"] is True and d["study"] == "ccnew_1h"
+
+
+def test_run_state_shows_finished_run_when_no_orphan(monkeypatch):
+    monkeypatch.setattr(APP.runner._MGR, "state",
+                        lambda: {"running": False, "pid": 100, "returncode": 0, "study": "ccold_4h", "tf": "4h", "target": 2})
+    monkeypatch.setattr(APP.runner, "detached_runs", lambda: [])
+    monkeypatch.setattr(APP.runner._MGR, "done_count", lambda: 2)
+    d = client.get("/api/run/state").json()
+    assert d["running"] is False and d["detached"] is False and d["study"] == "ccold_4h"
+
+
 def test_resume_endpoint(monkeypatch):
     monkeypatch.setattr(APP.control, "resume", lambda cfg: {"ok": True, "resumed": True})
     assert client.post("/api/resume", json={}).json()["resumed"]


### PR DESCRIPTION
Follow-up to #46: /api/run/state short-circuited on any pid (incl. finished), masking detached orphans when a prior run finished. Now short-circuits only while RUNNING; else orphans-first, then last-finished-state. Tests added.