### PR TITLE
Progress counts finished (complete+pruned) trials → reaches 100% (closes #51)

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
+++ b/subprojects/Parametric-Indicators/optimize/dashboard/runner.py
@@ -221,11 +221,12 @@ class RunManager:
         return list(self.lines)[-n:]
 
     def done_count(self) -> int:
-        """Completed-trial count for the active study, via the existing trial_count.py (store-aware)."""
+        """FINISHED-trial count (complete+pruned+fail) for the active study — progress toward the total-trial
+        target, so the bar reaches 100% even when trials are pruned. Via trial_count.py --finished."""
         if not self.prefix or not self.tf:
             return 0
         try:
-            r = subprocess.run([_python(), "optimize/trial_count.py", self.tf, "--prefix", self.prefix],
+            r = subprocess.run([_python(), "optimize/trial_count.py", self.tf, "--prefix", self.prefix, "--finished"],
                                cwd=str(_PI), env=_child_env(self.cfg or {}),
                                capture_output=True, text=True, timeout=20)
             return int("".join(ch for ch in r.stdout if ch.isdigit()) or 0)
@@ -365,7 +366,7 @@ def done_count_for(prefix: str, tf: str) -> int:
     if not prefix or not tf:
         return 0
     try:
-        r = subprocess.run([_python(), "optimize/trial_count.py", tf, "--prefix", prefix],
+        r = subprocess.run([_python(), "optimize/trial_count.py", tf, "--prefix", prefix, "--finished"],
                            cwd=str(_PI), env=_child_env({}), capture_output=True, text=True, timeout=20)
         return int("".join(c for c in r.stdout if c.isdigit()) or 0)
     except Exception:

--- a/subprojects/Parametric-Indicators/optimize/trial_count.py
+++ b/subprojects/Parametric-Indicators/optimize/trial_count.py
@@ -54,11 +54,23 @@ def completed(prefix: str, tf: str) -> int:
         return 0
 
 
+def finished(prefix: str, tf: str) -> int:
+    """FINISHED-trial count (complete + pruned + fail) — for progress toward a total-trial target, so the
+    bar reaches 100% (`--trials N` runs N trials total; pruned ones still count). NOT for the watchdog."""
+    name = f"{prefix}_{tf}{_SUF}"
+    try:
+        study = optuna.load_study(study_name=name, storage=_quiet_url(tf, name))
+        return sum(1 for t in study.trials if t.state.is_finished())
+    except Exception:
+        return 0
+
+
 if __name__ == "__main__":
     import argparse
     optuna.logging.set_verbosity(optuna.logging.WARNING)
     ap = argparse.ArgumentParser()
     ap.add_argument("tf")
     ap.add_argument("--prefix", default="wsh4")
+    ap.add_argument("--finished", action="store_true", help="count complete+pruned+fail (progress), not just complete")
     a = ap.parse_args()
-    print(completed(a.prefix, a.tf))
+    print(finished(a.prefix, a.tf) if a.finished else completed(a.prefix, a.tf))


### PR DESCRIPTION
The progress bar counted only COMPLETED trials vs a total-trial target → a finished run with pruned trials showed <100% (4/10=40% when 6 pruned). Now counts FINISHED trials (complete+pruned+fail) via trial_count.finished()/--finished; watchdog's completed() unchanged. 71 dashboard tests green.