### PR TITLE
perf(#54): indicator cold-miss — one function was 81% of it (1,396x, zero decision changes)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ fastapi
 uvicorn[standard]
 httpx
 optuna>=3.5.0
+numba  # optional fast path for calc/quant.dfa (#54); absent => verbatim reference fallback

--- a/subprojects/Parametric-Indicators/docs/PRIOR_ART_indicator_caching_gpu.md
+++ b/subprojects/Parametric-Indicators/docs/PRIOR_ART_indicator_caching_gpu.md
@@ -1,0 +1,84 @@
+# Prior Art — Indicator Caching & GPU Technical Analysis
+
+**Date:** 2026-07-27 · **Issue:** #54 · Feeds `REPORT_indicator_cache_acceleration.md`.
+Online pass answering: *has someone already solved "compute parameterized indicators once, reuse across a
+sweep", and does GPU help?* Each entry: what they do → the one idea transferable to **our** system (where
+`ind.directions()` is a pure function of `(indicator, params, price series)`).
+
+---
+
+## 1. vectorbt / vectorbt PRO — batch params as array columns + dedup + shared sub-compute
+- **What:** `IndicatorFactory` broadcasts *many parameter combinations into extra columns of one 2-D array*
+  and runs the indicator over all of them in a single vectorized (optionally jitted/multithreaded) pass.
+  `run_unique=True` **deduplicates repeated param combinations**; `cache_func` + `cached_property/method`
+  share intermediate results (e.g. a base EMA reused by BBANDS) across combos.
+- **Transferable idea:** this is the CPU analogue of our GPU-batch lever — compute a *whole param grid of
+  one indicator at once* rather than one array per cold miss. Their `run_unique` is exactly our cache's
+  dedup, but applied *within a single vectorized call*. Validates batching the top-N vectorizable
+  oscillators (Task 5) and suggests a **CPU batched path** as the "dumb control" the GPU must beat.
+- Sources: [DeepWiki](https://deepwiki.com/polakowo/vectorbt), [factory](https://vectorbt.dev/api/indicators/factory/), [PRO Indicators](https://vectorbt.pro/features/indicators/), [PRO Performance](https://vectorbt.pro/features/performance/).
+
+## 2. talipp / wickra — incremental (O(1)/tick) wins for *streaming*, loses to C batch for *one-shot*
+- **What:** `talipp` computes indicators incrementally — O(1) per new tick vs O(n) recompute — ideal for
+  live/iterative input; it beats TA-Lib when you *append* data. **But for a one-shot full-history batch,
+  TA-Lib (C, vectorized) is "a clear winner."** `wickra` is a Rust-core, 514-indicator, O(1)-per-tick,
+  drop-in TA-Lib replacement with Python bindings.
+- **Transferable idea:** our optimizer cold miss is a **batch** (compute the full 486,970-bar history once
+  per new param), *not* a streaming append — so the incremental route is the wrong tool for the cold miss;
+  vectorized/C/GPU is right. This corroborates our own `RESEARCH_indicator_recurrence_relations.md` and
+  narrows Task 3 to the *exact* recurrences (EMA-family `lfilter`, deque max/min) rather than a general
+  streaming rewrite. `wickra` is worth noting as a prebuilt option **iff** it reproduces our vote math
+  bit-identically (unlikely without porting — parity risk).
+- Sources: [talipp](https://github.com/nardew/talipp), [talipp PyPI](https://pypi.org/project/talipp/), [wickra](https://github.com/wickra-lib/wickra).
+
+## 3. Qlib — two-level (LRU memory + disk) expression cache with sub-expression reuse
+- **What:** Qlib parses each feature expression into a syntax tree and caches **every node's** result in an
+  in-memory LRU plus a `DiskExpressionCache`; a repeated (sub-)expression loads from cache instead of
+  recomputing. Disk cache on by default.
+- **Transferable idea:** exactly mirrors our `_VOTE_MEMO` (memory) + `vote_cache` (disk) two-level design —
+  independent industrial validation that our architecture is the standard answer. The *new* idea is
+  **sub-expression** caching: several of our indicators share a base EMA/ATR (MACD, Keltner, ADX). Caching
+  at the shared-primitive level (below `directions()`) could cut cold-miss cost further — a candidate for
+  the Task 6 cache-level analysis and a possible follow-up.
+- Sources: [Qlib data layer](https://qlib.readthedocs.io/en/stable/component/data.html), [Qlib paper](https://arxiv.org/pdf/2009.11189).
+
+## 4. RAPIDS cuDF / CuPy + Numba-CUDA — GPU batch is real, but only for the right shape
+- **What:** cuDF (~40× pandas on DataFrame-heavy pipelines), CuPy (NumPy-API GPU arrays), and Numba-CUDA
+  (NVIDIA reports >100× on *batched* Monte-Carlo trading simulations) all push array math to the GPU.
+  Repeated theme: **"batching thousands of scenarios on the GPU reduces minutes to seconds."**
+- **Transferable idea:** the GPU win is *throughput across many parallel scenarios*, not latency on one —
+  which is precisely our Task 5 framing (many param-combos of one indicator per kernel), **not** the tiny
+  28 MB data volume the 2026-06-11 scaling study correctly said GPU can't help. Caveat from the same
+  sources: cuDF's big wins are DataFrame ops (joins/groupby); our per-bar rolling arithmetic maps to
+  **CuPy / custom CUDA kernels**, and the host↔device transfer + kernel-launch overhead sets a break-even
+  #combos below which CPU wins — exactly what Task 5 measures.
+- Sources: [RAPIDS cuDF](https://developer.nvidia.com/blog/accelerated-data-analytics-speed-up-data-exploration-with-rapids-cudf/), [Numba 100× trading](https://developer.nvidia.com/blog/gpu-accelerate-algorithmic-trading-simulations-by-over-100x-with-numba/), [RAPIDS for trading](https://blog.quantinsti.com/nvidia-gpu-rapids-libraries-trading/), [cuDF+CuPy interop](https://medium.com/rapids-ai/10-minutes-to-cudf-and-cupy-e131cac0439b).
+
+## 5. Cache substrate — shared-memory options for cross-process array reuse
+- **What:** Arrow **Plasma** offered zero-copy immutable objects in shared memory across processes
+  (originated in Ray). **Caveat (verify, don't assume): Plasma was deprecated and removed from Apache Arrow
+  in later releases (~Arrow 12)** — it is *not* a safe new dependency in 2026. The durable options are
+  `/dev/shm` tmpfs (RAM-backed files, no serialization change from `.npy`), Python
+  `multiprocessing.shared_memory` (zero-copy numpy views across processes), Redis (network/socket hop +
+  (de)serialization, but battle-tested cross-host), and memory-mapped files.
+- **Transferable idea:** our current disk `.npy` under `/tmp` may already be on tmpfs or page-cache-hot
+  (123 GB RAM box) — so the *first* substrate question is empirical: is the `.npy` open/parse the cost, or
+  is it already RAM-speed? Task 6 measures `.npy` vs `/dev/shm` vs `shared_memory` vs Redis under 30
+  readers; **skip Plasma** (deprecated) and only include Redis if already installed (no silent caps).
+- Sources: [Plasma announcement](https://arrow.apache.org/blog/2017/08/08/plasma-in-memory-object-store/), [Arrow zero-copy cluster shared memory (2024)](https://arxiv.org/html/2404.03030v1).
+
+---
+
+## Synthesis → how prior art shapes each lever
+
+| Our lever (issue #54) | Prior-art verdict | Consequence for the PoC |
+|-----------------------|-------------------|-------------------------|
+| **Cold-miss compute (priority)** | vectorbt batches param-grids into columns; GPU gives 100× only on batched scenarios; incremental is wrong for one-shot batch | Task 5 GPU-batches the top-N oscillators; add a **CPU-batched** path as a dumb control the GPU must beat; keep Task 3 to the *exact* EMA/deque recurrences |
+| **Cache substrate** | Qlib validates 2-level memo+disk; Plasma deprecated; tmpfs/`shared_memory` are the live options | Task 6 measures `.npy` vs tmpfs vs `shared_memory` vs Redis; drop Plasma; question is empirical (is `.npy` already RAM-hot?) |
+| **Cache level** | Qlib caches *sub-expressions*, not just top-level features | Task 6 counts reuse for a `directions()` key; flag shared-primitive (EMA/ATR) caching as a follow-up |
+| **Do nothing / prebuilt** | `wickra` (Rust, drop-in TA-Lib) exists | Note as an option, but parity risk is high — our vote math must reproduce bit-identically |
+
+**Bottom line from prior art:** our two-level cache is the industry-standard design (Qlib), the GPU angle
+is legitimate *only* as batched-param throughput (RAPIDS/Numba), the cold miss should be attacked with
+vectorized/GPU batch rather than incremental streaming (talipp/TA-Lib), and the substrate benchmark should
+skip the deprecated Plasma and test tmpfs/`shared_memory`/Redis against a possibly-already-RAM-hot `.npy`.

--- a/subprojects/Parametric-Indicators/docs/PRIOR_ART_indicator_caching_gpu.md
+++ b/subprojects/Parametric-Indicators/docs/PRIOR_ART_indicator_caching_gpu.md
@@ -2,83 +2,106 @@
 
 **Date:** 2026-07-27 · **Issue:** #54 · Feeds `REPORT_indicator_cache_acceleration.md`.
 Online pass answering: *has someone already solved "compute parameterized indicators once, reuse across a
-sweep", and does GPU help?* Each entry: what they do → the one idea transferable to **our** system (where
-`ind.directions()` is a pure function of `(indicator, params, price series)`).
+sweep", and does GPU help?* This is the **deep** pass — full pages + GitHub source fetched, real numbers
+quoted, and the deprecated-Plasma claim verified against source. Each entry: what they do → the one idea
+transferable to **our** system (where `ind.directions()` is a pure fn of `(indicator, params, series)`).
+
+> **Verification note (honest sourcing).** Numbers below are quoted from the *fetched pages*. Where the
+> first (search-only) pass over-attributed a feature to the wrong page, it is corrected inline. Hard
+> decision-grade numbers for us still come from our own server + GPU benchmarks (Tasks 2/5), not blogs.
 
 ---
 
-## 1. vectorbt / vectorbt PRO — batch params as array columns + dedup + shared sub-compute
-- **What:** `IndicatorFactory` broadcasts *many parameter combinations into extra columns of one 2-D array*
-  and runs the indicator over all of them in a single vectorized (optionally jitted/multithreaded) pass.
-  `run_unique=True` **deduplicates repeated param combinations**; `cache_func` + `cached_property/method`
-  share intermediate results (e.g. a base EMA reused by BBANDS) across combos.
-- **Transferable idea:** this is the CPU analogue of our GPU-batch lever — compute a *whole param grid of
-  one indicator at once* rather than one array per cold miss. Their `run_unique` is exactly our cache's
-  dedup, but applied *within a single vectorized call*. Validates batching the top-N vectorizable
-  oscillators (Task 5) and suggests a **CPU batched path** as the "dumb control" the GPU must beat.
-- Sources: [DeepWiki](https://deepwiki.com/polakowo/vectorbt), [factory](https://vectorbt.dev/api/indicators/factory/), [PRO Indicators](https://vectorbt.pro/features/indicators/), [PRO Performance](https://vectorbt.pro/features/performance/).
+## 1. vectorbt / vectorbt PRO — batch params as array columns, chunked cache, Numba
+- **What (verified timings, `vectorbt.pro/features/performance`):** rolling mean **Pandas 45.6 ms →
+  Numba 5.33 ms → Numba+parallel 1.82 ms** (~25×); rolling Sortino **QuantStats 2.79 s → VBT 8.12 ms
+  (~343×)**; random-portfolio threadpool ~2×. Parameter sweeps run through `@vbt.chunked(chunk_len=100)`
+  — "at most 100 parameter combinations at once" — with `clear_cache=True` + `collect_garbage=True`
+  between chunks, and a central cache registry reporting hits/misses/MB per property (e.g. `filled_close`
+  6 hits / 1 miss).
+- **Correction to the first pass:** `run_unique` (dedup of repeated param combos) and `cache_func` are real
+  vectorbt features but come from the **DeepWiki** overview, *not* the performance page — re-sourced below.
+- **Transferable idea:** batching a *whole param grid of one indicator into columns and computing in one
+  vectorized/Numba pass* is the CPU analogue of our GPU-batch lever, and the **chunked** pattern
+  (bounded combos per pass + explicit cache clearing) is exactly how to keep our batch memory-bounded
+  against the 4B-combo wall. This is the **CPU-batched dumb control** the GPU must beat (Task 5).
+- Sources: [PRO Performance](https://vectorbt.pro/features/performance/), [DeepWiki](https://deepwiki.com/polakowo/vectorbt) (run_unique/cache_func), [factory](https://vectorbt.dev/api/indicators/factory/).
 
-## 2. talipp / wickra — incremental (O(1)/tick) wins for *streaming*, loses to C batch for *one-shot*
-- **What:** `talipp` computes indicators incrementally — O(1) per new tick vs O(n) recompute — ideal for
-  live/iterative input; it beats TA-Lib when you *append* data. **But for a one-shot full-history batch,
-  TA-Lib (C, vectorized) is "a clear winner."** `wickra` is a Rust-core, 514-indicator, O(1)-per-tick,
-  drop-in TA-Lib replacement with Python bindings.
-- **Transferable idea:** our optimizer cold miss is a **batch** (compute the full 486,970-bar history once
-  per new param), *not* a streaming append — so the incremental route is the wrong tool for the cold miss;
-  vectorized/C/GPU is right. This corroborates our own `RESEARCH_indicator_recurrence_relations.md` and
-  narrows Task 3 to the *exact* recurrences (EMA-family `lfilter`, deque max/min) rather than a general
-  streaming rewrite. `wickra` is worth noting as a prebuilt option **iff** it reproduces our vote math
-  bit-identically (unlikely without porting — parity risk).
-- Sources: [talipp](https://github.com/nardew/talipp), [talipp PyPI](https://pypi.org/project/talipp/), [wickra](https://github.com/wickra-lib/wickra).
+## 2. talipp / wickra — incremental wins *streaming*, ties C for *batch* (our cold miss is batch)
+- **talipp (verified, GitHub):** SMA(20) over 50k values — **batch ~200 ms ≈ TA-Lib ~200 ms**, but
+  **incremental 200 ms vs TA-Lib 6,800 ms (~34×)**; O(1)/update vs O(n) recompute; ~50+ indicators;
+  **does not state numerical parity with TA-Lib**. Explicit: for one-shot batch, "talib is a clear winner"
+  (C, vectorized).
+- **wickra (verified, GitHub):** 514 indicators, Rust core, O(1)/tick, drop-in TA-Lib, **zero deps** (not
+  even numpy), `array.array('d')` zero-copy to numpy; streaming 11–56× vs the other incremental peer;
+  **bit-for-bit batch==streaming across all 514 indicators**, golden fixtures replayed across 10 bindings.
+- **Transferable idea:** our optimizer cold miss is a **full-history batch** (compute 486,970 bars once per
+  new param), *not* a streaming append — so the incremental route buys nothing on the cold miss;
+  vectorized C/GPU is the ceiling. This narrows Task 3 to the *exact* recurrences (EMA-family `lfilter`,
+  deque max/min) rather than a general streaming rewrite. wickra's bit-for-bit batch/stream is an
+  engineering signal, but its parity is with **TA-Lib conventions, not our vote math** → adopting it would
+  still require our bit-identical gate (high risk; note only).
+- Sources: [talipp](https://github.com/nardew/talipp), [wickra](https://github.com/wickra-lib/wickra).
 
-## 3. Qlib — two-level (LRU memory + disk) expression cache with sub-expression reuse
-- **What:** Qlib parses each feature expression into a syntax tree and caches **every node's** result in an
-  in-memory LRU plus a `DiskExpressionCache`; a repeated (sub-)expression loads from cache instead of
-  recomputing. Disk cache on by default.
-- **Transferable idea:** exactly mirrors our `_VOTE_MEMO` (memory) + `vote_cache` (disk) two-level design —
-  independent industrial validation that our architecture is the standard answer. The *new* idea is
-  **sub-expression** caching: several of our indicators share a base EMA/ATR (MACD, Keltner, ADX). Caching
-  at the shared-primitive level (below `directions()`) could cut cold-miss cost further — a candidate for
-  the Task 6 cache-level analysis and a possible follow-up.
+## 3. Qlib — two-level (LRU memory + hash-keyed disk) cache, sub-expression reuse
+- **What (verified, readthedocs):** a global `MemCache` (Calendar/Instruments/**Features**), size-bounded
+  by `mem_cache_size_limit`/`limit_type`; `DiskExpressionCache` persists expression results (e.g.
+  `Mean($close,5)`) to disk under **hash-based names `hash(instrument, field_expression, freq)`**;
+  `DatasetCache` (`disk_cache=1` **default**) with `.meta`/`.index` tracking config + visit frequency;
+  server uses `redis_lock` to guard read/write conflicts.
+- **Transferable idea:** independent industrial confirmation that our `_VOTE_MEMO` (memory) + `vote_cache`
+  (sha256-keyed disk `.npy`) two-level design **is** the standard answer — Qlib's `hash(instrument, field,
+  freq)` maps 1:1 onto our `disk_key(version, slice_sig, use1, key, mode, params)`. The *new* idea is
+  caching **sub-expressions** (Qlib caches every syntax-tree node): several of our indicators share a base
+  EMA/ATR (MACD, Keltner, ADX) — caching that shared primitive *below* `directions()` could cut cold-miss
+  cost further (Task 6 cache-level note + a possible follow-up). Qlib's `redis_lock` also foreshadows our
+  Postgres-store contention lesson.
 - Sources: [Qlib data layer](https://qlib.readthedocs.io/en/stable/component/data.html), [Qlib paper](https://arxiv.org/pdf/2009.11189).
 
-## 4. RAPIDS cuDF / CuPy + Numba-CUDA — GPU batch is real, but only for the right shape
-- **What:** cuDF (~40× pandas on DataFrame-heavy pipelines), CuPy (NumPy-API GPU arrays), and Numba-CUDA
-  (NVIDIA reports >100× on *batched* Monte-Carlo trading simulations) all push array math to the GPU.
-  Repeated theme: **"batching thousands of scenarios on the GPU reduces minutes to seconds."**
-- **Transferable idea:** the GPU win is *throughput across many parallel scenarios*, not latency on one —
-  which is precisely our Task 5 framing (many param-combos of one indicator per kernel), **not** the tiny
-  28 MB data volume the 2026-06-11 scaling study correctly said GPU can't help. Caveat from the same
-  sources: cuDF's big wins are DataFrame ops (joins/groupby); our per-bar rolling arithmetic maps to
-  **CuPy / custom CUDA kernels**, and the host↔device transfer + kernel-launch overhead sets a break-even
-  #combos below which CPU wins — exactly what Task 5 measures.
-- Sources: [RAPIDS cuDF](https://developer.nvidia.com/blog/accelerated-data-analytics-speed-up-data-exploration-with-rapids-cudf/), [Numba 100× trading](https://developer.nvidia.com/blog/gpu-accelerate-algorithmic-trading-simulations-by-over-100x-with-numba/), [RAPIDS for trading](https://blog.quantinsti.com/nvidia-gpu-rapids-libraries-trading/), [cuDF+CuPy interop](https://medium.com/rapids-ai/10-minutes-to-cudf-and-cupy-e131cac0439b).
+## 4. RAPIDS cuDF / CuPy + Numba-CUDA — GPU batch is real, and its shape is exactly ours
+- **What (verified, NVIDIA H200 blog):** Monte-Carlo order-book sim — **14× (1 trading day) → 38× (5 days)
+  → 114× (1 month)** vs CPU. The speedup *grew with the time horizon* because the **time dimension stayed
+  sequential** while the **`Nsims = 1,000` parallel paths** saturated 14,000+ CUDA cores; `@cuda.jit`
+  kernels, random variates pre-batched to device via `cuda.to_device()` to avoid per-call overhead.
+  Separately, cuDF ≈ 40× pandas on DataFrame-heavy pipelines.
+- **Transferable idea (strong):** this is a near-perfect analogue of our cold miss. Our **serial dimension
+  is the price time-series** (per-bar recurrence, can't parallelize within one array); our **parallel
+  dimension is the param-combos** (thousands of independent parameterizations of one indicator). Batch
+  many combos per kernel and the GPU should show the same "parallel-axis" win — *provided* the per-combo
+  arithmetic amortizes the host↔device transfer (the break-even #combos Task 5 measures). cuDF's DataFrame
+  wins don't apply (our per-bar rolling math → **CuPy / custom CUDA kernels**), and the 2026-06-11 scaling
+  study's "GPU can't help the tiny 28 MB data" verdict is *not* contradicted — this is a *throughput*
+  win across combos, a different axis than data volume.
+- Sources: [Numba 114× trading (H200)](https://developer.nvidia.com/blog/gpu-accelerate-algorithmic-trading-simulations-by-over-100x-with-numba/), [RAPIDS cuDF](https://developer.nvidia.com/blog/accelerated-data-analytics-speed-up-data-exploration-with-rapids-cudf/), [cuDF+CuPy interop](https://medium.com/rapids-ai/10-minutes-to-cudf-and-cupy-e131cac0439b).
 
-## 5. Cache substrate — shared-memory options for cross-process array reuse
-- **What:** Arrow **Plasma** offered zero-copy immutable objects in shared memory across processes
-  (originated in Ray). **Caveat (verify, don't assume): Plasma was deprecated and removed from Apache Arrow
-  in later releases (~Arrow 12)** — it is *not* a safe new dependency in 2026. The durable options are
-  `/dev/shm` tmpfs (RAM-backed files, no serialization change from `.npy`), Python
-  `multiprocessing.shared_memory` (zero-copy numpy views across processes), Redis (network/socket hop +
-  (de)serialization, but battle-tested cross-host), and memory-mapped files.
-- **Transferable idea:** our current disk `.npy` under `/tmp` may already be on tmpfs or page-cache-hot
-  (123 GB RAM box) — so the *first* substrate question is empirical: is the `.npy` open/parse the cost, or
-  is it already RAM-speed? Task 6 measures `.npy` vs `/dev/shm` vs `shared_memory` vs Redis under 30
-  readers; **skip Plasma** (deprecated) and only include Redis if already installed (no silent caps).
-- Sources: [Plasma announcement](https://arrow.apache.org/blog/2017/08/08/plasma-in-memory-object-store/), [Arrow zero-copy cluster shared memory (2024)](https://arxiv.org/html/2404.03030v1).
+## 5. Cache substrate — shared-memory options (Plasma is dead; verified)
+- **What (verified against source):** Arrow **Plasma** (zero-copy immutable shared-memory objects, from
+  Ray) is **deprecated since Arrow 10.0.0 and REMOVED in Arrow 12.0.0** (2023-05-02, GH-33243); the
+  project's own migration guidance is pyarrow **IPC** or stdlib **pickle**. So Plasma is *not* a valid new
+  dependency in 2026. The durable options: `/dev/shm` tmpfs (RAM-backed files — same `.npy` code path,
+  zero serialization change), Python `multiprocessing.shared_memory` (zero-copy numpy views across
+  processes), Redis (socket hop + (de)serialization, but battle-tested cross-host), and mmap'd files.
+- **Transferable idea:** our current disk `.npy` under `/tmp` on a 123 GB box is very likely already
+  page-cache-hot (RAM-speed reads) — so the *first* substrate question is empirical: is the `.npy`
+  open/parse the cost, or is it already RAM-speed? Task 6 measures `.npy` vs `/dev/shm` vs
+  `shared_memory` vs Redis under 30 readers; **skip Plasma** (removed) and include Redis only if already
+  installed (log the skip — no silent caps).
+- Sources: [Plasma removed in 12.0.0 (GH-33243)](https://github.com/apache/arrow/issues/33243), [Plasma deprecated (GH-34738)](https://github.com/apache/arrow/issues/34738), [Arrow 12.0.0 release](https://arrow.apache.org/blog/2023/05/02/12.0.0-release/).
 
 ---
 
 ## Synthesis → how prior art shapes each lever
 
-| Our lever (issue #54) | Prior-art verdict | Consequence for the PoC |
-|-----------------------|-------------------|-------------------------|
-| **Cold-miss compute (priority)** | vectorbt batches param-grids into columns; GPU gives 100× only on batched scenarios; incremental is wrong for one-shot batch | Task 5 GPU-batches the top-N oscillators; add a **CPU-batched** path as a dumb control the GPU must beat; keep Task 3 to the *exact* EMA/deque recurrences |
-| **Cache substrate** | Qlib validates 2-level memo+disk; Plasma deprecated; tmpfs/`shared_memory` are the live options | Task 6 measures `.npy` vs tmpfs vs `shared_memory` vs Redis; drop Plasma; question is empirical (is `.npy` already RAM-hot?) |
-| **Cache level** | Qlib caches *sub-expressions*, not just top-level features | Task 6 counts reuse for a `directions()` key; flag shared-primitive (EMA/ATR) caching as a follow-up |
-| **Do nothing / prebuilt** | `wickra` (Rust, drop-in TA-Lib) exists | Note as an option, but parity risk is high — our vote math must reproduce bit-identically |
+| Our lever (issue #54) | Prior-art verdict (with numbers) | Consequence for the PoC |
+|-----------------------|----------------------------------|-------------------------|
+| **Cold-miss compute (priority)** | vectorbt Numba rolling-mean 45.6→1.82 ms (~25×); GPU H200 114× *because* the parallel axis (1000 paths) saturates cores while time stays serial; incremental ties C for batch | Task 5 GPU-batches top-N oscillators along the **param-combo axis**; add a **CPU-batched (Numba/chunked)** dumb control the GPU must beat; Task 3 stays on the exact EMA/deque recurrences |
+| **Cache substrate** | Qlib validates 2-level memo+hash-disk cache; **Plasma removed (Arrow 12.0.0)**; tmpfs/`shared_memory`/Redis are the live options | Task 6 measures `.npy` vs tmpfs vs `shared_memory` vs Redis; **drop Plasma**; question is empirical (is `.npy` already RAM-hot on the 123 GB box?) |
+| **Cache level** | Qlib caches *every sub-expression* node, not just top-level features | Task 6 counts reuse for a `directions()` key; flag shared-primitive (EMA/ATR) sub-caching as a follow-up |
+| **Do nothing / prebuilt** | wickra (Rust, 514 indicators, bit-for-bit batch/stream) exists but matches **TA-Lib**, not our votes | Note as an option; parity with our vote math is unproven → high adoption risk |
 
-**Bottom line from prior art:** our two-level cache is the industry-standard design (Qlib), the GPU angle
-is legitimate *only* as batched-param throughput (RAPIDS/Numba), the cold miss should be attacked with
-vectorized/GPU batch rather than incremental streaming (talipp/TA-Lib), and the substrate benchmark should
-skip the deprecated Plasma and test tmpfs/`shared_memory`/Redis against a possibly-already-RAM-hot `.npy`.
+**Bottom line from prior art:** our two-level cache is the industry-standard design (Qlib, to the hash-key
+detail); the GPU angle is legitimate specifically as **batched-param throughput** and the published H200
+114× is the *same parallel-axis mechanism* we'd exploit; the cold miss must be attacked with
+vectorized/GPU batch rather than incremental streaming (talipp/TA-Lib prove incremental ties C only for
+batch); and the substrate benchmark should **skip the removed Plasma** and test tmpfs/`shared_memory`/Redis
+against a `.npy` cache that may already be RAM-hot.

--- a/subprojects/Parametric-Indicators/docs/superpowers/plans/2026-07-27-indicator-cache-acceleration.md
+++ b/subprojects/Parametric-Indicators/docs/superpowers/plans/2026-07-27-indicator-cache-acceleration.md
@@ -1,0 +1,334 @@
+# Indicator Cold-Miss Acceleration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do NOT use analysis subagents**
+> (user rule: work inline, re-verify any mechanical parallel search yourself).
+
+**Goal:** Measure where the optimizer sweep's indicator time goes on the real server, then prove or
+disprove — with bit-identical parity — whether Numba/recurrence (CPU) and GPU batch-compute cut
+cold-miss indicator wall-clock by ≥3×, ranked against two dumb controls.
+
+**Architecture:** A read-only instrumentation harness first establishes the ground-truth cold/warm/I-O
+split on one real study. Cold-miss accelerators (CPU Numba/recurrence, then a batched CuPy/Numba-CUDA
+GPU kernel for the top-N vectorizable indicators) are each built behind a feature flag and gated on a
+bit-identical parity test against the existing pure-Python path. Secondary micro-benchmarks cover cache
+substrate and cache-level reuse. A final report ranks every lever.
+
+**Tech Stack:** Python, numpy, Numba (`@njit`), scipy.signal.lfilter, CuPy / Numba-CUDA (GPU box),
+Optuna+Postgres (existing), pytest (parity gates). Server: AMD (CPU) now; NVIDIA (requested) for GPU.
+
+## Global Constraints
+
+- **Speed only — results MUST NOT change.** Every accelerator is gated on bit-identical votes: verbatim
+  parity `$7,735 / $3,670 / n=66` (`optimize/test_parity.py`) + `optimize/test_indicator_parity.py` +
+  full `pytest` + a champion reproduction (wsh4 4h `$142,203 ± rounding`).
+- **No heavy compute on the local box.** All benchmarks run on the server; every long run emits a live
+  progress log + short polls (never a silent blocking wait).
+- **Local = source of truth.** Every PoC output + report is scp'd back and committed on this branch.
+- **No silent defaults.** Print the exact indicators/params used in every benchmark run.
+- **Pre-registered GO criterion:** a lever is adopted only if bit-identical AND ≥3× cold-miss reduction
+  AND it beats both dumb controls (warm `.npy` cache; +CPU workers). A quantified NO-GO is a valid result.
+- Working dir: `subprojects/Parametric-Indicators/` on branch `research/indicator-cache-acceleration`.
+
+---
+
+## File Structure
+
+- `optimize/perf/__init__.py` — new package for perf harnesses.
+- `optimize/perf/cache_probe.py` — instrumentation: wraps vote_cache to count hits/misses/cold-seconds/bytes.
+- `optimize/perf/test_cache_probe.py` — unit tests for the counters (result-neutral wrapper).
+- `optimize/perf/run_baseline.py` — server entry: run one real study slice, emit the cold/warm/I-O profile.
+- `optimize/perf/cold_accel.py` — CPU cold-miss accelerators (deque stoch, mfi sliding-sum, EMA lfilter/njit) behind a flag.
+- `optimize/perf/test_cold_accel_parity.py` — bit-identical parity: accelerated vs pure-Python reference.
+- `optimize/perf/gpu_batch.py` — batched GPU kernel for the top-N vectorizable indicators (CuPy/Numba-CUDA).
+- `optimize/perf/test_gpu_batch_parity.py` — GPU-vs-CPU bit/≈-identity on a fixed fold (skipped if no GPU).
+- `optimize/perf/bench_substrate.py` — substrate micro-bench (.npy vs shm/Redis/Arrow/DuckDB) under N readers.
+- `optimize/perf/bench_cache_level.py` — count distinct arrays: vote/mode key vs directions() key.
+- `optimize/REPORT_indicator_cache_acceleration.md` — final report (Mermaid, verbose, decision matrix, GO/NO-GO).
+- `docs/PRIOR_ART_indicator_caching_gpu.md` — online prior-art notes feeding the report.
+
+---
+
+## Task 0: Online prior-art pass (research, no code)
+
+**Files:**
+- Create: `docs/PRIOR_ART_indicator_caching_gpu.md`
+
+**Interfaces:**
+- Produces: cited findings the report's §"prior art" and each lever's "is this already solved" note reuse.
+
+- [ ] **Step 1: Search & read** — vectorbt / vectorbtpro indicator caching & broadcasting; NautilusTrader
+  indicator model; Microsoft Qlib expression/feature cache; TA-Lib vs pandas-ta vs `talipp` (incremental);
+  Optuna storage/caching practice; GPU technical-analysis (`cuDF`, CuPy rolling, `cuIndicators`/RAPIDS),
+  Arrow Plasma / shared-memory object stores; feature-store cold-vs-warm patterns. (WebSearch/WebFetch.)
+- [ ] **Step 2: Write notes** — for each: what they do, whether it maps to our pure-`directions()`
+  function, and the one transferable idea. One paragraph each, with URLs.
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/PRIOR_ART_indicator_caching_gpu.md
+git commit -m "docs(perf): online prior-art notes on indicator caching + GPU TA (#54)"
+```
+
+---
+
+## Task 1: Instrumentation harness (counters)
+
+**Files:**
+- Create: `optimize/perf/__init__.py`, `optimize/perf/cache_probe.py`, `optimize/perf/test_cache_probe.py`
+
+**Interfaces:**
+- Consumes: `optimize/vote_cache.py` (`get`, `put`, `disk_key`), `optimize/core._cached_votes`.
+- Produces: `cache_probe.Probe` with `.install()` / `.uninstall()` / `.snapshot() -> dict` returning
+  `{hits, misses, cold_seconds, bytes_read, bytes_written, per_indicator: {key: {misses, cold_seconds}}}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# optimize/perf/test_cache_probe.py
+import numpy as np
+from optimize import vote_cache
+from optimize.perf.cache_probe import Probe
+
+def test_probe_counts_hits_and_misses_without_changing_arrays(tmp_path):
+    vote_cache.set_cache_dir(tmp_path)
+    vote_cache._clear_disk_cache()
+    p = Probe(); p.install()
+    dkey = vote_cache.disk_key(("sig",), True, "rsi", "confirm", (("n", 14),))
+    arr = np.arange(10, dtype=np.int8)
+    assert vote_cache.get(dkey) is None          # miss
+    vote_cache.put(dkey, arr)
+    got = vote_cache.get(dkey)                    # hit
+    p.uninstall()
+    snap = p.snapshot()
+    assert snap["misses"] == 1 and snap["hits"] == 1
+    assert np.array_equal(got, arr)              # result-neutral
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest optimize/perf/test_cache_probe.py -v` — Expected: FAIL (`cache_probe` not found).
+
+- [ ] **Step 3: Implement `cache_probe.Probe`** — monkeypatch `vote_cache.get`/`put` to count and time,
+  delegating to the originals; `install()` saves originals, `uninstall()` restores them; a cold-compute
+  timer wraps the miss branch by also patching `core.runner._ind_vote` (increment `misses` + accumulate
+  wall-clock, keyed by indicator key parsed from the call). Return counts via `snapshot()`.
+
+- [ ] **Step 4: Run test to verify it passes** — Run: `pytest optimize/perf/test_cache_probe.py -v` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add optimize/perf/__init__.py optimize/perf/cache_probe.py optimize/perf/test_cache_probe.py
+git commit -m "feat(perf): result-neutral cache probe counting hits/misses/cold-seconds (#54)"
+```
+
+---
+
+## Task 2: Baseline profile on the real server
+
+**Files:**
+- Create: `optimize/perf/run_baseline.py`
+
+**Interfaces:**
+- Consumes: `cache_probe.Probe`, the existing study launcher (`optimize/optimizer.py` / `core.run_l1_cached`).
+- Produces: `optimize/perf/results/baseline_<instrument>_<tf>.json` — the ground-truth cold/warm/I-O split
+  and the **ranked per-indicator cold-cost table** that Task 5 (GPU top-N) consumes.
+
+- [ ] **Step 1: Write `run_baseline.py`** — install the Probe, run a fixed, seeded N-trial slice of one
+  real study (default: NQ 4h, cold cache) with `ind_1min=True`; print the params used (no-silent-defaults);
+  on finish dump `snapshot()` + wall-clock to JSON. Emit a progress line every M trials (never-wait-blindly).
+- [ ] **Step 2: Dry-run locally tiny** — `python -m optimize.perf.run_baseline --trials 3 --smoke` to prove
+  it runs and writes JSON (3 trials is negligible, not "heavy compute").
+- [ ] **Step 3: Run on server** — scp/pull the branch to the AMD box, run the real slice (e.g. `--trials 200`)
+  under `nohup` with a tailed log; poll the progress log. **Do not block silently.**
+- [ ] **Step 4: Pull results back** — scp `baseline_*.json` + log to local; commit. Record the headline
+  split (cold % / warm-hit % / I-O %) and the top-N costliest indicators in the commit message.
+- [ ] **Step 5: Commit**
+
+```bash
+git add optimize/perf/run_baseline.py optimize/perf/results/baseline_*.json
+git commit -m "perf: server baseline — real cold/warm/IO split + per-indicator cold-cost ranking (#54)"
+```
+
+---
+
+## Task 3: CPU cold-miss accelerators (parity-gated)
+
+**Files:**
+- Create: `optimize/perf/cold_accel.py`, `optimize/perf/test_cold_accel_parity.py`
+
+**Interfaces:**
+- Consumes: `indicators/classic.py` reference functions (loops), `indicators/library.py` indicator specs.
+- Produces: `cold_accel.accelerated_directions(key, ctx, params) -> (cdir, vdir)` matching
+  `Indicator.directions` **bit-identically**, and a flag `COLD_ACCEL` (default OFF ⇒ parity preserved).
+
+- [ ] **Step 1: Write the failing parity test** (start with the exact wins from
+  `RESEARCH_indicator_recurrence_relations.md`: monotonic-deque stochastic max/min, mfi sliding-sum, EMA
+  family via `lfilter`/`@njit`):
+
+```python
+# optimize/perf/test_cold_accel_parity.py
+import numpy as np
+from indicators import library
+from indicators.runner import market_context
+from optimize.perf import cold_accel
+
+def _ctx(seed=0, n=5000):
+    rng = np.random.default_rng(seed); c = 21000 + np.cumsum(rng.normal(0, 5, n))
+    import pandas as pd
+    df = pd.DataFrame({"Date": pd.date_range("2020", periods=n, freq="min"),
+                       "Open": c, "High": c+2, "Low": c-2, "Close": c, "Volume": rng.integers(1,100,n)})
+    return market_context(df)
+
+def test_stochastic_accel_bit_identical():
+    ctx = _ctx(); params = {"k": 14, "d": 3, "smooth": 3, "overbought": 80, "oversold": 20}
+    ref_c, ref_v = library.build("stochastic", params).directions(ctx)
+    acc_c, acc_v = cold_accel.accelerated_directions("stochastic", ctx, params)
+    assert np.array_equal(acc_c, ref_c) and np.array_equal(acc_v, ref_v)
+```
+
+- [ ] **Step 2: Run to verify it fails** — Run: `pytest optimize/perf/test_cold_accel_parity.py -v` — Expected: FAIL.
+- [ ] **Step 3: Implement the deque/sliding-sum/lfilter accelerators** in `cold_accel.py`, one indicator at
+  a time; each falls back to the reference for any indicator not yet ported (so the flag is always safe).
+- [ ] **Step 4: Run to verify PASS** for each ported indicator; then run the full parity gate:
+  `pytest optimize/test_parity.py optimize/test_indicator_parity.py optimize/perf/test_cold_accel_parity.py -v`.
+- [ ] **Step 5: Micro-bench** the ported set (cold-compute time accel vs reference) via a small timing loop
+  in the test file's `__main__`; record the per-indicator speedup.
+- [ ] **Step 6: Commit**
+
+```bash
+git add optimize/perf/cold_accel.py optimize/perf/test_cold_accel_parity.py
+git commit -m "feat(perf): CPU cold-miss accelerators (deque/sliding-sum/lfilter), parity-gated (#54)"
+```
+
+---
+
+## Task 4: Provision the NVIDIA box
+
+**Files:** none (ops).
+
+**Interfaces:**
+- Produces: an SSH-reachable GPU host + recorded `nvidia-smi` / CUDA / CuPy versions for the report.
+
+- [ ] **Step 1: Request/provision** — the interactive login or provider command is the USER's to run;
+  surface it and ask them to run it via `! <command>` so output lands in-session. **Blocked-on-user.**
+- [ ] **Step 2: Record environment** — once reachable, capture `nvidia-smi`, `nvcc --version`,
+  `python -c "import cupy; print(cupy.__version__)"` into `optimize/perf/results/gpu_env.txt`.
+- [ ] **Step 3: Commit** the env capture (no secrets):
+
+```bash
+git add optimize/perf/results/gpu_env.txt
+git commit -m "chore(perf): record GPU box environment (driver/CUDA/CuPy) (#54)"
+```
+
+---
+
+## Task 5: GPU batch-compute PoC (top-N, parity-gated)
+
+**Files:**
+- Create: `optimize/perf/gpu_batch.py`, `optimize/perf/test_gpu_batch_parity.py`
+
+**Interfaces:**
+- Consumes: Task 2's per-indicator ranking (choose top-N **vectorizable** ones — rolling-window
+  oscillators; exclude stateful SMC), the reference `directions()`.
+- Produces: `gpu_batch.batch_directions(key, ctx, param_grid) -> np.ndarray[len(grid), 2, N]` computing
+  many param-combos of one indicator in a single device call; result copied back to host int8.
+
+- [ ] **Step 1: Write the failing GPU parity test** (auto-skip when no CUDA):
+
+```python
+# optimize/perf/test_gpu_batch_parity.py
+import numpy as np, pytest
+cupy = pytest.importorskip("cupy")
+from indicators import library
+from optimize.perf import gpu_batch
+# reuse _ctx from the CPU parity test module
+from optimize.perf.test_cold_accel_parity import _ctx
+
+def test_gpu_batch_matches_cpu_for_each_combo():
+    ctx = _ctx(); grid = [{"n": n, "k": 2.0} for n in (10, 20, 30)]  # example: bollinger
+    out = gpu_batch.batch_directions("bollinger", ctx, grid)         # [3, 2, N]
+    for i, p in enumerate(grid):
+        ref_c, ref_v = library.build("bollinger", p).directions(ctx)
+        assert np.array_equal(out[i, 0], ref_c) and np.array_equal(out[i, 1], ref_v)
+```
+
+- [ ] **Step 2: Run on the GPU box to verify it fails** — Expected: FAIL (`gpu_batch` not implemented).
+- [ ] **Step 3: Implement `batch_directions`** — CuPy rolling kernels for the top-N; one host↔device
+  transfer of the price arrays, param-combos as a batched axis; copy results back as int8. Any combo whose
+  GPU result is not bit-identical to CPU is **rejected** and flagged (per Global Constraints).
+- [ ] **Step 4: Run to verify PASS** on the GPU box.
+- [ ] **Step 5: Benchmark** cold-miss throughput: CPU (Task 3) vs GPU (this task) across grid sizes
+  {1, 16, 256, 4096} combos, **including** host↔device transfer; write `gpu_batch_bench.json`. Compute the
+  break-even #combos where GPU overtakes CPU.
+- [ ] **Step 6: Pull results + commit**
+
+```bash
+git add optimize/perf/gpu_batch.py optimize/perf/test_gpu_batch_parity.py optimize/perf/results/gpu_batch_bench.json
+git commit -m "feat(perf): batched GPU indicator kernel + CPU-vs-GPU cold-miss benchmark (#54)"
+```
+
+---
+
+## Task 6: Secondary — substrate & cache-level micro-benchmarks
+
+**Files:**
+- Create: `optimize/perf/bench_substrate.py`, `optimize/perf/bench_cache_level.py`
+
+**Interfaces:**
+- Consumes: a fixed set of real `directions()` arrays (dumped once from Task 2).
+- Produces: `substrate_bench.json` (hit-latency per backend under N concurrent readers) +
+  `cache_level_reuse.json` (distinct-array count: vote/mode key vs directions() key on a real sweep trace).
+
+- [ ] **Step 1: `bench_substrate.py`** — store/load the fixed array set via `.npy` (current), `/dev/shm`
+  tmpfs, `multiprocessing.shared_memory`, Redis (if available), Arrow/Plasma (if available), DuckDB; drive
+  N=30 concurrent readers; record p50/p99 hit latency. Skip backends not installed (log the skip — no
+  silent caps).
+- [ ] **Step 2: `bench_cache_level.py`** — replay a real sweep's `(indicator, mode, params, tf)` request
+  trace; count distinct arrays under (a) today's `(…, mode, params)` key vs (b) a `(…, params)` key shared
+  across modes and the 6 TFs. Report the reuse multiplier.
+- [ ] **Step 3: Run on server, pull results, commit**
+
+```bash
+git add optimize/perf/bench_substrate.py optimize/perf/bench_cache_level.py optimize/perf/results/substrate_bench.json optimize/perf/results/cache_level_reuse.json
+git commit -m "perf: substrate + cache-level micro-benchmarks (#54)"
+```
+
+---
+
+## Task 7: Report — decision matrix + GO/NO-GO
+
+**Files:**
+- Create: `optimize/REPORT_indicator_cache_acceleration.md`
+
+**Interfaces:**
+- Consumes: all `optimize/perf/results/*.json`, Task 0 prior-art notes.
+
+- [ ] **Step 1: Write the report** — verbose, no-jargon, concrete numbers; **Mermaid-only** visuals
+  (pipeline diagram, cold/warm/I-O split, CPU-vs-GPU break-even curve, decision matrix). Sections: the two
+  reframing findings; prior art; baseline split; each lever's measured result vs the two dumb controls;
+  "what went well / what went wrong"; GO/NO-GO per the pre-registered criterion; recommended follow-up
+  issue(s) for adopting any winning lever.
+- [ ] **Step 2: Verify every number** in the report against the JSON artifacts (no unverified claims).
+- [ ] **Step 3: Commit + open PR** referencing #54
+
+```bash
+git add optimize/REPORT_indicator_cache_acceleration.md
+git commit -m "docs(perf): indicator cache-acceleration report — findings + GO/NO-GO (#54)"
+git push -u origin research/indicator-cache-acceleration
+gh pr create --title "Research: indicator cold-miss acceleration (Numba + GPU) — findings" --body "Closes #54. ..." --base dev
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Q1 GPU → Tasks 4,5; Q2 Numba/recurrence → Task 3; Q3 substrate → Task 6; Q4 cache
+  level → Task 6; instrumentation/baseline → Tasks 1,2; prior-art → Task 0; report/criterion → Task 7. All
+  spec sections mapped.
+- **Dumb controls:** enforced in Task 7's matrix (warm `.npy` + `+workers`), per criterion.
+- **Parity gate:** Tasks 3 & 5 each end on the bit-identical gate; default flags OFF ⇒ production unchanged.
+- **Dependency note:** Task 5's top-N selection consumes Task 2's ranking; Task 4 (GPU box) blocks Task 5
+  but not 1–3/6 — CPU track + report ship even if GPU provisioning stalls (spec §4.4).
+- **No local heavy compute:** every real run is server-side with a live log; only 3-trial smokes run locally.

--- a/subprojects/Parametric-Indicators/docs/superpowers/specs/2026-07-27-indicator-cache-acceleration-design.md
+++ b/subprojects/Parametric-Indicators/docs/superpowers/specs/2026-07-27-indicator-cache-acceleration-design.md
@@ -1,0 +1,144 @@
+# Design — Accelerating Indicator Cold-Miss Compute (Numba + GPU batch)
+
+**Date:** 2026-07-27 · **Issue:** #54 · **Branch:** `research/indicator-cache-acceleration`
+**Type:** research (pre-registered criterion) · **Hard rule:** speed only — results must not change.
+
+---
+
+## 1. Context (what is actually true today)
+
+A single backtest spends **~98–99% of wall-clock computing indicators** on the 486,970-row 1-minute
+frame; the trade/exit engine (`fast_engine`, vectorized + memoized, faster/trial than vectorBT) is ~1–2%.
+The optimizer is two-stage: **compute indicator signals → backtest on them**, run as ~30 shared-nothing
+Optuna worker processes against a Postgres trial store.
+
+Two facts, established from the codebase this session, define the problem:
+
+### Finding A — "precompute everything" is a combinatorics wall, not a bandwidth wall
+The 165 registered indicators (`indicators/library.py:SCHEMA`) carry discrete **stepped** parameter grids.
+Their full Cartesian product is **~4.0 billion parameterizations** (top contributors: Schaff Trend Cycle
+2.32B, stoch-RSI 1.18B, vol_ratio 106M, Kalman 100M, wavetrend 96M …). Each `directions()` output is
+~1 MB (cdir+vdir int8 × 486,970 bars), so materializing the full grid for **one** instrument ≈ **3.9 PB**.
+No storage tier (RAM, Redis, tmpfs, SSD, VRAM) changes this. **Precomputing "all possibilities" is out.**
+
+### Finding B — the on-demand cache the question imagines already exists
+`ind.directions()` — the expensive kernel — is a **pure function of `(indicator, params, price series)`**,
+independent of K, retrace/wait, SL/TP, the drawdown breaker, and the other enabled indicators. The repo
+already exploits this:
+
+- `optimize/core.py` — in-process `_VOTE_MEMO` keyed by `(slice_sig, use1, indicator_key, mode, params)`.
+- `optimize/vote_cache.py` — disk `.npy` cache under `/tmp/wsh_vote_cache/`, **shared across worker
+  processes + watchdog respawns**, atomic writes, versioned key. Result-neutral by construction.
+
+Memory records the payoff already banked: *memoization took candidate-L1 from 24 → 1286 trials/min.*
+
+**Conclusion.** The open question is not "should we cache" (done) but **"can we make the COLD MISS — the
+first time each `(indicator, params)` is computed — dramatically cheaper, and is `.npy`-on-SSD the right
+substrate?"** The actually-visited set across a full sweep is only tens of thousands of arrays, heavily
+re-requested across 30 workers and 6 timeframes — so cold-miss cost and substrate latency are the levers.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+1. Quantify, on the real server, where sweep time goes: cold-miss compute vs warm-cache hits vs I/O.
+2. **Primary lever (user priority): cut cold-miss compute** via (a) Numba / streaming-recurrence on CPU,
+   (b) **GPU batch-compute** — many parameterizations of one indicator in one batched kernel — benchmarked
+   on a requested NVIDIA box.
+3. Secondary analyses (report + smaller benchmarks): cache **substrate** (`.npy` vs tmpfs/Redis/Arrow/
+   shared-memory/DuckDB) and cache **level** (re-key at `directions()` to kill the 3× `mode` duplication
+   and share across the 6 decision TFs).
+4. A ranked, evidence-backed recommendation + the PoC code, all committed locally.
+
+**Non-goals**
+- Changing any result (bit-identical parity is a hard gate).
+- Precomputing the full grid (Finding A).
+- Replacing the Optuna/Postgres orchestration (covered by the 2026-06-11 scaling study; out of scope).
+- Distributed multi-node execution (deferred).
+
+---
+
+## 3. Research questions & pre-registered hypotheses
+
+| # | Question | Hypothesis to test | Primary metric |
+|---|----------|--------------------|----------------|
+| Q1 | Does GPU batch-compute of the top-N costliest indicators beat CPU on cold misses? | GPU wins only when a single kernel amortizes host↔device transfer over **many** param-combos of one indicator (high arithmetic intensity); loses on sequential/stateful ones (SMC, EMA-family recurrences). | cold-miss arrays/sec, incl. transfer + provisioning |
+| Q2 | Does Numba/streaming-recurrence cut cold-miss CPU cost bit-identically? | Yes for the classes flagged in `RESEARCH_indicator_recurrence_relations.md` (monotonic-deque stoch, mfi sliding-sum, EMA-family lfilter/njit); no for `cci` (no recurrence). | cold-miss wall-clock, parity pass/fail |
+| Q3 | Is `.npy`-per-file the substrate bottleneck under 30 workers? | tmpfs/`/dev/shm` and shared-memory beat SSD on hit latency; Redis/Arrow help cross-process sharing but add serialization; DuckDB/Parquet best for analytics, not hot-path. | warm-hit latency, hit-rate |
+| Q4 | Does re-keying the cache at `directions()` (not vote/mode) raise reuse? | Yes — collapses 3× mode duplication and shares 1-min arrays across all 6 decision TFs, result-neutral. | distinct-arrays computed per sweep |
+
+**Dumb controls (mandatory).** Every lever is compared against (i) the current **warm `.npy` cache** and
+(ii) simply **adding CPU workers**. A lever must beat both to be recommended.
+
+---
+
+## 4. Architecture of the PoC
+
+Three isolated, independently-shippable pieces. None touches production defaults; all gated on parity.
+
+### 4.1 Instrumentation & baseline harness (`optimize/perf/cache_probe.py`)
+- Wrap `vote_cache.get/put` + `_cached_votes` with counters: hits, misses, cold-compute seconds,
+  bytes read/written, per-indicator breakdown. Emit a JSON/CSV profile per run.
+- Run one **real** study slice on the AMD server (live progress log per the never-wait-blindly rule);
+  produce the ground-truth cold/warm/I-O split that every later number is measured against.
+
+### 4.2 Cold-miss accelerator (PRIMARY)
+- **CPU track:** apply the already-researched exact wins (deque stoch, mfi sliding-sum, EMA-family via
+  `scipy.signal.lfilter`/Numba `@njit`) behind a feature flag, each with a bit-identical parity test vs the
+  current pure-Python reference (the repo's established pattern).
+- **GPU track:** select the top-N most-expensive *vectorizable* indicators (from 4.1's per-indicator
+  breakdown — expected: rolling-window oscillators, NOT the stateful SMC loops). Implement a **batched**
+  CuPy / Numba-CUDA kernel that computes many `(param-combo)` columns for one indicator in a single
+  device call. Benchmark cold-miss throughput vs CPU **including** host↔device transfer and one-time
+  provisioning; compute the break-even #combos.
+
+### 4.3 Substrate & level micro-benchmarks (SECONDARY)
+- Substrate: a standalone bench that stores/loads a fixed set of real arrays via `.npy` (current),
+  `/dev/shm`, `multiprocessing.shared_memory`, Redis, Arrow/Plasma, DuckDB — measured under a simulated
+  30-reader load. Report latency + concurrency behavior only (no production swap in this issue).
+- Level: prototype a `directions()`-keyed cache adapter and measure distinct-array count on a real sweep
+  vs today's vote/mode key (pure counting; result-neutral).
+
+### 4.4 GPU provisioning
+Request an NVIDIA box (per approval). Record exact GPU/driver/CUDA + CuPy versions in the report for
+reproducibility. If provisioning stalls, the CPU track + a desk estimate of the GPU ceiling still ship;
+the GPU benchmark becomes a fast follow-up rather than a blocker.
+
+---
+
+## 5. Method & guardrails
+
+- **Server-only compute**, never the local box; every long run gets a live progress log + short polls.
+- **Parity is a hard gate**: `optimize/test_parity.py`, `test_indicator_parity.py`, full `pytest`, and a
+  champion reproduction must hold after any accelerator is toggled on. A reference pure-Python/CPU path is
+  kept to diff against every optimized path.
+- **No silent defaults**: print the params/indicators actually used in each benchmark; a "speedup" that
+  changed a vote is a failure, not a win.
+- **Local = source of truth**: all PoC outputs + report scp'd back and committed on this branch.
+- **Online prior-art pass** feeds §3 (vectorbt / nautilus / Qlib / TA-Lib / Optuna caching practice;
+  cuDF/CuPy GPU technical-analysis; Arrow Plasma; feature stores) — cited in the report.
+
+## 6. Deliverable (report)
+`optimize/REPORT_indicator_cache_acceleration.md` — verbose, no-jargon, concrete-$ where relevant,
+Mermaid-only visuals, explicit "what went well / what went wrong", and a decision matrix ranking every
+lever against the two dumb controls, ending in a GO/NO-GO per §7.
+
+## 7. Pre-registered success criterion
+A lever is **GO** only if, on a fixed parity fold, it (a) produces **bit-identical** votes AND (b) shows a
+**measured ≥ 3× cold-miss wall-clock reduction** on the server (GPU: after transfer + provisioning
+overhead), AND (c) **beats both dumb controls**. A quantified **NO-GO** is a valid, publishable outcome.
+
+## 8. Risks
+| Risk | Mitigation |
+|------|------------|
+| GPU float ops diverge from CPU → breaks parity | keep CPU reference; assert bit/≈-identity on a fixed fold before any adoption; GPU may be accepted only for indicators where it reproduces exactly |
+| GPU provisioning latency blocks the study | CPU track + desk-estimated GPU ceiling ship independently; GPU benchmark is a follow-up, not a gate |
+| Stateful/sequential indicators (SMC, EMA recurrences) don't vectorize on GPU | scope GPU to the rolling-window oscillators surfaced by 4.1; leave sequential ones on CPU/Numba |
+| Substrate swap introduces a stale/poisoned array | versioned key already exists; benchmarks are read-only, no production swap in this issue |
+| Scope creep into orchestration/DB | explicitly out (§2); the 2026-06-11 scaling study owns that axis |
+
+## 9. YAGNI
+No production substrate migration, no distributed executor, no full-grid materialization, no dashboard
+work in this issue. This issue delivers **measurements + a recommendation + PoC code**; adoption of any
+winning lever is a separate, criterion-gated follow-up issue.

--- a/subprojects/Parametric-Indicators/indicators/calc/quant.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/quant.py
@@ -32,8 +32,13 @@ def hurst_exp(close, n):
     return out
 
 
-def dfa(close, n):
-    """Rolling detrended-fluctuation exponent alpha of the window's returns (few log-spaced scales)."""
+def dfa_reference(close, n):
+    """REFERENCE (slow) rolling DFA exponent — kept verbatim as the parity oracle for `dfa` below.
+
+    Measured at ~248 s over the 486,969-bar 1-minute frame (n=100): a triple-nested Python loop calling
+    np.polyfit per segment. `dfa()` dispatches to a Numba closed-form equivalent that is ~1,400× faster
+    and vote-identical; this stays as the thing that equivalence is proven AGAINST (issue #54).
+    """
     c = np.asarray(close, float)
     N = len(c)
     out = np.full(N, np.nan)
@@ -60,6 +65,113 @@ def dfa(close, n):
         if len(fs) >= 2 and np.all(fs > 0):
             out[i] = np.polyfit(np.log(ls), np.log(fs), 1)[0]
     return out
+
+
+# --- fast DFA (issue #54) ---------------------------------------------------------------------------
+# The reference above dominated optimizer cold-compute (~81% of it). This replaces the per-segment
+# np.polyfit with the closed-form OLS slope + residual mean-square, in a single Numba pass.
+# fastmath=False keeps IEEE semantics (no reassociation) so the result is reproducible.
+# NOTE ON PARITY: np.polyfit solves via LAPACK lstsq, so the two paths are NOT bit-identical in float;
+# what is proven (optimize/perf/test_cold_accel_parity.py + bench_dfa.py on the real 1-minute frame) is
+# that the DOWNSTREAM VETO VOTE — both_veto(isfinite(alpha) & (alpha < threshold)) — is IDENTICAL across
+# the entire threshold grid [0.30, 0.70]. Without numba we fall back to the reference (slow but correct),
+# so a missing optional dependency can never change a result.
+try:                                                        # pragma: no cover - trivial import guard
+    from numba import njit as _njit
+    _HAVE_NUMBA = True
+except Exception:                                           # pragma: no cover
+    _HAVE_NUMBA = False
+
+    def _njit(*args, **kwargs):
+        def deco(f):
+            return f
+        return deco
+
+
+@_njit(cache=True, fastmath=False)
+def _dfa_core(c, n, scales):
+    N = c.shape[0]
+    out = np.full(N, np.nan)
+    ns = scales.shape[0]
+    if ns < 2:
+        return out
+    m = n - 1                                               # number of returns in the window
+    for i in range(n - 1, N):
+        rmean = 0.0
+        for k in range(m):
+            rmean += c[i - n + 2 + k] - c[i - n + 1 + k]
+        rmean /= m
+        y = np.empty(m)                                     # detrended profile = cumsum(r - mean(r))
+        acc = 0.0
+        for k in range(m):
+            acc += (c[i - n + 2 + k] - c[i - n + 1 + k]) - rmean
+            y[k] = acc
+        valid = 0
+        s_l = 0.0
+        s_f = 0.0
+        s_ll = 0.0
+        s_lf = 0.0
+        all_pos = True
+        for si in range(ns):
+            s = scales[si]
+            nb = m // s
+            if nb < 1:
+                continue
+            tbar = (s - 1) / 2.0
+            sxx = 0.0
+            for tt in range(s):
+                d = tt - tbar
+                sxx += d * d
+            f2sum = 0.0
+            for b in range(nb):
+                base = b * s
+                segbar = 0.0
+                for tt in range(s):
+                    segbar += y[base + tt]
+                segbar /= s
+                sdt = 0.0
+                sdd = 0.0
+                for tt in range(s):
+                    dd = y[base + tt] - segbar
+                    sdt += dd * (tt - tbar)
+                    sdd += dd * dd
+                bslope = sdt / sxx
+                f2 = (sdd - bslope * bslope * sxx) / s      # closed-form residual mean-square
+                if f2 < 0.0:
+                    f2 = 0.0
+                f2sum += f2
+            fs_val = np.sqrt(f2sum / nb)
+            if fs_val <= 0.0:
+                all_pos = False
+                break
+            ll = np.log(float(s))
+            lf = np.log(fs_val)
+            s_l += ll
+            s_f += lf
+            s_ll += ll * ll
+            s_lf += ll * lf
+            valid += 1
+        if valid >= 2 and all_pos:
+            denom = valid * s_ll - s_l * s_l
+            if denom != 0.0:
+                out[i] = (valid * s_lf - s_l * s_f) / denom
+    return out
+
+
+def dfa(close, n):
+    """Rolling detrended-fluctuation exponent alpha of the window's returns (few log-spaced scales).
+
+    Fast path (numba) when available; otherwise the verbatim `dfa_reference`. Vote-identical to the
+    reference — see the parity note above.
+    """
+    if not _HAVE_NUMBA:
+        return dfa_reference(close, n)
+    c = np.asarray(close, dtype=np.float64)
+    scales = np.asarray(
+        sorted({s for s in (4, n // 8, n // 4, n // 2) if 4 <= s <= (n - 1) // 2}), dtype=np.int64)
+    if scales.shape[0] < 2:
+        return np.full(c.shape[0], np.nan)
+    return _dfa_core(c, int(n), scales)
 
 
 def autocorr(close, n, lag=1):

--- a/subprojects/Parametric-Indicators/optimize/REPORT_indicator_cache_acceleration.md
+++ b/subprojects/Parametric-Indicators/optimize/REPORT_indicator_cache_acceleration.md
@@ -1,0 +1,318 @@
+# Report — Speeding Up the Optimizer's Indicator Stage
+
+**Date:** 2026-07-27 · **Issue:** #54 · **Branch:** `research/indicator-cache-acceleration`
+**Question asked:** *our optimizer spends ~98% of its time computing indicators and only ~2% backtesting.
+Should we pre-compute every indicator once and store it (files? database? vector DB? graph DB? Redis?
+RAM? GPU VRAM?) instead of recomputing on the fly — and would a GPU, an NVIDIA box, or an ARM box help?*
+
+**Short answer:** No pre-computed store was needed, and **no new hardware was needed**. The 98% was not a
+storage problem and not an arithmetic-throughput problem. It was **one indicator written as an extremely
+slow Python loop**. Rewriting that single function made it **1,150–1,396× faster with provably identical
+trading decisions**, on the machine we already own.
+
+---
+
+## 0. The three findings, in one place
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| **1** | **"Pre-compute every possibility" is mathematically impossible** — not slow, impossible. | The 165 indicators' parameter grids multiply out to **~4.0 billion** combinations ≈ **3.9 petabytes** for one instrument. |
+| **2** | **The cache you were imagining already exists** and already works. | `optimize/core.py` (memory) + `optimize/vote_cache.py` (disk) already compute each `(indicator, parameters)` once and re-use it across all ~30 worker processes. |
+| **3** | **The real cost was one pathological indicator.** `dfa` alone was **81%** of all indicator compute. | Measured on the server: `dfa` = 167 s of the 206 s of cold compute in a 3-trial profile. |
+
+Everything else in this report follows from those three facts.
+
+---
+
+## 1. Why "pre-compute everything" cannot work (Finding 1)
+
+Every indicator has tunable settings ("parameters") that the optimizer searches — e.g. a lookback window
+`n` from 20 to 400, a threshold from 0.30 to 0.70 in steps of 0.01. Each distinct combination produces a
+**different output series**, so "pre-compute all of them" means computing one array per combination.
+
+Counting the actual grids in `indicators/library.py`:
+
+| Indicator | Parameter combinations |
+|---|---:|
+| `schaff_trend_cycle` | 2,317,802,949 |
+| `stoch_rsi` | 1,176,610,050 |
+| `vol_ratio` | 105,853,473 |
+| `kalman` | 100,000,000 |
+| … (161 others) | … |
+| **Total across 165 indicators** | **~3,990,526,954** |
+
+Each output array is ~1 MB (two int8 direction arrays over 486,970 one-minute bars). So:
+
+> **~4.0 billion combinations × ~1 MB ≈ 3.9 PB — for ONE instrument.**
+
+For scale: the server has 123 GB of RAM and 937 GB of disk. This is **~32,000× more than the entire disk**.
+No technology on your list changes this — not Redis, not a vector database, not a graph database, not
+NVMe, not GPU VRAM. It is a **counting problem, not a bandwidth problem**. Pre-computing everything is
+therefore permanently off the table.
+
+```mermaid
+graph LR
+    A["165 indicators<br/>with tunable settings"] --> B["~4.0 BILLION<br/>parameter combinations"]
+    B --> C["~1 MB output each"]
+    C --> D["≈ 3.9 PETABYTES<br/>for one instrument"]
+    D --> E["Server disk: 937 GB<br/>❌ ~32,000× too small"]
+```
+
+---
+
+## 2. The cache already exists (Finding 2)
+
+The expensive unit is `ind.directions()` — one indicator's output over the price history. It is a **pure
+function**: it depends only on *(which indicator, its parameters, the price series)*. It does **not**
+depend on the confirm-count K, the retrace/wait settings, the stop-loss/take-profit, the drawdown
+breaker, or which other indicators are switched on.
+
+That means it can be computed once and re-used — and the repository **already does this, at two levels**:
+
+1. **In-memory** (`optimize/core.py:_VOTE_MEMO`) — within one worker process.
+2. **On disk** (`optimize/vote_cache.py`) — `.npy` files keyed by a SHA-256 of
+   `(cache version, data slice, 1-min flag, indicator, mode, parameters)`, explicitly *"shared across
+   worker processes + watchdog respawns."*
+
+Your own project memory records the payoff already banked: memoization took candidate-L1 from
+**24 → 1,286 trials/minute**.
+
+**Independent confirmation this is the right design:** Microsoft's Qlib platform uses exactly this
+two-level scheme — an in-memory LRU cache plus a `DiskExpressionCache` keyed by
+`hash(instrument, field_expression, freq)`. Our `disk_key(version, slice, use1, key, mode, params)` is the
+same idea. (Full prior-art notes: `docs/PRIOR_ART_indicator_caching_gpu.md`.)
+
+So the question "should we cache?" was already answered — **yes, and it's built.** The open question was
+only: *what does it cost the first time (the "cold miss"), and can that be made cheaper?*
+
+---
+
+## 3. What we measured (Finding 3 — the surprise)
+
+We built a **result-neutral probe** (`optimize/perf/cache_probe.py`) that counts cache hits/misses and
+times every cold computation without altering a single number, then ran the **real optimizer** on the AMD
+server, fully isolated (throwaway trial store + empty cache) so nothing in production was touched.
+
+**Baseline: 3 trials, NQ 4h, 165 indicators, indicators on the 1-minute frame, cold cache**
+
+```
+wall clock      208 s
+cold compute    206 s   ← 99% of all time   (confirms the ~98% you reported)
+cache hit rate  0.00    (expected: a cold cache has nothing to hit yet)
+```
+
+**Where those 206 seconds went:**
+
+| Indicator | Cold seconds | Share |
+|---|---:|---:|
+| **`dfa`** | **166.99** | **81%** |
+| `autocorr` | 3.67 | 1.8% |
+| `hurst_exp` | 2.94 | 1.4% |
+| `ifvg` | 2.49 | 1.2% |
+| `proj_bands` | 1.86 | 0.9% |
+| everything else (160 indicators) | < 1.5 each | ~14% |
+
+```mermaid
+pie title Where the 206 s of indicator compute actually went
+    "dfa (one indicator)" : 81
+    "autocorr" : 2
+    "hurst_exp" : 1
+    "ifvg" : 1
+    "all 161 others combined" : 15
+```
+
+**This overturned the previous internal report.** `REPORT_backtester_speed_optimization.md` (2026-06-11)
+named `smc.order_blocks`, `bollinger` and `cci` as the hot spots. Those were fixed or are no longer
+dominant; after the library grew from 21 to 165 indicators, the cost moved entirely to a **small tail of
+exotic new indicators** — and overwhelmingly to one.
+
+> **Plain language:** we assumed the slowness was spread across 165 indicators, which would have justified
+> exotic storage or a GPU. In reality **one indicator was doing 81% of the work**, and it was slow because
+> of *how it was written*, not because of how much maths it needed.
+
+---
+
+## 4. Why `dfa` was slow — and the fix
+
+`dfa` (Detrended Fluctuation Analysis) measures whether the market is trending or mean-reverting. The
+original implementation (`indicators/calc/quant.py`) was a **triple-nested Python loop that called
+`np.polyfit` (a full least-squares fit) on every small segment, for every one of ~486,970 bars**:
+
+```python
+for i in range(n - 1, N):          # ~486,970 bars
+    for s in scales:               # ~4 window scales
+        for b in range(nb):        # segments within the window
+            coef = np.polyfit(t, seg, 1)   # a least-squares solve, called hundreds of millions of times
+```
+
+`np.polyfit` is a heavyweight general-purpose routine (it builds a matrix and calls LAPACK). But fitting a
+straight line to a segment has a **closed-form answer** — a few sums, no matrix, no solver. Replacing the
+solver with that formula and compiling the loop with Numba (which turns Python into machine code) gives:
+
+**Measured on the real 486,969-bar NQ 1-minute series (`optimize/perf/results/dfa_bench_NQ_1m.json`):**
+
+| Window `n` | Before | After | Speed-up | Trading decisions changed |
+|---:|---:|---:|---:|:---:|
+| 20 | 57.0 s | 0.044 s | **1,309×** | **0** |
+| 100 (default) | 248.3 s | 0.178 s | **1,396×** | **0** |
+| 400 | **756.6 s** (12.6 min) | 0.658 s | **1,150×** | **0** |
+
+> At `n=400`, computing this **one indicator once** took **12.6 minutes**. It now takes **0.66 seconds**.
+
+```mermaid
+graph LR
+    subgraph Before["BEFORE — np.polyfit per segment"]
+        A1["for each of 486,969 bars"] --> A2["for each scale"] --> A3["for each segment"] --> A4["np.polyfit()<br/>full least-squares solve"]
+    end
+    subgraph After["AFTER — closed form + Numba"]
+        B1["one compiled pass"] --> B2["closed-form slope<br/>(a few sums)"] --> B3["0.18 s"]
+    end
+    Before -->|"1,396× faster<br/>0 decisions changed"| After
+```
+
+### How we know the results did not change
+
+This is the part that matters most: **speed is worthless if it changes a single trade.**
+
+`np.polyfit` solves via LAPACK, so the new formula is not bit-identical in the last floating-point digits.
+But `dfa` is a **veto** indicator — its only effect on trading is the yes/no test
+`alpha < threshold`. So the thing that must be identical is **the veto decision**, and we proved exactly
+that:
+
+- **On the real 1-minute series**, for **every threshold on the searched grid (0.30 → 0.70, step 0.01)**,
+  the number of bars where the veto decision differs is **zero** (`max_vote_flips_over_grid: 0`), at all
+  three window sizes.
+- The finite/NaN warm-up mask matches exactly, and the values agree to 1e-6 relative.
+- Four automated parity tests pass, **including an end-to-end test** that drives the actual `DFA`
+  indicator object and compares its emitted confirm/veto arrays against the original implementation.
+- The original code is **kept verbatim** as `dfa_reference` — it is the oracle every future change is
+  tested against, not deleted.
+- **If Numba is not installed, the code automatically falls back to the original implementation**, so a
+  missing optional dependency can never silently change a result.
+
+**Full-suite regression check (with a control).** The whole test suite was run twice on the server on
+identical trees — once **with** the change ("treatment") and once with the **original** `quant.py`
+("control") — and the failure sets compared:
+
+| | Treatment (fast dfa) | Control (original dfa) |
+|---|---|---|
+| Result | **25 failed, 834 passed, 1 skipped** | **25 failed** (same 25) |
+| Tests failing in treatment but passing in control (= regressions) | **0** | — |
+| Tests failing in control but passing in treatment | **0** | — |
+
+The two failure sets are **identical**, so the change introduces **zero regressions**. Those 25 failures
+are pre-existing and unrelated: they sit in `optimize/l2/*` and `test_intracandle_*`, none touch `dfa` or
+`quant`, `test_parity_anchor.py` is a **known-stale test** (recorded in project memory as pinning a frozen
+anchor after the 4h default moved to the champion), and `test_intracandle_parity.py` carried uncommitted
+local edits before this work began. **Caveat, stated honestly:** several of the `l2` failures may also be
+an artifact of this deployment excluding `*.csv` result files from the server copy — they were *not*
+individually diagnosed, because the control proves none of them are caused by this change.
+
+---
+
+## 5. Answering each technology you asked about
+
+| Your question | Verdict | Why |
+|---|---|---|
+| Pre-compute **all** indicator values and call them? | ❌ **Impossible** | ~4.0 B combinations ≈ 3.9 PB (§1). |
+| Is file storage (JSON/CSV/XML/…) a read/write bottleneck? | ➖ **Not the bottleneck** | It was never storage. The compute was 99% of wall-clock; a cache already exists and stores compact `.npy` binaries (not JSON/CSV/XML, which would indeed be slow). |
+| A database built for this? | ➖ **Not needed** | The access pattern is "one array by exact key" — a hash lookup. A database adds overhead without solving the compute cost. |
+| Vector DB / graph DB? | ❌ **Wrong tool** | Vector DBs answer *similarity* queries ("find vectors near this one"); graph DBs answer *relationship* queries. We need exact-key retrieval of a fixed array. Neither fits. |
+| Redis (lives in RAM, no SSD)? | ➖ **Marginal at best** | The server has 123 GB RAM; the existing `.npy` files are almost certainly already served from the OS page cache at RAM speed. Redis would add a socket hop and serialization. *(Un-measured — see §7 Honest gaps.)* |
+| Load everything into RAM as numpy arrays? | ➖ **Already effectively true** | Working data is ~28 MB; the whole set fits in RAM thousands of times over. RAM capacity was never the constraint. |
+| Is a prebuilt solution better than ours? | ➖ **Ours is the standard design** | Qlib uses the identical two-level cache. vectorbt's tricks (batching parameters into array columns, de-duplicating repeated combos) are worth borrowing *if* we ever need more, but they do not beat fixing a 1,396× algorithmic defect. |
+| Do we hit hardware/bandwidth limits? | ❌ **No** | Nowhere near. The bottleneck was CPU time inside a Python loop, not memory bandwidth or I/O. |
+| **Would a GPU / NVIDIA box help?** | ❌ **Not needed** | GPUs win by running *thousands of independent arithmetic tasks in parallel* (NVIDIA's own benchmark shows 114× on Monte-Carlo paths *because* 1,000 simulations run side by side). Our cost was **not arithmetic volume** — it was a slow interpreted loop calling a heavyweight solver. Fixing the algorithm gave **1,396× on the CPU we already own**, which is *more* than the published GPU speed-ups for comparable work — with no new hardware, no data-transfer overhead, and no code-portability risk. |
+| **Would an ARM box help?** | ❌ **No** | Same reasoning: changing the processor cannot fix an algorithmic defect. A different CPU might give ~1–2×; the rewrite gave ~1,400×. |
+
+**On the GPU specifically:** it is now **shelved, not rejected forever**. If, after the remaining
+indicators are fixed, the cold cost is still dominated by genuinely dense arithmetic across many parameter
+combinations, GPU batching becomes worth benchmarking. Today the evidence says it would be solving a
+problem we no longer have.
+
+---
+
+## 6. What went well / what went wrong
+
+**What went well**
+- **Profiling before optimizing.** Had we followed the original plan (GPU-first), we would have spent
+  significant money and effort porting indicators to CUDA to accelerate a problem that a one-function
+  rewrite eliminated. The 3-trial measurement redirected the entire workstream in ~3 minutes of compute.
+- **The two impossible/already-solved findings came from reading the codebase**, not from guessing —
+  they killed two expensive dead ends (pre-compute-everything; build-a-cache) before any code was written.
+- **The parity contract was defined precisely** (the *veto decision*, not the raw float), which made a
+  1,396× speed-up provably safe instead of "probably fine."
+- **A control run** was used to attribute pre-existing test failures rather than assuming.
+
+**What went wrong / what to watch**
+- **The previous performance report was stale.** It named `order_blocks`/`bollinger`/`cci`; the library
+  had since grown 21 → 165 indicators and the bottleneck moved entirely. *Lesson: re-profile after any
+  large library change; never optimize from an old profile.*
+- **The 3-trial baseline is small.** The `dfa` finding is robust (its per-call cost is enormous and
+  stable, and was independently confirmed on the full series), but the **ranking of the remaining tail**
+  and the **steady-state cache hit-rate** deserve a longer run.
+- **`np.polyfit`-style "convenience" calls inside per-bar loops are a recurring pattern**, not a one-off:
+  `hurst_exp`, `autocorr`, and `linreg_r2` share the identical structure. This should be a review rule for
+  every new indicator.
+- **A subtle cache hazard was noticed:** `vote_cache`'s key includes a `CACHE_VERSION` constant that must
+  be bumped whenever an indicator's maths changes. Our change is vote-identical so no bump is required,
+  but any *non*-identical change would silently load stale arrays. Worth a guard.
+
+---
+
+## 7. Honest gaps (not yet measured)
+
+Stated plainly so nothing here is over-claimed:
+
+1. **The re-baseline is pending** — we have not yet re-run the profile *with* the fast `dfa` to confirm the
+   new distribution of cost and how much of the original 208 s remains.
+2. **Cache substrate was not benchmarked** (`.npy` vs `/dev/shm` vs Redis vs shared memory). It was
+   de-prioritized once compute proved to be 99% of the cost, but the Redis/RAM question is therefore
+   answered by *reasoning*, not measurement.
+3. **Cache-level re-keying was not measured** — today the key includes `mode`, so confirm/veto/both may
+   store the same underlying arrays separately, and arrays are not shared across the 6 decision
+   timeframes. A `directions()`-level key would likely raise re-use. Unquantified.
+4. **The remaining tail is unfixed** — `autocorr`, `hurst_exp`, `linreg_r2` still use the slow pattern.
+
+---
+
+## 8. Verdict against the pre-registered criterion
+
+The criterion registered before any measurement was: **bit-identical results AND ≥3× cold-miss reduction
+AND beats both dumb controls** (the warm cache; simply adding CPU workers).
+
+| Test | Result |
+|---|---|
+| Decisions unchanged | ✅ **0 vote flips** across the entire threshold grid, all window sizes, on real data |
+| ≥ 3× cold-miss reduction | ✅ **1,150–1,396×** (≈400× the required bar) |
+| Beats "just use the warm cache" | ✅ The warm cache does not help a **cold** miss at all; every new parameter combination pays full price. The optimizer explores new combinations constantly. |
+| Beats "just add more CPU workers" | ✅ Adding workers is bounded by 32 cores (≤32× and it costs cores other work needs). This is ~1,400× on **one** core. |
+
+> **GO.** The change is adopted and wired in (`indicators/calc/quant.py`).
+
+---
+
+## 9. Recommended next steps
+
+1. **Fix the same pattern in `hurst_exp`, `autocorr`, `linreg_r2`** — identical per-bar-loop structure,
+   same closed-form/Numba treatment, same vote-parity gate. (Expected: another large cut to the remaining
+   ~19%.)
+2. **Re-run the baseline** with the fast `dfa` to publish the new cost distribution.
+3. **Add a review rule:** no `np.polyfit` / `np.corrcoef` / `np.linalg.*` inside a per-bar loop in any new
+   indicator; and add a cheap CI timing check so a future indicator cannot silently reintroduce a
+   12-minute compute.
+4. **Optional, only if still needed:** the substrate and cache-level questions (§7.2, §7.3).
+5. **Keep the GPU shelved** unless a future profile shows dense parallel arithmetic dominating.
+
+---
+
+## 10. One-paragraph summary
+
+We set out to decide between pre-computed indicator stores, exotic databases, RAM caches and GPUs. The
+measurement said none of them were the answer: pre-computing everything is impossible by a factor of
+32,000, the cache we were going to build already existed, and **81% of all indicator time was a single
+indicator implemented as a triple-nested Python loop calling a least-squares solver hundreds of millions
+of times**. Rewriting that one function in closed form gave **1,150–1,396× on the hardware we already
+own, with zero change to any trading decision** — proven across every threshold the optimizer can search.
+The GPU, the NVIDIA box and the ARM box are not needed. The lesson is the oldest one in performance work:
+**measure first — the bottleneck is rarely where the architecture diagram says it is.**

--- a/subprojects/Parametric-Indicators/optimize/REPORT_indicator_cache_acceleration.md
+++ b/subprojects/Parametric-Indicators/optimize/REPORT_indicator_cache_acceleration.md
@@ -210,6 +210,45 @@ individually diagnosed, because the control proves none of them are caused by th
 
 ---
 
+## 4b. The end-to-end result: the same profile, re-run
+
+The indicator-level speed-up is only meaningful if the *whole optimizer run* gets faster. We re-ran the
+**identical** profile (same timeframe, same seed ⇒ the optimizer suggested the **same trials**, and the
+probe confirms the **same 233 cold computations**), the only difference being the fixed `dfa`:
+
+| Measurement (3 trials, NQ 4h, 165 indicators, cold cache) | Before | After | Change |
+|---|---:|---:|---:|
+| **Wall clock** | 208 s | **40 s** | **5.1× faster** |
+| Cold indicator compute | 206 s | 39 s | 5.3× less |
+| Cold computations performed | 233 | 233 | identical (apples-to-apples) |
+| `dfa` cold time | **167.0 s** | **0.161 s** | 1,037× less |
+| `dfa` share of all indicator time | **81%** | **0.42%** | no longer in the top 12 |
+
+```mermaid
+graph TB
+    subgraph B["BEFORE — 208 s"]
+        B1["dfa — 167 s (81%)"]
+        B2["all 164 others — 39 s"]
+    end
+    subgraph A["AFTER — 40 s"]
+        A1["dfa — 0.16 s (0.4%)"]
+        A2["all 164 others — 39 s"]
+    end
+    B -->|"one function rewritten<br/>0 decisions changed"| A
+```
+
+**Read this carefully, because it sets the ceiling on further work.** The 164 other indicators still cost
+the same ~39 s — that part was never the problem and is untouched. The whole 168-second saving came from
+one function. The remaining cost is now **diffuse**: the new leader, `autocorr`, is 3.66 s (9% of what's
+left), followed by `hurst_exp` 2.93 s and `ifvg` 2.51 s. There is no second `dfa` hiding in the profile.
+
+**What this means for a real sweep:** a production study runs thousands of trials, not three. Every trial
+that switched `dfa` on previously paid ~83 s per fold-slice compute (up to ~756 s on the full series at
+`n=400`). Those costs are now ~0.2–0.7 s. The saving compounds across every trial and every one of the
+~30 parallel workers.
+
+---
+
 ## 5. Answering each technology you asked about
 
 | Your question | Verdict | Why |
@@ -264,8 +303,7 @@ problem we no longer have.
 
 Stated plainly so nothing here is over-claimed:
 
-1. **The re-baseline is pending** — we have not yet re-run the profile *with* the fast `dfa` to confirm the
-   new distribution of cost and how much of the original 208 s remains.
+1. ~~The re-baseline is pending~~ — **done, see §4b** (208 s → 40 s on an identical workload).
 2. **Cache substrate was not benchmarked** (`.npy` vs `/dev/shm` vs Redis vs shared memory). It was
    de-prioritized once compute proved to be 99% of the cost, but the Redis/RAM question is therefore
    answered by *reasoning*, not measurement.
@@ -294,15 +332,15 @@ AND beats both dumb controls** (the warm cache; simply adding CPU workers).
 
 ## 9. Recommended next steps
 
-1. **Fix the same pattern in `hurst_exp`, `autocorr`, `linreg_r2`** — identical per-bar-loop structure,
-   same closed-form/Numba treatment, same vote-parity gate. (Expected: another large cut to the remaining
-   ~19%.)
-2. **Re-run the baseline** with the fast `dfa` to publish the new cost distribution.
-3. **Add a review rule:** no `np.polyfit` / `np.corrcoef` / `np.linalg.*` inside a per-bar loop in any new
+1. **Fix the same pattern in `autocorr` (3.66 s), `hurst_exp` (2.93 s), `linreg_r2`** — identical
+   per-bar-loop structure, same closed-form/Numba treatment, same vote-parity gate. Realistic expectation:
+   these three are ~17% of what remains, so the honest upside is roughly **40 s → ~33 s** — worthwhile and
+   cheap, but nothing like the `dfa` win. **There is no second `dfa`.** Diminishing returns start here.
+2. **Add a review rule:** no `np.polyfit` / `np.corrcoef` / `np.linalg.*` inside a per-bar loop in any new
    indicator; and add a cheap CI timing check so a future indicator cannot silently reintroduce a
    12-minute compute.
-4. **Optional, only if still needed:** the substrate and cache-level questions (§7.2, §7.3).
-5. **Keep the GPU shelved** unless a future profile shows dense parallel arithmetic dominating.
+3. **Optional, only if still needed:** the substrate and cache-level questions (§7.2, §7.3).
+4. **Keep the GPU shelved** unless a future profile shows dense parallel arithmetic dominating.
 
 ---
 

--- a/subprojects/Parametric-Indicators/optimize/perf/__init__.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/__init__.py
@@ -1,0 +1,4 @@
+"""Performance harnesses for issue #54 (indicator cold-miss acceleration).
+
+Contains only measurement + PoC code. Nothing here is imported by the production optimizer path, and
+every accelerator ships behind a default-OFF flag so results stay bit-identical (speed only)."""

--- a/subprojects/Parametric-Indicators/optimize/perf/bench_dfa.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/bench_dfa.py
@@ -1,0 +1,64 @@
+"""Task 3 server benchmark: accelerated `dfa` vs the reference on the REAL 1-minute frame (issue #54).
+
+For each window n in {20, 100, 400} (grid min / default / max) over the true ~486,970-bar NQ 1-minute
+close: time the reference (`calc.quant.dfa`) vs the accelerated `cold_accel.dfa_fast`, and re-verify the
+parity contract on real data — identical finite mask, float-closeness, and ZERO vote-boolean flips across
+the whole threshold grid [0.30, 0.70]. Writes results/dfa_bench_NQ_1m.json.
+
+Run: WSH_DATA_BASE=/home/dev/Mulham/wsg-i /home/dev/Mulham/.venv/bin/python3 -m optimize.perf.bench_dfa
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import numpy as np
+
+from loader import load_data
+from indicators.calc import quant as Q
+from optimize import timeframes as TF
+from optimize.perf import cold_accel
+
+THR = np.round(np.arange(0.30, 0.7001, 0.01), 2)
+
+
+def main() -> int:
+    base = os.environ.get("WSH_DATA_BASE", "/mnt/data/projects/trading")
+    csv = Path(base) / TF.RAW_DIR / "NQ_1m.csv"
+    close = load_data(str(csv)).sort_values("Date")["Close"].to_numpy(float)
+    print(f"[dfa-bench] loaded {len(close):,} 1-min closes from {csv}", flush=True)
+
+    cold_accel.dfa_fast(close[:3000], 100)   # warm up the JIT so timings exclude compilation
+    res = {"n_bars": int(len(close)), "per_n": {}}
+    for n in (20, 100, 400):
+        t0 = time.perf_counter(); ref = Q.dfa(close, n); tr = time.perf_counter() - t0
+        t0 = time.perf_counter(); fast = cold_accel.dfa_fast(close, n); tf = time.perf_counter() - t0
+        fin_ref, fin_fast = np.isfinite(ref), np.isfinite(fast)
+        mask_ok = bool(np.array_equal(fin_ref, fin_fast))
+        close_ok = bool(np.allclose(ref[fin_ref], fast[fin_fast], rtol=1e-6, atol=1e-8)) if fin_ref.any() else True
+        max_flips = 0
+        for thr in THR:
+            vr = fin_ref & (ref < thr); vf = fin_fast & (fast < thr)
+            max_flips = max(max_flips, int(np.sum(vr != vf)))
+        row = {"ref_s": round(tr, 3), "fast_s": round(tf, 3),
+               "speedup": round(tr / tf, 1) if tf else None,
+               "mask_match": mask_ok, "float_close": close_ok,
+               "max_vote_flips_over_grid": max_flips}
+        res["per_n"][str(n)] = row
+        print(f"[dfa-bench n={n}] ref={tr:.2f}s fast={tf:.3f}s speedup={tr/tf:.0f}x "
+              f"mask={mask_ok} float_close={close_ok} max_vote_flips={max_flips}", flush=True)
+
+    out = Path(__file__).resolve().parent / "results" / "dfa_bench_NQ_1m.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(res, indent=2))
+    print(f"[dfa-bench] WROTE {out}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/Parametric-Indicators/optimize/perf/cache_probe.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/cache_probe.py
@@ -1,0 +1,126 @@
+"""Result-neutral instrumentation of the indicator vote cache (issue #54, Task 1).
+
+`Probe` monkeypatches three call sites and only COUNTS/TIMES them — it never alters the arrays that flow
+through, so a run with the probe installed produces byte-identical votes to one without it:
+
+  * ``vote_cache.get``  — a non-None return is a DISK-CACHE HIT (bytes_read); a None return is a MISS.
+  * ``vote_cache.put``  — an array persisted (bytes_written).
+  * ``indicators.runner._ind_vote`` — a genuine COLD COMPUTE of one indicator's vote array; we accumulate
+    wall-clock and per-indicator counts (keyed by ``ind.key``) so Task 2 can rank the costliest indicators.
+
+The in-process ``core._VOTE_MEMO`` hits bypass ``vote_cache.get`` entirely, so this measures the DISK
+cache's hit-rate and the true cold-compute cost — exactly the cold/warm/I-O split Task 2 needs.
+
+Usage (single process — the baseline runner installs it around one study slice):
+
+    p = Probe(); p.install()
+    ...run the sweep...
+    p.uninstall()
+    profile = p.snapshot()
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass
+class Probe:
+    hits: int = 0
+    misses: int = 0
+    cold_seconds: float = 0.0
+    cold_computes: int = 0
+    bytes_read: int = 0
+    bytes_written: int = 0
+    per_indicator: dict = field(default_factory=dict)  # ind.key -> {"computes": int, "cold_seconds": float}
+    _installed: bool = False
+    _orig: dict = field(default_factory=dict)
+
+    # -- lifecycle ---------------------------------------------------------------------------------
+    def install(self) -> "Probe":
+        if self._installed:
+            return self
+        from optimize import vote_cache
+        from indicators import runner
+
+        self._orig = {
+            "get": vote_cache.get,
+            "put": vote_cache.put,
+            "ind_vote": runner._ind_vote,
+        }
+        _orig_get, _orig_put, _orig_vote = (
+            self._orig["get"], self._orig["put"], self._orig["ind_vote"],
+        )
+
+        def get_wrapper(dkey):
+            arr = _orig_get(dkey)
+            if arr is None:
+                self.misses += 1
+            else:
+                self.hits += 1
+                self.bytes_read += int(getattr(arr, "nbytes", 0))
+            return arr
+
+        def put_wrapper(dkey, arr):
+            try:
+                self.bytes_written += int(np.asarray(arr).nbytes)
+            except Exception:
+                pass
+            return _orig_put(dkey, arr)
+
+        def vote_wrapper(ind, ctx, bdir, src=None):
+            t0 = time.perf_counter()
+            out = _orig_vote(ind, ctx, bdir, src)
+            dt = time.perf_counter() - t0
+            self.cold_seconds += dt
+            self.cold_computes += 1
+            key = getattr(ind, "key", getattr(getattr(ind, "config", None), "key", "?"))
+            slot = self.per_indicator.setdefault(key, {"computes": 0, "cold_seconds": 0.0})
+            slot["computes"] += 1
+            slot["cold_seconds"] += dt
+            return out
+
+        vote_cache.get = get_wrapper
+        vote_cache.put = put_wrapper
+        runner._ind_vote = vote_wrapper
+        self._installed = True
+        return self
+
+    def uninstall(self) -> "Probe":
+        if not self._installed:
+            return self
+        from optimize import vote_cache
+        from indicators import runner
+
+        vote_cache.get = self._orig["get"]
+        vote_cache.put = self._orig["put"]
+        runner._ind_vote = self._orig["ind_vote"]
+        self._installed = False
+        return self
+
+    def __enter__(self):
+        return self.install()
+
+    def __exit__(self, *_exc):
+        self.uninstall()
+        return False
+
+    # -- reporting ---------------------------------------------------------------------------------
+    def snapshot(self) -> dict:
+        total = self.hits + self.misses
+        top = sorted(self.per_indicator.items(), key=lambda kv: -kv[1]["cold_seconds"])
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "hit_rate": (self.hits / total) if total else 0.0,
+            "cold_seconds": round(self.cold_seconds, 6),
+            "cold_computes": self.cold_computes,
+            "bytes_read": self.bytes_read,
+            "bytes_written": self.bytes_written,
+            "per_indicator": {
+                k: {"computes": v["computes"], "cold_seconds": round(v["cold_seconds"], 6)}
+                for k, v in top
+            },
+        }

--- a/subprojects/Parametric-Indicators/optimize/perf/cold_accel.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/cold_accel.py
@@ -1,122 +1,26 @@
-"""CPU cold-miss accelerators for the pathological indicators (issue #54, Task 3).
+"""Cold-miss accelerator entry points (issue #54, Task 3).
 
-The baseline (optimize/perf/results/baseline_NQ_4h_smoke3.json) showed ONE indicator, `dfa`, is ~81% of
-all cold-compute time (~83 s per compute) — a triple-nested Python loop calling `np.polyfit` per segment
-over ~486,970 one-minute bars (`indicators/calc/quant.py:dfa`). This module provides a vectorized /
-Numba-JIT replacement.
+The baseline (`optimize/perf/results/baseline_NQ_4h_smoke3.json`) showed ONE indicator, `dfa`, was ~81%
+of all cold-compute time — a triple-nested Python loop calling `np.polyfit` per segment over ~486,969
+one-minute bars.
 
-**Parity contract.** `np.polyfit` solves via LAPACK lstsq (SVD), so a closed-form fit is NOT bit-identical
-at the float level. What must not change is the downstream VOTE: `DFA.directions` emits
-`both_veto(isfinite(alpha) & (alpha < threshold))` for `threshold ∈ [0.30, 0.70]` step 0.01. So the
-accelerated `alpha` must reproduce that boolean EXACTLY on the real series, across the whole threshold
-grid. `test_cold_accel_parity.py` asserts float-closeness AND exact vote-boolean equality; the server
-harness re-checks it on the true 1-minute frame before this is trusted. Default-OFF at the call sites.
+The accelerated implementation now lives WITH the primitive it replaces, in
+`indicators/calc/quant.py` (`dfa` = Numba closed-form fast path, `dfa_reference` = the original loop kept
+as the parity oracle). This module keeps a thin alias so the benchmarks/tests read naturally and so
+`indicators/` never has to import from `optimize/` (layering stays one-way).
 """
 from __future__ import annotations
 
-import numpy as np
+from indicators.calc.quant import dfa as _dfa, dfa_reference as _dfa_reference
 
-try:
-    from numba import njit
-except Exception:  # pragma: no cover - numba is present on the server venv; fallback runs pure-Python
-    def njit(*args, **kwargs):  # identity decorator so _dfa_core still runs (slowly) without numba
-        if len(args) == 1 and callable(args[0]) and not kwargs:
-            return args[0]
-        def deco(f):
-            return f
-        return deco
+__all__ = ["dfa_fast", "dfa_reference"]
 
 
-def _scales_for(n: int) -> list[int]:
-    """The reference's scale set (depends only on n): sorted unique {4, n//8, n//4, n//2} within
-    [4, (n-1)//2]. Kept byte-identical to calc/quant.py:dfa so both see the same scales."""
-    return sorted({s for s in (4, n // 8, n // 4, n // 2) if 4 <= s <= (n - 1) // 2})
+def dfa_fast(close, n):
+    """Accelerated rolling DFA alpha (Numba closed-form; falls back to the reference without numba)."""
+    return _dfa(close, n)
 
 
-@njit(cache=True, fastmath=False)
-def _dfa_core(c, n, scales):
-    """Rolling DFA-alpha, closed-form linear detrend (no polyfit), one pass. Mirrors the reference's
-    arithmetic order (r - mean(r); cumsum; per-segment OLS residual mean-square; sqrt(mean(F2));
-    log-log slope) but in scalar float64 so Numba reproduces it deterministically. fastmath=False keeps
-    IEEE semantics (no reassociation) — essential for reproducing the vote threshold."""
-    N = c.shape[0]
-    out = np.full(N, np.nan)
-    ns = scales.shape[0]
-    if ns < 2:
-        return out
-    m = n - 1                                   # length of the returns/profile window
-    # precompute per-scale t-centering constants (t = 0..s-1)
-    for i in range(n - 1, N):
-        # returns r[k] = c[i-n+2+k] - c[i-n+1+k], k=0..m-1
-        rmean = 0.0
-        for k in range(m):
-            rmean += c[i - n + 2 + k] - c[i - n + 1 + k]
-        rmean /= m
-        # detrended profile y = cumsum(r - rmean)
-        y = np.empty(m)
-        acc = 0.0
-        for k in range(m):
-            acc += (c[i - n + 2 + k] - c[i - n + 1 + k]) - rmean
-            y[k] = acc
-        valid = 0
-        sum_log_l = 0.0
-        sum_log_f = 0.0
-        sum_log_ll = 0.0
-        sum_log_lf = 0.0
-        all_pos = True
-        for si in range(ns):
-            s = scales[si]
-            nb = m // s
-            if nb < 1:
-                continue
-            # t stats for t = 0..s-1 (fixed per scale)
-            tbar = (s - 1) / 2.0
-            sxx = 0.0
-            for tt in range(s):
-                d = tt - tbar
-                sxx += d * d
-            f2sum = 0.0
-            for b in range(nb):
-                base = b * s
-                # segment mean
-                segbar = 0.0
-                for tt in range(s):
-                    segbar += y[base + tt]
-                segbar /= s
-                sdt = 0.0
-                sdd = 0.0
-                for tt in range(s):
-                    dd = y[base + tt] - segbar
-                    sdt += dd * (tt - tbar)
-                    sdd += dd * dd
-                bslope = sdt / sxx
-                # residual mean-square = (Sdd - b^2 * Sxx) / s  (closed form of mean((seg - a - b t)^2))
-                f2 = (sdd - bslope * bslope * sxx) / s
-                if f2 < 0.0:
-                    f2 = 0.0
-                f2sum += f2
-            fs_val = np.sqrt(f2sum / nb)
-            if fs_val <= 0.0:
-                all_pos = False
-                break
-            ll = np.log(float(s))
-            lf = np.log(fs_val)
-            sum_log_l += ll
-            sum_log_f += lf
-            sum_log_ll += ll * ll
-            sum_log_lf += ll * lf
-            valid += 1
-        if valid >= 2 and all_pos:
-            denom = valid * sum_log_ll - sum_log_l * sum_log_l
-            if denom != 0.0:
-                out[i] = (valid * sum_log_lf - sum_log_l * sum_log_f) / denom
-    return out
-
-
-def dfa_fast(close, n: int) -> np.ndarray:
-    """Vectorized/Numba drop-in for calc.quant.dfa — same shape/NaN warm-up, closed-form detrend."""
-    c = np.asarray(close, dtype=np.float64)
-    scales = np.asarray(_scales_for(int(n)), dtype=np.int64)
-    if scales.shape[0] < 2:
-        return np.full(c.shape[0], np.nan)
-    return _dfa_core(c, int(n), scales)
+def dfa_reference(close, n):
+    """The original triple-nested-loop implementation — the oracle parity is proven against."""
+    return _dfa_reference(close, n)

--- a/subprojects/Parametric-Indicators/optimize/perf/cold_accel.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/cold_accel.py
@@ -1,0 +1,122 @@
+"""CPU cold-miss accelerators for the pathological indicators (issue #54, Task 3).
+
+The baseline (optimize/perf/results/baseline_NQ_4h_smoke3.json) showed ONE indicator, `dfa`, is ~81% of
+all cold-compute time (~83 s per compute) — a triple-nested Python loop calling `np.polyfit` per segment
+over ~486,970 one-minute bars (`indicators/calc/quant.py:dfa`). This module provides a vectorized /
+Numba-JIT replacement.
+
+**Parity contract.** `np.polyfit` solves via LAPACK lstsq (SVD), so a closed-form fit is NOT bit-identical
+at the float level. What must not change is the downstream VOTE: `DFA.directions` emits
+`both_veto(isfinite(alpha) & (alpha < threshold))` for `threshold ∈ [0.30, 0.70]` step 0.01. So the
+accelerated `alpha` must reproduce that boolean EXACTLY on the real series, across the whole threshold
+grid. `test_cold_accel_parity.py` asserts float-closeness AND exact vote-boolean equality; the server
+harness re-checks it on the true 1-minute frame before this is trusted. Default-OFF at the call sites.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    from numba import njit
+except Exception:  # pragma: no cover - numba is present on the server venv; fallback runs pure-Python
+    def njit(*args, **kwargs):  # identity decorator so _dfa_core still runs (slowly) without numba
+        if len(args) == 1 and callable(args[0]) and not kwargs:
+            return args[0]
+        def deco(f):
+            return f
+        return deco
+
+
+def _scales_for(n: int) -> list[int]:
+    """The reference's scale set (depends only on n): sorted unique {4, n//8, n//4, n//2} within
+    [4, (n-1)//2]. Kept byte-identical to calc/quant.py:dfa so both see the same scales."""
+    return sorted({s for s in (4, n // 8, n // 4, n // 2) if 4 <= s <= (n - 1) // 2})
+
+
+@njit(cache=True, fastmath=False)
+def _dfa_core(c, n, scales):
+    """Rolling DFA-alpha, closed-form linear detrend (no polyfit), one pass. Mirrors the reference's
+    arithmetic order (r - mean(r); cumsum; per-segment OLS residual mean-square; sqrt(mean(F2));
+    log-log slope) but in scalar float64 so Numba reproduces it deterministically. fastmath=False keeps
+    IEEE semantics (no reassociation) — essential for reproducing the vote threshold."""
+    N = c.shape[0]
+    out = np.full(N, np.nan)
+    ns = scales.shape[0]
+    if ns < 2:
+        return out
+    m = n - 1                                   # length of the returns/profile window
+    # precompute per-scale t-centering constants (t = 0..s-1)
+    for i in range(n - 1, N):
+        # returns r[k] = c[i-n+2+k] - c[i-n+1+k], k=0..m-1
+        rmean = 0.0
+        for k in range(m):
+            rmean += c[i - n + 2 + k] - c[i - n + 1 + k]
+        rmean /= m
+        # detrended profile y = cumsum(r - rmean)
+        y = np.empty(m)
+        acc = 0.0
+        for k in range(m):
+            acc += (c[i - n + 2 + k] - c[i - n + 1 + k]) - rmean
+            y[k] = acc
+        valid = 0
+        sum_log_l = 0.0
+        sum_log_f = 0.0
+        sum_log_ll = 0.0
+        sum_log_lf = 0.0
+        all_pos = True
+        for si in range(ns):
+            s = scales[si]
+            nb = m // s
+            if nb < 1:
+                continue
+            # t stats for t = 0..s-1 (fixed per scale)
+            tbar = (s - 1) / 2.0
+            sxx = 0.0
+            for tt in range(s):
+                d = tt - tbar
+                sxx += d * d
+            f2sum = 0.0
+            for b in range(nb):
+                base = b * s
+                # segment mean
+                segbar = 0.0
+                for tt in range(s):
+                    segbar += y[base + tt]
+                segbar /= s
+                sdt = 0.0
+                sdd = 0.0
+                for tt in range(s):
+                    dd = y[base + tt] - segbar
+                    sdt += dd * (tt - tbar)
+                    sdd += dd * dd
+                bslope = sdt / sxx
+                # residual mean-square = (Sdd - b^2 * Sxx) / s  (closed form of mean((seg - a - b t)^2))
+                f2 = (sdd - bslope * bslope * sxx) / s
+                if f2 < 0.0:
+                    f2 = 0.0
+                f2sum += f2
+            fs_val = np.sqrt(f2sum / nb)
+            if fs_val <= 0.0:
+                all_pos = False
+                break
+            ll = np.log(float(s))
+            lf = np.log(fs_val)
+            sum_log_l += ll
+            sum_log_f += lf
+            sum_log_ll += ll * ll
+            sum_log_lf += ll * lf
+            valid += 1
+        if valid >= 2 and all_pos:
+            denom = valid * sum_log_ll - sum_log_l * sum_log_l
+            if denom != 0.0:
+                out[i] = (valid * sum_log_lf - sum_log_l * sum_log_f) / denom
+    return out
+
+
+def dfa_fast(close, n: int) -> np.ndarray:
+    """Vectorized/Numba drop-in for calc.quant.dfa — same shape/NaN warm-up, closed-form detrend."""
+    c = np.asarray(close, dtype=np.float64)
+    scales = np.asarray(_scales_for(int(n)), dtype=np.int64)
+    if scales.shape[0] < 2:
+        return np.full(c.shape[0], np.nan)
+    return _dfa_core(c, int(n), scales)

--- a/subprojects/Parametric-Indicators/optimize/perf/results/baseline_NQ_4h_after_dfa.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/baseline_NQ_4h_after_dfa.json
@@ -1,0 +1,619 @@
+{
+  "tf": "4h",
+  "instrument": "NQ",
+  "trials": 3,
+  "folds": 5,
+  "min_trades": 5,
+  "registry_size": 165,
+  "ind_1min": true,
+  "wall_seconds": 40.46,
+  "cold_seconds": 38.735731,
+  "cold_computes": 233,
+  "cold_frac_of_wall": 0.9575,
+  "hits": 0,
+  "misses": 233,
+  "hit_rate": 0.0,
+  "bytes_read": 0,
+  "bytes_written": 97394,
+  "per_indicator": {
+    "autocorr": {
+      "computes": 2,
+      "cold_seconds": 3.659805
+    },
+    "hurst_exp": {
+      "computes": 3,
+      "cold_seconds": 2.934921
+    },
+    "ifvg": {
+      "computes": 1,
+      "cold_seconds": 2.508907
+    },
+    "proj_bands": {
+      "computes": 2,
+      "cold_seconds": 1.845414
+    },
+    "ou_halflife": {
+      "computes": 2,
+      "cold_seconds": 1.57829
+    },
+    "linreg_channel": {
+      "computes": 2,
+      "cold_seconds": 1.414655
+    },
+    "schaff_trend_cycle": {
+      "computes": 2,
+      "cold_seconds": 1.34327
+    },
+    "sinewave": {
+      "computes": 1,
+      "cold_seconds": 1.282125
+    },
+    "frama": {
+      "computes": 2,
+      "cold_seconds": 1.07487
+    },
+    "chande_kroll": {
+      "computes": 2,
+      "cold_seconds": 0.986326
+    },
+    "ulcer": {
+      "computes": 2,
+      "cold_seconds": 0.786565
+    },
+    "stoch_rsi": {
+      "computes": 3,
+      "cold_seconds": 0.767812
+    },
+    "cmo_chande_dmi": {
+      "computes": 1,
+      "cold_seconds": 0.760519
+    },
+    "hilbert_cycle": {
+      "computes": 2,
+      "cold_seconds": 0.724557
+    },
+    "ichimoku_tk_cross": {
+      "computes": 1,
+      "cold_seconds": 0.679294
+    },
+    "fisher": {
+      "computes": 2,
+      "cold_seconds": 0.67184
+    },
+    "ichimoku_cloud": {
+      "computes": 1,
+      "cold_seconds": 0.654765
+    },
+    "rsi_connors": {
+      "computes": 2,
+      "cold_seconds": 0.614106
+    },
+    "lsma": {
+      "computes": 1,
+      "cold_seconds": 0.602297
+    },
+    "hma": {
+      "computes": 2,
+      "cold_seconds": 0.56673
+    },
+    "linreg_r2": {
+      "computes": 1,
+      "cold_seconds": 0.55315
+    },
+    "kdj": {
+      "computes": 2,
+      "cold_seconds": 0.537513
+    },
+    "aroon_osc": {
+      "computes": 3,
+      "cold_seconds": 0.523721
+    },
+    "mama_fama": {
+      "computes": 1,
+      "cold_seconds": 0.464901
+    },
+    "smi": {
+      "computes": 1,
+      "cold_seconds": 0.446181
+    },
+    "stochastic": {
+      "computes": 2,
+      "cold_seconds": 0.444017
+    },
+    "order_block": {
+      "computes": 2,
+      "cold_seconds": 0.400738
+    },
+    "atr_norm": {
+      "computes": 3,
+      "cold_seconds": 0.304983
+    },
+    "kama": {
+      "computes": 3,
+      "cold_seconds": 0.304346
+    },
+    "vol_ratio": {
+      "computes": 2,
+      "cold_seconds": 0.29764
+    },
+    "linreg_slope": {
+      "computes": 1,
+      "cold_seconds": 0.2869
+    },
+    "derivative_osc": {
+      "computes": 2,
+      "cold_seconds": 0.275515
+    },
+    "chandelier": {
+      "computes": 1,
+      "cold_seconds": 0.271842
+    },
+    "qqe": {
+      "computes": 1,
+      "cold_seconds": 0.245663
+    },
+    "wavetrend": {
+      "computes": 3,
+      "cold_seconds": 0.233621
+    },
+    "adx": {
+      "computes": 1,
+      "cold_seconds": 0.223011
+    },
+    "williams_r": {
+      "computes": 1,
+      "cold_seconds": 0.221592
+    },
+    "choppiness": {
+      "computes": 1,
+      "cold_seconds": 0.221282
+    },
+    "laguerre_rsi": {
+      "computes": 2,
+      "cold_seconds": 0.219957
+    },
+    "donchian": {
+      "computes": 1,
+      "cold_seconds": 0.218711
+    },
+    "rvi_dorsey": {
+      "computes": 2,
+      "cold_seconds": 0.208361
+    },
+    "stddev": {
+      "computes": 3,
+      "cold_seconds": 0.198192
+    },
+    "klinger": {
+      "computes": 3,
+      "cold_seconds": 0.194961
+    },
+    "hist_vol": {
+      "computes": 3,
+      "cold_seconds": 0.188895
+    },
+    "trix": {
+      "computes": 2,
+      "cold_seconds": 0.184416
+    },
+    "tma": {
+      "computes": 2,
+      "cold_seconds": 0.18206
+    },
+    "sine_wma": {
+      "computes": 2,
+      "cold_seconds": 0.180033
+    },
+    "alligator": {
+      "computes": 1,
+      "cold_seconds": 0.179593
+    },
+    "aroon": {
+      "computes": 1,
+      "cold_seconds": 0.176163
+    },
+    "gmma": {
+      "computes": 1,
+      "cold_seconds": 0.171938
+    },
+    "tema": {
+      "computes": 2,
+      "cold_seconds": 0.168517
+    },
+    "ttm_squeeze": {
+      "computes": 2,
+      "cold_seconds": 0.165061
+    },
+    "rvgi": {
+      "computes": 1,
+      "cold_seconds": 0.16309
+    },
+    "dfa": {
+      "computes": 2,
+      "cold_seconds": 0.161004
+    },
+    "vidya": {
+      "computes": 1,
+      "cold_seconds": 0.15747
+    },
+    "gator": {
+      "computes": 1,
+      "cold_seconds": 0.154563
+    },
+    "efficiency_ratio": {
+      "computes": 2,
+      "cold_seconds": 0.154474
+    },
+    "di_cross": {
+      "computes": 1,
+      "cold_seconds": 0.151077
+    },
+    "cyber_cycle": {
+      "computes": 2,
+      "cold_seconds": 0.142676
+    },
+    "breaker": {
+      "computes": 1,
+      "cold_seconds": 0.135942
+    },
+    "alma": {
+      "computes": 3,
+      "cold_seconds": 0.135801
+    },
+    "yang_zhang": {
+      "computes": 2,
+      "cold_seconds": 0.127027
+    },
+    "elder_impulse": {
+      "computes": 2,
+      "cold_seconds": 0.112666
+    },
+    "tsi": {
+      "computes": 1,
+      "cold_seconds": 0.107041
+    },
+    "psar": {
+      "computes": 3,
+      "cold_seconds": 0.106886
+    },
+    "starc": {
+      "computes": 2,
+      "cold_seconds": 0.102013
+    },
+    "rma": {
+      "computes": 1,
+      "cold_seconds": 0.101667
+    },
+    "supertrend": {
+      "computes": 1,
+      "cold_seconds": 0.100728
+    },
+    "wma": {
+      "computes": 1,
+      "cold_seconds": 0.095441
+    },
+    "asi": {
+      "computes": 1,
+      "cold_seconds": 0.090691
+    },
+    "ema_trend": {
+      "computes": 3,
+      "cold_seconds": 0.086694
+    },
+    "vol_osc": {
+      "computes": 3,
+      "cold_seconds": 0.085288
+    },
+    "roofing": {
+      "computes": 1,
+      "cold_seconds": 0.080721
+    },
+    "garch_ewma": {
+      "computes": 1,
+      "cold_seconds": 0.06814
+    },
+    "emd": {
+      "computes": 1,
+      "cold_seconds": 0.066315
+    },
+    "keltner": {
+      "computes": 1,
+      "cold_seconds": 0.065654
+    },
+    "evwma": {
+      "computes": 1,
+      "cold_seconds": 0.064171
+    },
+    "mcginley": {
+      "computes": 1,
+      "cold_seconds": 0.063387
+    },
+    "chaikin_osc": {
+      "computes": 2,
+      "cold_seconds": 0.057314
+    },
+    "vzo": {
+      "computes": 2,
+      "cold_seconds": 0.056888
+    },
+    "dema": {
+      "computes": 1,
+      "cold_seconds": 0.05582
+    },
+    "zlema": {
+      "computes": 2,
+      "cold_seconds": 0.055817
+    },
+    "parkinson": {
+      "computes": 1,
+      "cold_seconds": 0.051852
+    },
+    "rogers_satchell": {
+      "computes": 1,
+      "cold_seconds": 0.051778
+    },
+    "jma": {
+      "computes": 1,
+      "cold_seconds": 0.048708
+    },
+    "coppock": {
+      "computes": 1,
+      "cold_seconds": 0.046807
+    },
+    "pvt": {
+      "computes": 2,
+      "cold_seconds": 0.045564
+    },
+    "fractals": {
+      "computes": 1,
+      "cold_seconds": 0.045498
+    },
+    "zscore": {
+      "computes": 2,
+      "cold_seconds": 0.045309
+    },
+    "macd": {
+      "computes": 1,
+      "cold_seconds": 0.043222
+    },
+    "cci": {
+      "computes": 3,
+      "cold_seconds": 0.042754
+    },
+    "tvi": {
+      "computes": 2,
+      "cold_seconds": 0.038259
+    },
+    "structure_trend": {
+      "computes": 2,
+      "cold_seconds": 0.037185
+    },
+    "rsi": {
+      "computes": 1,
+      "cold_seconds": 0.036699
+    },
+    "bandpass": {
+      "computes": 1,
+      "cold_seconds": 0.035246
+    },
+    "pvi": {
+      "computes": 1,
+      "cold_seconds": 0.034385
+    },
+    "nvi": {
+      "computes": 1,
+      "cold_seconds": 0.032995
+    },
+    "bollinger": {
+      "computes": 2,
+      "cold_seconds": 0.032075
+    },
+    "kalman": {
+      "computes": 2,
+      "cold_seconds": 0.031227
+    },
+    "pgo": {
+      "computes": 2,
+      "cold_seconds": 0.029883
+    },
+    "elder_ray": {
+      "computes": 2,
+      "cold_seconds": 0.029212
+    },
+    "demand_index": {
+      "computes": 1,
+      "cold_seconds": 0.029147
+    },
+    "mass_index": {
+      "computes": 1,
+      "cold_seconds": 0.028928
+    },
+    "force_index": {
+      "computes": 2,
+      "cold_seconds": 0.028666
+    },
+    "super_smoother": {
+      "computes": 1,
+      "cold_seconds": 0.02854
+    },
+    "apo": {
+      "computes": 1,
+      "cold_seconds": 0.028465
+    },
+    "expma": {
+      "computes": 1,
+      "cold_seconds": 0.028407
+    },
+    "pivot_woodie": {
+      "computes": 1,
+      "cold_seconds": 0.027849
+    },
+    "pivot_demark": {
+      "computes": 1,
+      "cold_seconds": 0.027757
+    },
+    "pivot_camarilla": {
+      "computes": 1,
+      "cold_seconds": 0.027601
+    },
+    "chaikin_vol": {
+      "computes": 2,
+      "cold_seconds": 0.027353
+    },
+    "pivot_fib": {
+      "computes": 1,
+      "cold_seconds": 0.02676
+    },
+    "cpr": {
+      "computes": 1,
+      "cold_seconds": 0.026611
+    },
+    "pivot_floor": {
+      "computes": 1,
+      "cold_seconds": 0.026507
+    },
+    "anchored_vwap": {
+      "computes": 1,
+      "cold_seconds": 0.021252
+    },
+    "fvg": {
+      "computes": 1,
+      "cold_seconds": 0.019954
+    },
+    "cisd": {
+      "computes": 1,
+      "cold_seconds": 0.018404
+    },
+    "mfi": {
+      "computes": 1,
+      "cold_seconds": 0.016822
+    },
+    "td_sequential": {
+      "computes": 1,
+      "cold_seconds": 0.011741
+    },
+    "td_combo": {
+      "computes": 1,
+      "cold_seconds": 0.011691
+    },
+    "ultimate_osc": {
+      "computes": 2,
+      "cold_seconds": 0.008593
+    },
+    "td_rei": {
+      "computes": 3,
+      "cold_seconds": 0.006714
+    },
+    "cmo": {
+      "computes": 3,
+      "cold_seconds": 0.004929
+    },
+    "vortex": {
+      "computes": 2,
+      "cold_seconds": 0.004611
+    },
+    "trend_intensity": {
+      "computes": 2,
+      "cold_seconds": 0.003803
+    },
+    "volume_ratio_asia": {
+      "computes": 1,
+      "cold_seconds": 0.00322
+    },
+    "psy": {
+      "computes": 3,
+      "cold_seconds": 0.002803
+    },
+    "rsi_cutler": {
+      "computes": 1,
+      "cold_seconds": 0.002495
+    },
+    "eom": {
+      "computes": 2,
+      "cold_seconds": 0.00177
+    },
+    "sma_trend": {
+      "computes": 2,
+      "cold_seconds": 0.001754
+    },
+    "accel_osc": {
+      "computes": 1,
+      "cold_seconds": 0.001571
+    },
+    "demarker": {
+      "computes": 1,
+      "cold_seconds": 0.001512
+    },
+    "cmf": {
+      "computes": 1,
+      "cold_seconds": 0.00151
+    },
+    "twiggs_mf": {
+      "computes": 1,
+      "cold_seconds": 0.001498
+    },
+    "dma": {
+      "computes": 1,
+      "cold_seconds": 0.001258
+    },
+    "vwma": {
+      "computes": 1,
+      "cold_seconds": 0.001189
+    },
+    "bias": {
+      "computes": 2,
+      "cold_seconds": 0.001056
+    },
+    "bw_mfi": {
+      "computes": 1,
+      "cold_seconds": 0.000966
+    },
+    "awesome_osc": {
+      "computes": 1,
+      "cold_seconds": 0.000909
+    },
+    "ad_line": {
+      "computes": 1,
+      "cold_seconds": 0.000815
+    },
+    "balance_of_power": {
+      "computes": 2,
+      "cold_seconds": 0.000797
+    },
+    "wvad": {
+      "computes": 1,
+      "cold_seconds": 0.000786
+    },
+    "elliott_wave_osc": {
+      "computes": 1,
+      "cold_seconds": 0.000746
+    },
+    "obv": {
+      "computes": 1,
+      "cold_seconds": 0.000727
+    },
+    "ma_envelope": {
+      "computes": 1,
+      "cold_seconds": 0.00057
+    },
+    "dpo": {
+      "computes": 1,
+      "cold_seconds": 0.000424
+    },
+    "momentum": {
+      "computes": 2,
+      "cold_seconds": 0.000375
+    },
+    "ichimoku_chikou": {
+      "computes": 1,
+      "cold_seconds": 0.000207
+    }
+  },
+  "optimizer_result": {
+    "timeframe": "4h",
+    "n_trials": 3,
+    "front": 0,
+    "front_all": 0,
+    "dur_s": 40.1714608669281
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/perf/results/baseline_NQ_4h_smoke3.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/baseline_NQ_4h_smoke3.json
@@ -1,0 +1,619 @@
+{
+  "tf": "4h",
+  "instrument": "NQ",
+  "trials": 3,
+  "folds": 5,
+  "min_trades": 5,
+  "registry_size": 165,
+  "ind_1min": true,
+  "wall_seconds": 207.91,
+  "cold_seconds": 206.105646,
+  "cold_computes": 233,
+  "cold_frac_of_wall": 0.9913,
+  "hits": 0,
+  "misses": 233,
+  "hit_rate": 0.0,
+  "bytes_read": 0,
+  "bytes_written": 97394,
+  "per_indicator": {
+    "dfa": {
+      "computes": 2,
+      "cold_seconds": 166.993761
+    },
+    "autocorr": {
+      "computes": 2,
+      "cold_seconds": 3.674513
+    },
+    "hurst_exp": {
+      "computes": 3,
+      "cold_seconds": 2.943875
+    },
+    "ifvg": {
+      "computes": 1,
+      "cold_seconds": 2.486343
+    },
+    "proj_bands": {
+      "computes": 2,
+      "cold_seconds": 1.862737
+    },
+    "ou_halflife": {
+      "computes": 2,
+      "cold_seconds": 1.600584
+    },
+    "linreg_channel": {
+      "computes": 2,
+      "cold_seconds": 1.404204
+    },
+    "schaff_trend_cycle": {
+      "computes": 2,
+      "cold_seconds": 1.342522
+    },
+    "sinewave": {
+      "computes": 1,
+      "cold_seconds": 1.292791
+    },
+    "frama": {
+      "computes": 2,
+      "cold_seconds": 1.075494
+    },
+    "chande_kroll": {
+      "computes": 2,
+      "cold_seconds": 0.992379
+    },
+    "ulcer": {
+      "computes": 2,
+      "cold_seconds": 0.796669
+    },
+    "stoch_rsi": {
+      "computes": 3,
+      "cold_seconds": 0.770261
+    },
+    "cmo_chande_dmi": {
+      "computes": 1,
+      "cold_seconds": 0.766288
+    },
+    "hilbert_cycle": {
+      "computes": 2,
+      "cold_seconds": 0.723314
+    },
+    "ichimoku_cloud": {
+      "computes": 1,
+      "cold_seconds": 0.669192
+    },
+    "fisher": {
+      "computes": 2,
+      "cold_seconds": 0.666049
+    },
+    "ichimoku_tk_cross": {
+      "computes": 1,
+      "cold_seconds": 0.662544
+    },
+    "lsma": {
+      "computes": 1,
+      "cold_seconds": 0.611851
+    },
+    "rsi_connors": {
+      "computes": 2,
+      "cold_seconds": 0.6076
+    },
+    "hma": {
+      "computes": 2,
+      "cold_seconds": 0.574013
+    },
+    "breaker": {
+      "computes": 1,
+      "cold_seconds": 0.568504
+    },
+    "linreg_r2": {
+      "computes": 1,
+      "cold_seconds": 0.55906
+    },
+    "kdj": {
+      "computes": 2,
+      "cold_seconds": 0.542936
+    },
+    "aroon_osc": {
+      "computes": 3,
+      "cold_seconds": 0.528372
+    },
+    "mama_fama": {
+      "computes": 1,
+      "cold_seconds": 0.451857
+    },
+    "stochastic": {
+      "computes": 2,
+      "cold_seconds": 0.446648
+    },
+    "smi": {
+      "computes": 1,
+      "cold_seconds": 0.423218
+    },
+    "order_block": {
+      "computes": 2,
+      "cold_seconds": 0.403962
+    },
+    "kama": {
+      "computes": 3,
+      "cold_seconds": 0.305009
+    },
+    "atr_norm": {
+      "computes": 3,
+      "cold_seconds": 0.30399
+    },
+    "vol_ratio": {
+      "computes": 2,
+      "cold_seconds": 0.300386
+    },
+    "linreg_slope": {
+      "computes": 1,
+      "cold_seconds": 0.288058
+    },
+    "derivative_osc": {
+      "computes": 2,
+      "cold_seconds": 0.275458
+    },
+    "chandelier": {
+      "computes": 1,
+      "cold_seconds": 0.273996
+    },
+    "laguerre_rsi": {
+      "computes": 2,
+      "cold_seconds": 0.250822
+    },
+    "qqe": {
+      "computes": 1,
+      "cold_seconds": 0.245175
+    },
+    "wavetrend": {
+      "computes": 3,
+      "cold_seconds": 0.235758
+    },
+    "klinger": {
+      "computes": 3,
+      "cold_seconds": 0.225068
+    },
+    "donchian": {
+      "computes": 1,
+      "cold_seconds": 0.224126
+    },
+    "choppiness": {
+      "computes": 1,
+      "cold_seconds": 0.223161
+    },
+    "adx": {
+      "computes": 1,
+      "cold_seconds": 0.222203
+    },
+    "williams_r": {
+      "computes": 1,
+      "cold_seconds": 0.222171
+    },
+    "rvi_dorsey": {
+      "computes": 2,
+      "cold_seconds": 0.210924
+    },
+    "stddev": {
+      "computes": 3,
+      "cold_seconds": 0.197309
+    },
+    "trix": {
+      "computes": 2,
+      "cold_seconds": 0.188902
+    },
+    "hist_vol": {
+      "computes": 3,
+      "cold_seconds": 0.188156
+    },
+    "tma": {
+      "computes": 2,
+      "cold_seconds": 0.181696
+    },
+    "sine_wma": {
+      "computes": 2,
+      "cold_seconds": 0.181523
+    },
+    "aroon": {
+      "computes": 1,
+      "cold_seconds": 0.176075
+    },
+    "tema": {
+      "computes": 2,
+      "cold_seconds": 0.175324
+    },
+    "gmma": {
+      "computes": 1,
+      "cold_seconds": 0.167577
+    },
+    "ttm_squeeze": {
+      "computes": 2,
+      "cold_seconds": 0.165549
+    },
+    "rvgi": {
+      "computes": 1,
+      "cold_seconds": 0.1612
+    },
+    "vidya": {
+      "computes": 1,
+      "cold_seconds": 0.158745
+    },
+    "efficiency_ratio": {
+      "computes": 2,
+      "cold_seconds": 0.157013
+    },
+    "di_cross": {
+      "computes": 1,
+      "cold_seconds": 0.151299
+    },
+    "alligator": {
+      "computes": 1,
+      "cold_seconds": 0.150722
+    },
+    "gator": {
+      "computes": 1,
+      "cold_seconds": 0.1507
+    },
+    "cyber_cycle": {
+      "computes": 2,
+      "cold_seconds": 0.14127
+    },
+    "alma": {
+      "computes": 3,
+      "cold_seconds": 0.136684
+    },
+    "yang_zhang": {
+      "computes": 2,
+      "cold_seconds": 0.12781
+    },
+    "elder_impulse": {
+      "computes": 2,
+      "cold_seconds": 0.112799
+    },
+    "tsi": {
+      "computes": 1,
+      "cold_seconds": 0.107621
+    },
+    "psar": {
+      "computes": 3,
+      "cold_seconds": 0.106785
+    },
+    "rma": {
+      "computes": 1,
+      "cold_seconds": 0.104238
+    },
+    "starc": {
+      "computes": 2,
+      "cold_seconds": 0.101443
+    },
+    "supertrend": {
+      "computes": 1,
+      "cold_seconds": 0.099208
+    },
+    "wma": {
+      "computes": 1,
+      "cold_seconds": 0.09684
+    },
+    "ema_trend": {
+      "computes": 3,
+      "cold_seconds": 0.09097
+    },
+    "asi": {
+      "computes": 1,
+      "cold_seconds": 0.090051
+    },
+    "vol_osc": {
+      "computes": 3,
+      "cold_seconds": 0.085038
+    },
+    "roofing": {
+      "computes": 1,
+      "cold_seconds": 0.08329
+    },
+    "emd": {
+      "computes": 1,
+      "cold_seconds": 0.069003
+    },
+    "garch_ewma": {
+      "computes": 1,
+      "cold_seconds": 0.068426
+    },
+    "evwma": {
+      "computes": 1,
+      "cold_seconds": 0.064927
+    },
+    "keltner": {
+      "computes": 1,
+      "cold_seconds": 0.064919
+    },
+    "mcginley": {
+      "computes": 1,
+      "cold_seconds": 0.063987
+    },
+    "zlema": {
+      "computes": 2,
+      "cold_seconds": 0.058002
+    },
+    "vzo": {
+      "computes": 2,
+      "cold_seconds": 0.057774
+    },
+    "chaikin_osc": {
+      "computes": 2,
+      "cold_seconds": 0.056226
+    },
+    "dema": {
+      "computes": 1,
+      "cold_seconds": 0.055993
+    },
+    "parkinson": {
+      "computes": 1,
+      "cold_seconds": 0.05148
+    },
+    "rogers_satchell": {
+      "computes": 1,
+      "cold_seconds": 0.051363
+    },
+    "jma": {
+      "computes": 1,
+      "cold_seconds": 0.049828
+    },
+    "coppock": {
+      "computes": 1,
+      "cold_seconds": 0.047566
+    },
+    "pvt": {
+      "computes": 2,
+      "cold_seconds": 0.045199
+    },
+    "zscore": {
+      "computes": 2,
+      "cold_seconds": 0.044722
+    },
+    "cci": {
+      "computes": 3,
+      "cold_seconds": 0.043878
+    },
+    "macd": {
+      "computes": 1,
+      "cold_seconds": 0.042697
+    },
+    "tvi": {
+      "computes": 2,
+      "cold_seconds": 0.040738
+    },
+    "rsi": {
+      "computes": 1,
+      "cold_seconds": 0.035683
+    },
+    "bandpass": {
+      "computes": 1,
+      "cold_seconds": 0.035513
+    },
+    "structure_trend": {
+      "computes": 2,
+      "cold_seconds": 0.03477
+    },
+    "nvi": {
+      "computes": 1,
+      "cold_seconds": 0.033616
+    },
+    "bollinger": {
+      "computes": 2,
+      "cold_seconds": 0.03313
+    },
+    "pvi": {
+      "computes": 1,
+      "cold_seconds": 0.032638
+    },
+    "kalman": {
+      "computes": 2,
+      "cold_seconds": 0.031955
+    },
+    "fractals": {
+      "computes": 1,
+      "cold_seconds": 0.030206
+    },
+    "elder_ray": {
+      "computes": 2,
+      "cold_seconds": 0.030056
+    },
+    "pgo": {
+      "computes": 2,
+      "cold_seconds": 0.029965
+    },
+    "expma": {
+      "computes": 1,
+      "cold_seconds": 0.029681
+    },
+    "demand_index": {
+      "computes": 1,
+      "cold_seconds": 0.028844
+    },
+    "super_smoother": {
+      "computes": 1,
+      "cold_seconds": 0.028613
+    },
+    "mass_index": {
+      "computes": 1,
+      "cold_seconds": 0.028471
+    },
+    "apo": {
+      "computes": 1,
+      "cold_seconds": 0.028454
+    },
+    "force_index": {
+      "computes": 2,
+      "cold_seconds": 0.028127
+    },
+    "chaikin_vol": {
+      "computes": 2,
+      "cold_seconds": 0.027846
+    },
+    "cpr": {
+      "computes": 1,
+      "cold_seconds": 0.027157
+    },
+    "pivot_fib": {
+      "computes": 1,
+      "cold_seconds": 0.027031
+    },
+    "pivot_woodie": {
+      "computes": 1,
+      "cold_seconds": 0.026415
+    },
+    "pivot_demark": {
+      "computes": 1,
+      "cold_seconds": 0.026415
+    },
+    "pivot_floor": {
+      "computes": 1,
+      "cold_seconds": 0.026396
+    },
+    "pivot_camarilla": {
+      "computes": 1,
+      "cold_seconds": 0.026119
+    },
+    "fvg": {
+      "computes": 1,
+      "cold_seconds": 0.021029
+    },
+    "anchored_vwap": {
+      "computes": 1,
+      "cold_seconds": 0.020755
+    },
+    "cisd": {
+      "computes": 1,
+      "cold_seconds": 0.018148
+    },
+    "mfi": {
+      "computes": 1,
+      "cold_seconds": 0.016691
+    },
+    "td_combo": {
+      "computes": 1,
+      "cold_seconds": 0.01239
+    },
+    "td_sequential": {
+      "computes": 1,
+      "cold_seconds": 0.011115
+    },
+    "ultimate_osc": {
+      "computes": 2,
+      "cold_seconds": 0.008534
+    },
+    "td_rei": {
+      "computes": 3,
+      "cold_seconds": 0.006577
+    },
+    "cmo": {
+      "computes": 3,
+      "cold_seconds": 0.004795
+    },
+    "vortex": {
+      "computes": 2,
+      "cold_seconds": 0.004587
+    },
+    "trend_intensity": {
+      "computes": 2,
+      "cold_seconds": 0.003914
+    },
+    "volume_ratio_asia": {
+      "computes": 1,
+      "cold_seconds": 0.00304
+    },
+    "psy": {
+      "computes": 3,
+      "cold_seconds": 0.002768
+    },
+    "rsi_cutler": {
+      "computes": 1,
+      "cold_seconds": 0.002484
+    },
+    "eom": {
+      "computes": 2,
+      "cold_seconds": 0.002475
+    },
+    "twiggs_mf": {
+      "computes": 1,
+      "cold_seconds": 0.001867
+    },
+    "sma_trend": {
+      "computes": 2,
+      "cold_seconds": 0.001747
+    },
+    "cmf": {
+      "computes": 1,
+      "cold_seconds": 0.001529
+    },
+    "accel_osc": {
+      "computes": 1,
+      "cold_seconds": 0.001481
+    },
+    "demarker": {
+      "computes": 1,
+      "cold_seconds": 0.001468
+    },
+    "dma": {
+      "computes": 1,
+      "cold_seconds": 0.001246
+    },
+    "vwma": {
+      "computes": 1,
+      "cold_seconds": 0.001209
+    },
+    "bias": {
+      "computes": 2,
+      "cold_seconds": 0.001051
+    },
+    "bw_mfi": {
+      "computes": 1,
+      "cold_seconds": 0.000954
+    },
+    "wvad": {
+      "computes": 1,
+      "cold_seconds": 0.000878
+    },
+    "ad_line": {
+      "computes": 1,
+      "cold_seconds": 0.000832
+    },
+    "balance_of_power": {
+      "computes": 2,
+      "cold_seconds": 0.000796
+    },
+    "awesome_osc": {
+      "computes": 1,
+      "cold_seconds": 0.000791
+    },
+    "obv": {
+      "computes": 1,
+      "cold_seconds": 0.000729
+    },
+    "elliott_wave_osc": {
+      "computes": 1,
+      "cold_seconds": 0.00069
+    },
+    "ma_envelope": {
+      "computes": 1,
+      "cold_seconds": 0.000574
+    },
+    "dpo": {
+      "computes": 1,
+      "cold_seconds": 0.000423
+    },
+    "momentum": {
+      "computes": 2,
+      "cold_seconds": 0.000374
+    },
+    "ichimoku_chikou": {
+      "computes": 1,
+      "cold_seconds": 0.000196
+    }
+  },
+  "optimizer_result": {
+    "timeframe": "4h",
+    "n_trials": 3,
+    "front": 0,
+    "front_all": 0,
+    "dur_s": 207.65075659751892
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/perf/results/dfa_bench_NQ_1m.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/dfa_bench_NQ_1m.json
@@ -1,0 +1,29 @@
+{
+  "n_bars": 486969,
+  "per_n": {
+    "20": {
+      "ref_s": 57.0,
+      "fast_s": 0.044,
+      "speedup": 1309.3,
+      "mask_match": true,
+      "float_close": true,
+      "max_vote_flips_over_grid": 0
+    },
+    "100": {
+      "ref_s": 248.276,
+      "fast_s": 0.178,
+      "speedup": 1396.1,
+      "mask_match": true,
+      "float_close": true,
+      "max_vote_flips_over_grid": 0
+    },
+    "400": {
+      "ref_s": 756.561,
+      "fast_s": 0.658,
+      "speedup": 1150.1,
+      "mask_match": true,
+      "float_close": true,
+      "max_vote_flips_over_grid": 0
+    }
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/perf/run_baseline.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/run_baseline.py
@@ -1,0 +1,113 @@
+"""Task 2 — server baseline profile of the optimizer's indicator cold/warm split (issue #54).
+
+Runs the REAL optimizer objective for N trials with the cache Probe installed, fully isolated so it
+pollutes nothing:
+  * ``WSH_JOURNAL_DIR`` → a throwaway per-study journal store (no shared Postgres/SQLite write).
+  * a fresh, COLD ``vote_cache`` dir → the first trials are genuine cold misses; reuse builds as it goes,
+    so the measured hit-rate is the real sweep's steady-state, not a pre-warmed artifact.
+
+Emits, to ``optimize/perf/results/baseline_<inst>_<tf>.json``: wall-clock, cold-compute seconds and its
+fraction of wall, disk hit-rate, and the **per-indicator cold-cost ranking** that Tasks 3/5 use to pick
+which indicators to accelerate. A daemon heartbeat prints progress every ``--heartbeat`` seconds.
+
+Server run (venv has numpy/pandas/optuna/scipy/numba):
+  WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data \
+  /home/dev/Mulham/.venv/bin/python3 -m optimize.perf.run_baseline --tf 4h --trials 200
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # Parametric-Indicators root
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tf", default="4h")
+    ap.add_argument("--instrument", default="NQ")
+    ap.add_argument("--trials", type=int, default=200)
+    ap.add_argument("--folds", type=int, default=5)
+    ap.add_argument("--min-trades", type=int, default=5)
+    ap.add_argument("--heartbeat", type=int, default=30, help="seconds between progress prints")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    # --- isolation: throwaway journal store + cold vote cache -------------------------------------
+    tmp = Path(tempfile.mkdtemp(prefix="probe54_"))
+    (tmp / "journal").mkdir(parents=True, exist_ok=True)
+    os.environ["WSH_JOURNAL_DIR"] = str(tmp / "journal")     # journal wins over any WSH_STORAGE_URL (isolation)
+
+    from optimize import vote_cache, core
+    vote_cache.set_cache_dir(tmp / "vote_cache")
+    vote_cache._clear_disk_cache()
+    core._clear_caches()
+
+    from optimize import optimizer
+    from indicators import library
+    from optimize.perf.cache_probe import Probe
+
+    prefix = f"probe54_{int(time.time())}"                    # unique throwaway study prefix
+    print(f"[baseline] tf={args.tf} inst={args.instrument} trials={args.trials} folds={args.folds} "
+          f"min_trades={args.min_trades} registry={len(library.SCHEMA)} ind_1min=True prefix={prefix}",
+          flush=True)
+
+    probe = Probe().install()
+    stop = threading.Event()
+
+    def heartbeat():
+        while not stop.wait(args.heartbeat):
+            s = probe.snapshot()
+            print(f"[hb {time.strftime('%H:%M:%S')}] cold_computes={s['cold_computes']} "
+                  f"cold_s={s['cold_seconds']:.1f} hits={s['hits']} misses={s['misses']} "
+                  f"hit_rate={s['hit_rate']:.2f}", flush=True)
+
+    hb = threading.Thread(target=heartbeat, daemon=True)
+    hb.start()
+
+    t0 = time.time()
+    result = optimizer.run(args.tf, n_trials=args.trials, folds=args.folds,
+                           min_trades=args.min_trades, ind_1min=True,
+                           study_prefix=prefix, warm_start=False, instrument=args.instrument)
+    wall = time.time() - t0
+    stop.set()
+    probe.uninstall()
+
+    snap = probe.snapshot()
+    out = {
+        "tf": args.tf, "instrument": args.instrument, "trials": args.trials,
+        "folds": args.folds, "min_trades": args.min_trades,
+        "registry_size": len(library.SCHEMA), "ind_1min": True,
+        "wall_seconds": round(wall, 2),
+        "cold_seconds": snap["cold_seconds"], "cold_computes": snap["cold_computes"],
+        "cold_frac_of_wall": round(snap["cold_seconds"] / wall, 4) if wall else None,
+        "hits": snap["hits"], "misses": snap["misses"], "hit_rate": snap["hit_rate"],
+        "bytes_read": snap["bytes_read"], "bytes_written": snap["bytes_written"],
+        "per_indicator": snap["per_indicator"],
+        "optimizer_result": result,
+    }
+    outp = Path(args.out) if args.out else (
+        Path(__file__).resolve().parent / "results" / f"baseline_{args.instrument}_{args.tf}.json")
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    outp.write_text(json.dumps(out, indent=2))
+    cold_pct = (100 * snap["cold_seconds"] / wall) if wall else 0.0
+    print(f"[baseline] DONE wall={wall:.0f}s cold={snap['cold_seconds']:.0f}s ({cold_pct:.0f}% of wall) "
+          f"hit_rate={snap['hit_rate']:.2f} cold_computes={snap['cold_computes']} -> {outp}", flush=True)
+    top = list(out["per_indicator"].items())[:12]
+    print("[baseline] top cold-cost indicators:", flush=True)
+    for k, v in top:
+        print(f"    {k:24s} computes={v['computes']:5d} cold_s={v['cold_seconds']:.2f}", flush=True)
+
+    shutil.rmtree(tmp, ignore_errors=True)                    # drop the throwaway store
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/Parametric-Indicators/optimize/perf/test_cache_probe.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/test_cache_probe.py
@@ -1,0 +1,39 @@
+"""Task 1 gate: the cache probe COUNTS without changing arrays (result-neutral)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # Parametric-Indicators root
+
+import numpy as np
+
+from optimize import vote_cache
+from optimize.perf.cache_probe import Probe
+
+
+def test_probe_counts_hits_and_misses_without_changing_arrays(tmp_path):
+    vote_cache.set_cache_dir(tmp_path)
+    vote_cache._clear_disk_cache()
+    p = Probe().install()
+    try:
+        dkey = vote_cache.disk_key(("sig",), True, "rsi", "confirm", (("n", 14),))
+        arr = np.arange(10, dtype=np.int8)
+        assert vote_cache.get(dkey) is None          # miss (nothing stored yet)
+        vote_cache.put(dkey, arr)
+        got = vote_cache.get(dkey)                    # hit
+    finally:
+        p.uninstall()
+    snap = p.snapshot()
+    assert snap["misses"] == 1
+    assert snap["hits"] == 1
+    assert snap["hit_rate"] == 0.5
+    assert snap["bytes_written"] == arr.nbytes
+    assert np.array_equal(got, arr)                  # result-neutral: exact array round-trips
+
+
+def test_uninstall_restores_originals(tmp_path):
+    vote_cache.set_cache_dir(tmp_path)
+    orig_get = vote_cache.get
+    p = Probe().install()
+    assert vote_cache.get is not orig_get            # patched
+    p.uninstall()
+    assert vote_cache.get is orig_get                # restored exactly

--- a/subprojects/Parametric-Indicators/optimize/perf/test_cold_accel_parity.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/test_cold_accel_parity.py
@@ -32,8 +32,8 @@ THRESHOLDS = np.round(np.arange(0.30, 0.7001, 0.01), 2)
 @pytest.mark.parametrize("n", [100, 200])
 def test_dfa_fast_reproduces_vote_boolean(n):
     close = _random_walk(seed=n, n_bars=6000)
-    ref = Q.dfa(close, n)
-    fast = cold_accel.dfa_fast(close, n)
+    ref = Q.dfa_reference(close, n)      # the original loop (oracle)
+    fast = Q.dfa(close, n)               # what the DFA indicator now actually calls
 
     assert fast.shape == ref.shape
     fin_ref, fin_fast = np.isfinite(ref), np.isfinite(fast)
@@ -52,4 +52,27 @@ def test_dfa_fast_reproduces_vote_boolean(n):
 
 def test_dfa_fast_matches_reference_shape_on_short_input():
     close = _random_walk(seed=1, n_bars=300)
-    assert cold_accel.dfa_fast(close, 100).shape == Q.dfa(close, 100).shape
+    assert cold_accel.dfa_fast(close, 100).shape == Q.dfa_reference(close, 100).shape
+
+
+def test_dfa_indicator_votes_match_reference_end_to_end():
+    """The gate at the level that actually matters: the DFA Indicator's emitted veto directions."""
+    from indicators import library
+    from indicators.runner import market_context
+    import pandas as pd
+
+    close = _random_walk(seed=7, n_bars=4000)
+    df = pd.DataFrame({"Date": pd.date_range("2020", periods=len(close), freq="min"),
+                       "Open": close, "High": close + 2, "Low": close - 2,
+                       "Close": close, "Volume": np.ones(len(close))})
+    ctx = market_context(df)
+    ind = library.from_specs([{"key": "dfa", "enabled": True, "mode": "veto",
+                               "params": {"n": 100, "threshold": 0.5}}])[0]
+    cdir_fast, vdir_fast = ind.directions(ctx)
+
+    # recompute what the reference implementation would have voted
+    from indicators import votes as V
+    ref_alpha = Q.dfa_reference(close, 100)
+    cdir_ref, vdir_ref = V.both_veto(np.isfinite(ref_alpha) & (ref_alpha < 0.5))
+    assert np.array_equal(np.asarray(vdir_fast), np.asarray(vdir_ref))
+    assert np.array_equal(np.asarray(cdir_fast), np.asarray(cdir_ref))

--- a/subprojects/Parametric-Indicators/optimize/perf/test_cold_accel_parity.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/test_cold_accel_parity.py
@@ -1,0 +1,55 @@
+"""Task 3 parity gate: accelerated `dfa` reproduces the reference VOTE exactly (issue #54).
+
+`np.polyfit` (reference) uses LAPACK lstsq, so the closed-form fast path is not bit-identical at the
+float level. The contract that matters is the downstream vote — `both_veto(isfinite(alpha) & (alpha <
+threshold))` — so we assert (a) the finite mask matches, (b) alpha is float-close, and (c) the vote
+boolean is IDENTICAL across the entire threshold grid [0.30, 0.70] step 0.01. The server harness re-runs
+this on the true 486,970-bar 1-minute frame before the accelerator is trusted.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # Parametric-Indicators root
+
+import numpy as np
+import pytest
+
+from indicators.calc import quant as Q
+from optimize.perf import cold_accel
+
+
+def _random_walk(seed: int = 0, n_bars: int = 6000) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    # NQ-like level with mixed persistent/anti-persistent stretches so alpha spans the threshold grid
+    steps = rng.normal(0.0, 3.0, n_bars)
+    steps[: n_bars // 3] = np.cumsum(rng.normal(0.0, 0.3, n_bars // 3))  # a trendy stretch
+    return 21000.0 + np.cumsum(steps)
+
+
+THRESHOLDS = np.round(np.arange(0.30, 0.7001, 0.01), 2)
+
+
+@pytest.mark.parametrize("n", [100, 200])
+def test_dfa_fast_reproduces_vote_boolean(n):
+    close = _random_walk(seed=n, n_bars=6000)
+    ref = Q.dfa(close, n)
+    fast = cold_accel.dfa_fast(close, n)
+
+    assert fast.shape == ref.shape
+    fin_ref, fin_fast = np.isfinite(ref), np.isfinite(fast)
+    assert np.array_equal(fin_ref, fin_fast), "finite/NaN warm-up mask differs"
+
+    # float-closeness on the finite region (closed-form vs LAPACK lstsq)
+    assert np.allclose(ref[fin_ref], fast[fin_fast], rtol=1e-6, atol=1e-8), "alpha not float-close"
+
+    # THE gate: identical veto vote for every threshold on the grid
+    for thr in THRESHOLDS:
+        vote_ref = fin_ref & (ref < thr)
+        vote_fast = fin_fast & (fast < thr)
+        flips = int(np.sum(vote_ref != vote_fast))
+        assert flips == 0, f"n={n} thr={thr}: {flips} vote bars flipped"
+
+
+def test_dfa_fast_matches_reference_shape_on_short_input():
+    close = _random_walk(seed=1, n_bars=300)
+    assert cold_accel.dfa_fast(close, 100).shape == Q.dfa(close, 100).shape


### PR DESCRIPTION
Closes #54.

## TL;DR

We asked whether to pre-compute all indicators into some store (files / DB / vector-DB / graph-DB / Redis
/ RAM / GPU VRAM) and whether a GPU, NVIDIA or ARM box would help the optimizer, which spends ~98% of its
time computing indicators.

**Answer: none of them. No pre-computed store and no new hardware.** 81% of all indicator time was **one
indicator** (`dfa`) written as a triple-nested Python loop calling `np.polyfit` hundreds of millions of
times. Rewriting it in closed form + Numba gave **1,150–1,396×** on the CPU we already own, **with zero
change to any trading decision**.

## The three findings

1. **"Pre-compute everything" is impossible** — the 165 indicators' parameter grids multiply to **~4.0
   billion** combinations ≈ **3.9 PB** for one instrument (~32,000× the server disk). Combinatorics wall,
   not a bandwidth wall.
2. **The cache already existed** — `core._VOTE_MEMO` (memory) + `vote_cache.py` (disk `.npy`, shared
   across all ~30 workers). Microsoft's Qlib uses the identical two-level design.
3. **The real cost was one pathological implementation** — measured, not assumed.

## Measured results (AMD server, real 486,969-bar NQ 1-minute frame)

`dfa` alone, full threshold grid [0.30, 0.70]:

| window `n` | before | after | speed-up | **vote flips** |
|---:|---:|---:|---:|:---:|
| 20 | 57.0 s | 0.044 s | **1,309×** | **0** |
| 100 | 248.3 s | 0.178 s | **1,396×** | **0** |
| 400 | 756.6 s (12.6 min) | 0.658 s | **1,150×** | **0** |

End-to-end re-baseline, **identical workload** (same seed ⇒ same trials; probe confirms the same **233
cold computes**):

| | before | after |
|---|---:|---:|
| wall clock | 208 s | **40 s (5.1×)** |
| cold compute | 206 s | 39 s |
| `dfa` share of cold time | **81%** | **0.42%** |

## Correctness — how we know nothing changed

`dfa` is a **veto** indicator; its only effect is the test `alpha < threshold`. `np.polyfit` goes through
LAPACK so the closed form is not bit-identical in the last float digits, therefore we proved the thing
that actually matters:

- **Zero** differing veto decisions across **every threshold on the searched grid**, at all three window
  sizes, on the real series.
- 4 parity tests green, including an **end-to-end test** driving the real `DFA` indicator object.
- The original implementation is kept verbatim as `dfa_reference` (the parity oracle).
- **No numba installed ⇒ automatic fallback to the original**, so a missing optional dep can never change
  a result.
- **Full-suite control run:** 25 failures in **both** treatment and control, **empty diff both
  directions ⇒ zero regressions**. (Those 25 are pre-existing — `l2/*` and `intracandle`; none touch
  `dfa`/`quant`; `test_parity_anchor` is a known-stale test; some may be an artifact of this deploy
  excluding `*.csv`. Not individually diagnosed, because the control proves they aren't caused here.)

## Pre-registered criterion (set before measuring)

bit-identical decisions **AND** ≥3× cold-miss reduction **AND** beats both dumb controls (warm cache;
more CPU workers) → **GO** on all four counts (≈400× the required speed bar).

## What's in this PR

- `indicators/calc/quant.py` — fast `dfa` + `dfa_reference` oracle + graceful numba fallback
- `optimize/perf/` — result-neutral cache probe, isolated server baseline runner, benchmarks, parity tests
- `optimize/REPORT_indicator_cache_acceleration.md` — full report (Mermaid, plain language, per-technology
  verdicts, **honest gaps**, what went well/wrong)
- `docs/PRIOR_ART_indicator_caching_gpu.md` — deep prior-art pass (vectorbt, talipp/wickra, Qlib,
  RAPIDS/Numba; verified Plasma removal in Arrow 12.0.0)
- design spec + implementation plan under `docs/superpowers/`

## Honest gaps (not measured)

Cache **substrate** (`.npy` vs `/dev/shm` vs Redis vs shared-memory) and cache **level** re-keying were
de-prioritized once compute proved to be 99% of wall — so the Redis/RAM answer rests on reasoning, not
measurement. The remaining tail (`autocorr` 3.66 s, `hurst_exp` 2.93 s, `linreg_r2`) shares the same slow
pattern; honest upside there is ~40 s → ~33 s. **There is no second `dfa`.**

## Lesson

The previous internal performance report named `order_blocks`/`bollinger`/`cci`. The library then grew
21 → 165 indicators and the bottleneck moved entirely. **Re-profile after any large library change; never
optimize from an old profile.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
