### PR TITLE
research(#58): cache substrate + level, measured — NO-GO on all of it

### DIFF
--- a/subprojects/Parametric-Indicators/optimize/REPORT_cache_substrate_and_level.md
+++ b/subprojects/Parametric-Indicators/optimize/REPORT_cache_substrate_and_level.md
@@ -1,0 +1,192 @@
+# Report — Cache Substrate & Cache Level, Measured
+
+**Date:** 2026-07-27 · **Issue:** #58 · **Branch:** `research/cache-substrate`
+**Purpose:** #54 answered the storage question by **reasoning** ("compute is 99% of wall, so storage can't
+matter"). That reasoning was never verified, and storage was one of the original questions. This report
+**measures** it.
+
+---
+
+## 0. Verdict up front
+
+**NO-GO on every substrate change.** Not because the alternatives are slow, but because of **two
+independent reasons, each sufficient on its own**:
+
+1. **A cache read costs ~0.009% of the compute it replaces.** Reading a cached array takes **15 µs**;
+   computing one takes **~167,000 µs**. Even a *perfect, zero-cost* substrate would save 0.009%.
+2. **In a fresh sweep the cache is read almost never.** Measured hit rate over **1,995 lookups across 30 trials: 0.00**. Every trial samples new parameters from a ~4-billion-combination grid, and every fold is a
+   different data slice, so essentially every lookup is a miss.
+
+> Optimizing the substrate would mean making a *rarely-taken* path *0.009% faster*.
+
+**One correction to earlier work, stated plainly:** #54 and the #58 issue text both speculated that the
+cache key's `mode` field caused up to **3× duplication** (confirm/veto/both storing the same array).
+**That is false** — see §3. I had asserted it twice without checking; reading the optimizer disproved it.
+
+---
+
+## 1. Question A — the substrate benchmark
+
+300 **real** cached arrays from the live cache (median 6.5 KB, max 266 KB), on the AMD server
+(123 GB RAM, `/tmp` = ext4 on NVMe, `/dev/shm` = tmpfs).
+
+| substrate | p50 | p99 | vs current | verdict |
+|---|---:|---:|---:|---|
+| `dict` (in-process, theoretical floor) | **0.04 µs** | 0.10 µs | 383× faster | not a real option (per-process, unbounded RAM) |
+| `shared_mem` (`multiprocessing.shared_memory`) | **0.36 µs** | 0.86 µs | **43× faster** | fastest real option — but see §2 |
+| **`npy_tmp` (CURRENT)** | **15.32 µs** | 50.58 µs | — | baseline |
+| `npy_shm` (tmpfs `/dev/shm`) | 15.17 µs | 48.63 µs | 1.01× (noise) | **no gain** |
+| `redis` (loopback, real server) | 24.70 µs | 80.18 µs | **1.6× SLOWER** | ❌ |
+| `npy_mmap` (`mmap_mode='r'`) | 29.24 µs | 67.99 µs | 1.9× SLOWER | ❌ |
+| **30 concurrent readers** | | | | |
+| `npy_tmp` ×30 | 50.49 µs | 677 µs | — | |
+| `npy_shm` ×30 | 46.79 µs | 697 µs | within noise | **no gain** |
+
+*Excluded:* **Arrow Plasma** — deprecated in Arrow 10.0.0, **removed in 12.0.0** (GH-33243). Not a valid
+option in 2026; verified against the Arrow issue tracker rather than assumed.
+
+**Three things worth naming:**
+
+- **tmpfs buys nothing.** `/tmp` is ext4 on NVMe, but with **98 GB in page cache** on a 123 GB box the
+  `.npy` files are already served from RAM. `/dev/shm` just makes that explicit. (Across two runs the
+  concurrent numbers flipped which was faster — i.e. **noise**, not a real difference. Reported honestly
+  rather than cherry-picked.)
+- **Redis is slower, measured not assumed.** A loopback TCP round-trip plus deserialization (24.7 µs)
+  costs more than `np.load` from page cache (15.3 µs). To measure this I ran a throwaway Redis container
+  and installed `redis-py` into an isolated directory — **both removed afterwards**; your shared venv was
+  not modified.
+- **`shared_memory` genuinely is 43× faster** — and that is exactly why the ratio in §2 matters.
+
+---
+
+## 2. The number that ends the discussion
+
+From the #54 re-baseline: **39 s of cold compute over 233 computations ≈ 167 ms per computation.**
+
+| | time |
+|---|---:|
+| Reading a cached array (current) | **15 µs** |
+| Reading a cached array (best possible, `shared_memory`) | 0.36 µs |
+| **Computing that array when it's missing** | **~167,000 µs** |
+
+```mermaid
+graph LR
+    A["Cache READ<br/>15 µs"] -->|"0.009% of"| B["Cache MISS COMPUTE<br/>167,000 µs"]
+    C["Best possible substrate gain<br/>≈ 15 µs saved"] -->|"0.009% of one compute"| B
+```
+
+Switching to the fastest substrate saves **~15 µs per hit**. One avoided *compute* saves **167,000 µs** —
+**11,000× more**. This is why #54's reasoning was right, and it is now measured rather than asserted.
+
+---
+
+## 3. Question B — is the cache keyed at the wrong LEVEL?
+
+### 3a. The `mode` hypothesis is FALSE (correction)
+
+The claim in #54/#58 was that `mode` in the key causes confirm/veto/both to store the same array 3×.
+`optimize/optimizer.py:_suggest_indicators` shows otherwise:
+
+```python
+specs.append({"key": key, "enabled": enabled, "mode": meta["mode"], "params": params, ...})
+```
+
+**`mode` is taken from the schema default and is never suggested to Optuna** — it is a *constant* per
+indicator for the whole sweep. There is no mode duplication, and re-keying to remove `mode` would save
+**nothing**. My earlier statement was wrong; this supersedes it.
+
+### 3b. What *is* real: per-fold and per-timeframe recomputation
+
+Two genuine sources of repeated `directions()` work — with honest limits:
+
+| Source | Real? | Why it is not the free win it looks like |
+|---|---|---|
+| **Per fold** — each trial scores K=5 folds, each a different slice ⇒ 5 separate computes of the same `(indicator, params)` | ✅ real | You *could* compute `directions()` once on the full series and slice per fold — but warm-up at each fold boundary would differ, so **it is not result-neutral**. It changes numbers. Under our rules that disqualifies it unless proven vote-identical (unlikely). |
+| **Per timeframe** — the 6 decision TFs all read the *same* 1-minute arrays, but each TF is a separate study with its own slice signature | ✅ real | Each TF study runs its own NSGA sampler with its own seed, so they explore **different** parameter combinations. Overlap across a ~4-billion grid is near zero except for warm-start champion seeds. The sharing mechanism would exist; the hits would not. Also, the production sweep is **4h-only** by default, so there is usually just one TF running. |
+
+**The deeper structural point:** the cached unit is the **vote** (per decision bar, so timeframe-specific),
+while the **expensive** unit is `directions()` (on the 1-minute frame, timeframe-*independent*). Caching
+one level lower would be the theoretically right shape — but per §2 and §4 it would be optimizing a path
+that is both cheap and rarely taken.
+
+---
+
+## 4. The second kill — the cache barely gets hits
+
+Measured with the probe on a fresh 4h sweep (cold cache, real optimizer):
+
+```
+30 trials · 1,995 cold computes · 1,995 lookups → hits 0, misses 1,995 → hit_rate = 0.00
+wall 317 s · cold 301 s (95% of wall)
+```
+
+**Why:** every trial draws a *new* parameter combination from a ~4-billion grid, and every fold is a
+different slice. Repeats essentially never happen during exploration.
+
+**Where the caching that DOES pay actually lives:** the in-process `_VOTE_MEMO`, which stops the same vote
+array being recomputed by `veto_mask` / `confirm_mask` / `confirm_count` within a single evaluation. That
+is the memoization your project memory records as taking candidate-L1 from **24 → 1,286 trials/min** —
+**not** the disk cache.
+
+**An honest caveat about the 201,354 files (4.3 GB) sitting in the production cache:** that is evidence of
+201,354 *misses being written*, not of hits. It says nothing about how often anything was read back.
+
+**When the disk cache *does* earn its keep:** resuming/re-running a study, warm-start champion seeds
+(repeated parameters by construction), and watchdog respawns. Those are real but are not the hot path.
+
+---
+
+## 5. Question C — sub-primitive (shared EMA/ATR) caching
+
+Qlib caches every sub-expression node; several of our indicators share a base EMA/ATR (MACD, Keltner,
+ADX). **Estimated, not built** — and the estimate says don't: the shared primitives are the *cheap*
+vectorized ones (an EMA over the 1-minute frame is milliseconds). The expensive indicators are expensive
+because of their *own* per-bar loops, which share nothing. Complexity is real; the upside is not.
+
+---
+
+## 6. Verdict per lever
+
+| Lever | Verdict | Basis |
+|---|---|---|
+| tmpfs `/dev/shm` | **NO-GO** | 1.01× (noise); already page-cache-resident |
+| Redis | **NO-GO** | **1.6× slower**, measured, plus an ops dependency |
+| mmap | **NO-GO** | 1.9× slower for arrays this small |
+| `shared_memory` | **NO-GO (despite being 43× faster)** | saves 15 µs against a 167,000 µs miss, on a path with a 0.00 hit rate |
+| Parquet/DuckDB | **NO-GO** | analytics store, wrong shape for single-key retrieval |
+| Arrow Plasma | **N/A** | removed from Arrow in 12.0.0 |
+| Re-key to drop `mode` | **NO-GO** | mode is never searched — zero duplication exists |
+| Re-key at `directions()` level | **NO-GO for now** | correct in shape, but per-fold sharing is not result-neutral and per-TF overlap is ~zero |
+| Sub-primitive caching | **NO-GO** | shared primitives are the cheap ones |
+
+**Nothing here is worth implementing.** That is a real result, not a failure: it closes an open question
+with evidence and prevents future effort being spent on it.
+
+---
+
+## 7. What would change this answer
+
+State the conditions so a future round can re-test cheaply instead of re-litigating:
+
+- **If cold compute ever drops to the ~microsecond range** (it will not — the remaining indicators are
+  milliseconds at best), the 15 µs read would start to matter.
+- **If the workload shifts from exploration to replay** — e.g. re-scoring thousands of *known* parameter
+  sets (champion re-validation, ablation grids, cross-instrument replication). There the hit rate could be
+  high, and `shared_memory` (43×) would become worth revisiting.
+- **If a study ever runs many TFs over a shared warm-start seed set**, per-TF `directions()` sharing gets
+  real overlap.
+
+---
+
+## 8. Honest gaps
+
+1. **The 0.00 hit rate was measured on a deliberately COLD cache** (the harness clears it for clean cold
+   timing). A production run against the accumulated 4.3 GB cache could show a non-zero rate on repeated
+   studies. **Not measured** — the harness would need a "don't clear" flag.
+2. **Per-fold `directions()` sharing was reasoned, not tested.** I did not empirically confirm that
+   fold-boundary warm-up changes the numbers; I inferred it from how warm-up works. If someone wants that
+   win, that assumption is the thing to test first.
+3. **Concurrency was tested at 30 readers on an idle box.** A saturated 30-worker sweep might behave
+   differently, though the §2 ratio makes it moot.
+4. Redis was tested with default settings (no pipelining, no unix socket). Tuning could close some of the
+   1.6× gap — it could not close a 11,000× ratio.

--- a/subprojects/Parametric-Indicators/optimize/perf/bench_substrate.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/bench_substrate.py
@@ -1,0 +1,196 @@
+"""Issue #58 Question A — is the cache SUBSTRATE a bottleneck? (measure, don't reason)
+
+Reads REAL cached vote arrays from the live cache and times retrieval through every substrate we could
+plausibly switch to, at 1 and N concurrent readers:
+
+  dict        in-process dict            — the theoretical floor (pure RAM, no I/O, no parse)
+  npy_tmp     np.load from /tmp          — CURRENT (ext4 on NVMe, but page-cache-hot on a 123 GB box)
+  npy_shm     np.load from /dev/shm      — tmpfs (RAM-backed file, identical code path)
+  npy_mmap    np.load(mmap_mode='r')     — lazy paging, no full parse
+  shared_mem  multiprocessing.shared_memory — zero-copy numpy view across processes
+  redis       redis GET + frombuffer     — only if a server is reachable (skipped loudly otherwise)
+
+The number that decides the issue is not the winner — it is the **ratio of read latency to the cold
+COMPUTE time it saves**. If a read costs microseconds and computing the array costs milliseconds-to-
+seconds, the substrate is irrelevant no matter which one wins.
+
+Run: /home/dev/Mulham/.venv/bin/python3 -m optimize.perf.bench_substrate --n-files 300 --readers 30
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import numpy as np
+
+CACHE = Path("/tmp/wsh_vote_cache")
+SHM = Path("/dev/shm/issue58_bench")
+
+
+def _pct(xs, p):
+    xs = sorted(xs)
+    if not xs:
+        return None
+    k = min(len(xs) - 1, int(round((p / 100.0) * (len(xs) - 1))))
+    return xs[k]
+
+
+def _stats(lat_us, n_bytes):
+    return {"n_reads": len(lat_us),
+            "p50_us": round(_pct(lat_us, 50), 2), "p99_us": round(_pct(lat_us, 99), 2),
+            "mean_us": round(statistics.fmean(lat_us), 2),
+            "MB_per_s": round((n_bytes / 1e6) / (sum(lat_us) / 1e6), 1) if sum(lat_us) else None}
+
+
+# --- worker bodies (module level so ProcessPoolExecutor can pickle them) ---------------------------
+def _read_npy(paths):
+    lat, nb = [], 0
+    for p in paths:
+        t0 = time.perf_counter()
+        a = np.load(p, allow_pickle=False)
+        lat.append((time.perf_counter() - t0) * 1e6)
+        nb += a.nbytes
+    return lat, nb
+
+
+def _read_mmap(paths):
+    lat, nb = [], 0
+    for p in paths:
+        t0 = time.perf_counter()
+        a = np.load(p, allow_pickle=False, mmap_mode="r")
+        s = int(a[0]) if a.size else 0      # touch a page so the read is real
+        lat.append((time.perf_counter() - t0) * 1e6)
+        nb += a.nbytes + (s * 0)
+    return lat, nb
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n-files", type=int, default=300)
+    ap.add_argument("--readers", type=int, default=30)
+    ap.add_argument("--redis-url", default=os.environ.get("ISSUE58_REDIS", ""))
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    files = sorted(CACHE.glob("*.npy"))[: args.n_files]
+    if not files:
+        print(f"[substrate] NO cached arrays in {CACHE} — run a sweep first", flush=True)
+        return 1
+    sizes = [f.stat().st_size for f in files]
+    arrays = {f.name: np.load(f, allow_pickle=False) for f in files}
+    total_bytes = sum(a.nbytes for a in arrays.values())
+    print(f"[substrate] {len(files)} real cached arrays | file bytes p50={_pct(sizes,50)} "
+          f"max={max(sizes)} | in-RAM total={total_bytes/1e6:.1f} MB", flush=True)
+
+    res = {"n_files": len(files), "readers": args.readers,
+           "file_bytes_p50": _pct(sizes, 50), "file_bytes_max": max(sizes),
+           "arrays_total_bytes": int(total_bytes), "substrates": {}, "skipped": {}}
+
+    # ---- dict (floor) ----------------------------------------------------------------------------
+    lat, nb = [], 0
+    for name in arrays:
+        t0 = time.perf_counter()
+        a = arrays[name]
+        lat.append((time.perf_counter() - t0) * 1e6)
+        nb += a.nbytes
+    res["substrates"]["dict"] = _stats(lat, nb)
+
+    # ---- npy from /tmp (current) ----------------------------------------------------------------
+    lat, nb = _read_npy(files)
+    res["substrates"]["npy_tmp"] = _stats(lat, nb)
+
+    # ---- npy from /dev/shm (tmpfs) ---------------------------------------------------------------
+    shutil.rmtree(SHM, ignore_errors=True)
+    SHM.mkdir(parents=True, exist_ok=True)
+    shm_files = []
+    for f in files:
+        d = SHM / f.name
+        shutil.copyfile(f, d)
+        shm_files.append(d)
+    lat, nb = _read_npy(shm_files)
+    res["substrates"]["npy_shm"] = _stats(lat, nb)
+
+    # ---- mmap ------------------------------------------------------------------------------------
+    lat, nb = _read_mmap(files)
+    res["substrates"]["npy_mmap"] = _stats(lat, nb)
+
+    # ---- multiprocessing.shared_memory -----------------------------------------------------------
+    from multiprocessing import shared_memory
+    segs = {}
+    try:
+        for name, a in arrays.items():
+            sm = shared_memory.SharedMemory(create=True, size=max(a.nbytes, 1))
+            np.ndarray(a.shape, dtype=a.dtype, buffer=sm.buf)[:] = a[:]
+            segs[name] = (sm, a.shape, a.dtype)
+        lat, nb = [], 0
+        for name, (sm, shape, dt) in segs.items():
+            t0 = time.perf_counter()
+            v = np.ndarray(shape, dtype=dt, buffer=sm.buf)
+            _ = int(v[0]) if v.size else 0
+            lat.append((time.perf_counter() - t0) * 1e6)
+            nb += v.nbytes
+        res["substrates"]["shared_mem"] = _stats(lat, nb)
+    finally:
+        for sm, _, _ in segs.values():
+            sm.close()
+            sm.unlink()
+
+    # ---- redis (only if reachable) ---------------------------------------------------------------
+    if args.redis_url:
+        try:
+            import redis  # type: ignore
+            r = redis.Redis.from_url(args.redis_url)
+            r.ping()
+            for name, a in arrays.items():
+                r.set(name, a.tobytes())
+            lat, nb = [], 0
+            for name, a in arrays.items():
+                t0 = time.perf_counter()
+                raw = r.get(name)
+                v = np.frombuffer(raw, dtype=a.dtype)
+                lat.append((time.perf_counter() - t0) * 1e6)
+                nb += v.nbytes
+            res["substrates"]["redis"] = _stats(lat, nb)
+            for name in arrays:
+                r.delete(name)
+        except Exception as e:  # noqa: BLE001
+            res["skipped"]["redis"] = f"{type(e).__name__}: {e}"
+            print(f"[substrate] redis SKIPPED — {type(e).__name__}: {e}", flush=True)
+    else:
+        res["skipped"]["redis"] = "no --redis-url / ISSUE58_REDIS given (no server installed)"
+        print("[substrate] redis SKIPPED — no server URL given", flush=True)
+    res["skipped"]["arrow_plasma"] = "REMOVED from Apache Arrow in 12.0.0 (GH-33243) — not a valid option"
+
+    # ---- concurrency: N processes hammering the two realistic candidates --------------------------
+    chunks = [files[i::args.readers] for i in range(args.readers)]
+    shm_chunks = [shm_files[i::args.readers] for i in range(args.readers)]
+    for label, cks in (("npy_tmp", chunks), ("npy_shm", shm_chunks)):
+        t0 = time.perf_counter()
+        with ProcessPoolExecutor(max_workers=args.readers) as ex:
+            out = list(ex.map(_read_npy, cks))
+        wall = time.perf_counter() - t0
+        all_lat = [x for lat_, _ in out for x in lat_]
+        res["substrates"][f"{label}_x{args.readers}"] = {
+            **_stats(all_lat, sum(nb_ for _, nb_ in out)), "wall_s": round(wall, 3)}
+
+    shutil.rmtree(SHM, ignore_errors=True)
+
+    outp = Path(args.out) if args.out else (Path(__file__).resolve().parent / "results" / "substrate_bench.json")
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    outp.write_text(json.dumps(res, indent=2))
+    print(json.dumps(res["substrates"], indent=2), flush=True)
+    print(f"[substrate] WROTE {outp}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/Parametric-Indicators/optimize/perf/results/baseline_NQ_4h_30trials.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/baseline_NQ_4h_30trials.json
@@ -1,0 +1,671 @@
+{
+  "tf": "4h",
+  "instrument": "NQ",
+  "trials": 30,
+  "folds": 5,
+  "min_trades": 5,
+  "registry_size": 165,
+  "ind_1min": true,
+  "wall_seconds": 316.81,
+  "cold_seconds": 301.368582,
+  "cold_computes": 1995,
+  "cold_frac_of_wall": 0.9513,
+  "hits": 0,
+  "misses": 1995,
+  "hit_rate": 0.0,
+  "bytes_read": 0,
+  "bytes_written": 833910,
+  "per_indicator": {
+    "autocorr": {
+      "computes": 16,
+      "cold_seconds": 29.815683
+    },
+    "proj_bands": {
+      "computes": 18,
+      "cold_seconds": 16.827879
+    },
+    "hurst_exp": {
+      "computes": 15,
+      "cold_seconds": 14.974989
+    },
+    "ou_halflife": {
+      "computes": 14,
+      "cold_seconds": 11.414807
+    },
+    "ichimoku_tk_cross": {
+      "computes": 17,
+      "cold_seconds": 11.314309
+    },
+    "cmo_chande_dmi": {
+      "computes": 14,
+      "cold_seconds": 10.743616
+    },
+    "linreg_r2": {
+      "computes": 18,
+      "cold_seconds": 10.334736
+    },
+    "lsma": {
+      "computes": 16,
+      "cold_seconds": 9.562226
+    },
+    "schaff_trend_cycle": {
+      "computes": 14,
+      "cold_seconds": 9.423056
+    },
+    "ichimoku_cloud": {
+      "computes": 13,
+      "cold_seconds": 8.654355
+    },
+    "linreg_channel": {
+      "computes": 12,
+      "cold_seconds": 8.634608
+    },
+    "ulcer": {
+      "computes": 20,
+      "cold_seconds": 7.520967
+    },
+    "frama": {
+      "computes": 12,
+      "cold_seconds": 6.492102
+    },
+    "chande_kroll": {
+      "computes": 12,
+      "cold_seconds": 5.96221
+    },
+    "smi": {
+      "computes": 13,
+      "cold_seconds": 5.504521
+    },
+    "rsi_connors": {
+      "computes": 16,
+      "cold_seconds": 4.86477
+    },
+    "fisher": {
+      "computes": 14,
+      "cold_seconds": 4.649585
+    },
+    "mama_fama": {
+      "computes": 10,
+      "cold_seconds": 4.498398
+    },
+    "choppiness": {
+      "computes": 18,
+      "cold_seconds": 3.997684
+    },
+    "chandelier": {
+      "computes": 14,
+      "cold_seconds": 3.823396
+    },
+    "hma": {
+      "computes": 13,
+      "cold_seconds": 3.739816
+    },
+    "williams_r": {
+      "computes": 16,
+      "cold_seconds": 3.555099
+    },
+    "kdj": {
+      "computes": 13,
+      "cold_seconds": 3.554226
+    },
+    "linreg_slope": {
+      "computes": 12,
+      "cold_seconds": 3.349927
+    },
+    "hilbert_cycle": {
+      "computes": 9,
+      "cold_seconds": 3.179666
+    },
+    "stoch_rsi": {
+      "computes": 12,
+      "cold_seconds": 3.073719
+    },
+    "aroon_osc": {
+      "computes": 16,
+      "cold_seconds": 2.892409
+    },
+    "stochastic": {
+      "computes": 13,
+      "cold_seconds": 2.889461
+    },
+    "donchian": {
+      "computes": 12,
+      "cold_seconds": 2.660116
+    },
+    "ifvg": {
+      "computes": 1,
+      "cold_seconds": 2.533854
+    },
+    "order_block": {
+      "computes": 12,
+      "cold_seconds": 2.478062
+    },
+    "adx": {
+      "computes": 11,
+      "cold_seconds": 2.452488
+    },
+    "rvgi": {
+      "computes": 15,
+      "cold_seconds": 2.416761
+    },
+    "qqe": {
+      "computes": 9,
+      "cold_seconds": 2.219403
+    },
+    "aroon": {
+      "computes": 12,
+      "cold_seconds": 2.150554
+    },
+    "atr_norm": {
+      "computes": 21,
+      "cold_seconds": 2.117821
+    },
+    "vidya": {
+      "computes": 13,
+      "cold_seconds": 2.058652
+    },
+    "kama": {
+      "computes": 20,
+      "cold_seconds": 2.020616
+    },
+    "di_cross": {
+      "computes": 13,
+      "cold_seconds": 1.973707
+    },
+    "dfa": {
+      "computes": 18,
+      "cold_seconds": 1.965774
+    },
+    "center_of_gravity": {
+      "computes": 14,
+      "cold_seconds": 1.929137
+    },
+    "rvi_dorsey": {
+      "computes": 17,
+      "cold_seconds": 1.774725
+    },
+    "vol_ratio": {
+      "computes": 11,
+      "cold_seconds": 1.660938
+    },
+    "laguerre_rsi": {
+      "computes": 15,
+      "cold_seconds": 1.636717
+    },
+    "rmi": {
+      "computes": 16,
+      "cold_seconds": 1.615524
+    },
+    "tma": {
+      "computes": 17,
+      "cold_seconds": 1.557586
+    },
+    "roofing": {
+      "computes": 18,
+      "cold_seconds": 1.428303
+    },
+    "rma": {
+      "computes": 14,
+      "cold_seconds": 1.409981
+    },
+    "yang_zhang": {
+      "computes": 17,
+      "cold_seconds": 1.409762
+    },
+    "tsi": {
+      "computes": 13,
+      "cold_seconds": 1.379649
+    },
+    "trix": {
+      "computes": 15,
+      "cold_seconds": 1.378942
+    },
+    "ppo": {
+      "computes": 17,
+      "cold_seconds": 1.327379
+    },
+    "stddev": {
+      "computes": 19,
+      "cold_seconds": 1.273813
+    },
+    "sinewave": {
+      "computes": 1,
+      "cold_seconds": 1.257859
+    },
+    "tema": {
+      "computes": 15,
+      "cold_seconds": 1.247574
+    },
+    "wma": {
+      "computes": 13,
+      "cold_seconds": 1.244488
+    },
+    "klinger": {
+      "computes": 19,
+      "cold_seconds": 1.230327
+    },
+    "ttm_squeeze": {
+      "computes": 14,
+      "cold_seconds": 1.14871
+    },
+    "supertrend": {
+      "computes": 11,
+      "cold_seconds": 1.110783
+    },
+    "cyber_cycle": {
+      "computes": 16,
+      "cold_seconds": 1.104385
+    },
+    "wavetrend": {
+      "computes": 14,
+      "cold_seconds": 1.097241
+    },
+    "derivative_osc": {
+      "computes": 8,
+      "cold_seconds": 1.094666
+    },
+    "efficiency_ratio": {
+      "computes": 14,
+      "cold_seconds": 1.084931
+    },
+    "hist_vol": {
+      "computes": 16,
+      "cold_seconds": 1.04994
+    },
+    "sine_wma": {
+      "computes": 11,
+      "cold_seconds": 1.001858
+    },
+    "t3": {
+      "computes": 11,
+      "cold_seconds": 0.924188
+    },
+    "keltner": {
+      "computes": 14,
+      "cold_seconds": 0.916052
+    },
+    "asi": {
+      "computes": 10,
+      "cold_seconds": 0.896719
+    },
+    "mcginley": {
+      "computes": 14,
+      "cold_seconds": 0.878589
+    },
+    "garch_ewma": {
+      "computes": 12,
+      "cold_seconds": 0.832044
+    },
+    "evwma": {
+      "computes": 13,
+      "cold_seconds": 0.828116
+    },
+    "dema": {
+      "computes": 15,
+      "cold_seconds": 0.827602
+    },
+    "alma": {
+      "computes": 18,
+      "cold_seconds": 0.814992
+    },
+    "garman_klass": {
+      "computes": 15,
+      "cold_seconds": 0.771058
+    },
+    "parkinson": {
+      "computes": 15,
+      "cold_seconds": 0.765422
+    },
+    "breaker": {
+      "computes": 12,
+      "cold_seconds": 0.756516
+    },
+    "ergodic_osc": {
+      "computes": 7,
+      "cold_seconds": 0.742122
+    },
+    "elder_impulse": {
+      "computes": 13,
+      "cold_seconds": 0.721016
+    },
+    "emd": {
+      "computes": 11,
+      "cold_seconds": 0.715255
+    },
+    "starc": {
+      "computes": 14,
+      "cold_seconds": 0.711849
+    },
+    "macd": {
+      "computes": 16,
+      "cold_seconds": 0.666081
+    },
+    "jma": {
+      "computes": 13,
+      "cold_seconds": 0.616254
+    },
+    "ema_trend": {
+      "computes": 21,
+      "cold_seconds": 0.591596
+    },
+    "rogers_satchell": {
+      "computes": 11,
+      "cold_seconds": 0.565022
+    },
+    "zlema": {
+      "computes": 20,
+      "cold_seconds": 0.553523
+    },
+    "rsi": {
+      "computes": 15,
+      "cold_seconds": 0.542356
+    },
+    "psar": {
+      "computes": 15,
+      "cold_seconds": 0.527132
+    },
+    "apo": {
+      "computes": 19,
+      "cold_seconds": 0.526335
+    },
+    "vol_osc": {
+      "computes": 19,
+      "cold_seconds": 0.524647
+    },
+    "bandpass": {
+      "computes": 15,
+      "cold_seconds": 0.522676
+    },
+    "pvi": {
+      "computes": 16,
+      "cold_seconds": 0.520439
+    },
+    "chaikin_osc": {
+      "computes": 18,
+      "cold_seconds": 0.505916
+    },
+    "vzo": {
+      "computes": 16,
+      "cold_seconds": 0.452112
+    },
+    "nvi": {
+      "computes": 13,
+      "cold_seconds": 0.42937
+    },
+    "mass_index": {
+      "computes": 15,
+      "cold_seconds": 0.421009
+    },
+    "expma": {
+      "computes": 15,
+      "cold_seconds": 0.418882
+    },
+    "super_smoother": {
+      "computes": 14,
+      "cold_seconds": 0.384373
+    },
+    "demand_index": {
+      "computes": 13,
+      "cold_seconds": 0.371963
+    },
+    "cci": {
+      "computes": 18,
+      "cold_seconds": 0.314594
+    },
+    "force_index": {
+      "computes": 21,
+      "cold_seconds": 0.293952
+    },
+    "fvg": {
+      "computes": 14,
+      "cold_seconds": 0.283066
+    },
+    "tvi": {
+      "computes": 14,
+      "cold_seconds": 0.268663
+    },
+    "pgo": {
+      "computes": 17,
+      "cold_seconds": 0.253052
+    },
+    "mfi": {
+      "computes": 15,
+      "cold_seconds": 0.253
+    },
+    "kalman": {
+      "computes": 15,
+      "cold_seconds": 0.224315
+    },
+    "elder_ray": {
+      "computes": 15,
+      "cold_seconds": 0.21521
+    },
+    "bollinger": {
+      "computes": 15,
+      "cold_seconds": 0.211286
+    },
+    "pvt": {
+      "computes": 9,
+      "cold_seconds": 0.200073
+    },
+    "zscore": {
+      "computes": 13,
+      "cold_seconds": 0.194402
+    },
+    "chaikin_vol": {
+      "computes": 13,
+      "cold_seconds": 0.180508
+    },
+    "structure_trend": {
+      "computes": 10,
+      "cold_seconds": 0.177219
+    },
+    "gmma": {
+      "computes": 1,
+      "cold_seconds": 0.16577
+    },
+    "alligator": {
+      "computes": 1,
+      "cold_seconds": 0.151011
+    },
+    "gator": {
+      "computes": 1,
+      "cold_seconds": 0.150501
+    },
+    "ultimate_osc": {
+      "computes": 18,
+      "cold_seconds": 0.079743
+    },
+    "kst": {
+      "computes": 16,
+      "cold_seconds": 0.053769
+    },
+    "coppock": {
+      "computes": 1,
+      "cold_seconds": 0.048183
+    },
+    "td_rei": {
+      "computes": 15,
+      "cold_seconds": 0.032355
+    },
+    "vortex": {
+      "computes": 14,
+      "cold_seconds": 0.031641
+    },
+    "fractals": {
+      "computes": 1,
+      "cold_seconds": 0.03013
+    },
+    "cpr": {
+      "computes": 1,
+      "cold_seconds": 0.027503
+    },
+    "cmo": {
+      "computes": 17,
+      "cold_seconds": 0.02737
+    },
+    "pivot_fib": {
+      "computes": 1,
+      "cold_seconds": 0.02718
+    },
+    "pivot_demark": {
+      "computes": 1,
+      "cold_seconds": 0.027105
+    },
+    "pivot_woodie": {
+      "computes": 1,
+      "cold_seconds": 0.026628
+    },
+    "pivot_floor": {
+      "computes": 1,
+      "cold_seconds": 0.026424
+    },
+    "pivot_camarilla": {
+      "computes": 1,
+      "cold_seconds": 0.026221
+    },
+    "volume_ratio_asia": {
+      "computes": 11,
+      "cold_seconds": 0.026211
+    },
+    "demarker": {
+      "computes": 13,
+      "cold_seconds": 0.022961
+    },
+    "rsi_cutler": {
+      "computes": 13,
+      "cold_seconds": 0.022275
+    },
+    "trend_intensity": {
+      "computes": 12,
+      "cold_seconds": 0.022058
+    },
+    "twiggs_mf": {
+      "computes": 14,
+      "cold_seconds": 0.021115
+    },
+    "vwap": {
+      "computes": 1,
+      "cold_seconds": 0.020911
+    },
+    "anchored_vwap": {
+      "computes": 1,
+      "cold_seconds": 0.020597
+    },
+    "cmf": {
+      "computes": 13,
+      "cold_seconds": 0.019863
+    },
+    "cisd": {
+      "computes": 1,
+      "cold_seconds": 0.018209
+    },
+    "psy": {
+      "computes": 18,
+      "cold_seconds": 0.01466
+    },
+    "vwma": {
+      "computes": 12,
+      "cold_seconds": 0.014651
+    },
+    "dma": {
+      "computes": 11,
+      "cold_seconds": 0.014133
+    },
+    "ad_line": {
+      "computes": 15,
+      "cold_seconds": 0.012435
+    },
+    "td_combo": {
+      "computes": 1,
+      "cold_seconds": 0.011875
+    },
+    "td_sequential": {
+      "computes": 1,
+      "cold_seconds": 0.01105
+    },
+    "eom": {
+      "computes": 12,
+      "cold_seconds": 0.010992
+    },
+    "accel_bands": {
+      "computes": 13,
+      "cold_seconds": 0.010728
+    },
+    "obv": {
+      "computes": 13,
+      "cold_seconds": 0.010113
+    },
+    "sma_trend": {
+      "computes": 12,
+      "cold_seconds": 0.008808
+    },
+    "bias": {
+      "computes": 17,
+      "cold_seconds": 0.008632
+    },
+    "wvad": {
+      "computes": 10,
+      "cold_seconds": 0.008254
+    },
+    "ma_envelope": {
+      "computes": 14,
+      "cold_seconds": 0.007537
+    },
+    "disparity": {
+      "computes": 14,
+      "cold_seconds": 0.006584
+    },
+    "dpo": {
+      "computes": 13,
+      "cold_seconds": 0.005716
+    },
+    "balance_of_power": {
+      "computes": 13,
+      "cold_seconds": 0.005287
+    },
+    "roc": {
+      "computes": 20,
+      "cold_seconds": 0.004748
+    },
+    "ma_displaced": {
+      "computes": 10,
+      "cold_seconds": 0.004566
+    },
+    "ichimoku_chikou": {
+      "computes": 12,
+      "cold_seconds": 0.002633
+    },
+    "momentum": {
+      "computes": 10,
+      "cold_seconds": 0.00215
+    },
+    "accel_osc": {
+      "computes": 1,
+      "cold_seconds": 0.001573
+    },
+    "bbi": {
+      "computes": 1,
+      "cold_seconds": 0.00151
+    },
+    "bw_mfi": {
+      "computes": 1,
+      "cold_seconds": 0.000962
+    },
+    "awesome_osc": {
+      "computes": 1,
+      "cold_seconds": 0.000746
+    },
+    "elliott_wave_osc": {
+      "computes": 1,
+      "cold_seconds": 0.0007
+    }
+  },
+  "optimizer_result": {
+    "timeframe": "4h",
+    "n_trials": 30,
+    "front": 0,
+    "front_all": 0,
+    "dur_s": 316.3278224468231
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/perf/results/substrate_bench.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/substrate_bench.json
@@ -1,0 +1,70 @@
+{
+  "n_files": 300,
+  "readers": 30,
+  "file_bytes_p50": 6527,
+  "file_bytes_max": 265759,
+  "arrays_total_bytes": 6773939,
+  "substrates": {
+    "dict": {
+      "n_reads": 300,
+      "p50_us": 0.04,
+      "p99_us": 0.1,
+      "mean_us": 0.05,
+      "MB_per_s": 489811.9
+    },
+    "npy_tmp": {
+      "n_reads": 300,
+      "p50_us": 15.32,
+      "p99_us": 50.58,
+      "mean_us": 16.85,
+      "MB_per_s": 1340.0
+    },
+    "npy_shm": {
+      "n_reads": 300,
+      "p50_us": 15.17,
+      "p99_us": 48.63,
+      "mean_us": 16.49,
+      "MB_per_s": 1369.4
+    },
+    "npy_mmap": {
+      "n_reads": 300,
+      "p50_us": 29.24,
+      "p99_us": 67.99,
+      "mean_us": 30.98,
+      "MB_per_s": 728.9
+    },
+    "shared_mem": {
+      "n_reads": 300,
+      "p50_us": 0.36,
+      "p99_us": 0.86,
+      "mean_us": 0.4,
+      "MB_per_s": 56638.4
+    },
+    "redis": {
+      "n_reads": 300,
+      "p50_us": 24.7,
+      "p99_us": 80.18,
+      "mean_us": 28.47,
+      "MB_per_s": 793.1
+    },
+    "npy_tmp_x30": {
+      "n_reads": 300,
+      "p50_us": 50.49,
+      "p99_us": 677.3,
+      "mean_us": 105.38,
+      "MB_per_s": 214.3,
+      "wall_s": 0.044
+    },
+    "npy_shm_x30": {
+      "n_reads": 300,
+      "p50_us": 46.79,
+      "p99_us": 696.61,
+      "mean_us": 84.25,
+      "MB_per_s": 268.0,
+      "wall_s": 0.042
+    }
+  },
+  "skipped": {
+    "arrow_plasma": "REMOVED from Apache Arrow in 12.0.0 (GH-33243) \u2014 not a valid option"
+  }
+}


### PR DESCRIPTION
Closes #58.

#54 answered the storage question by **reasoning** ("compute is 99% of wall, so storage can't matter").
That was never verified, and storage was one of the original questions asked. This **measures** it.

## Verdict: NO-GO on every substrate change — for two independent reasons

1. **A cache read is 0.009% of the compute it replaces.** Read = **15 µs**; the compute it saves =
   **~167,000 µs**. Even a *perfect, zero-cost* substrate saves 0.009%.
2. **The cache is barely read at all.** Measured **hit_rate = 0.00 over 1,995 lookups / 30 trials** —
   fresh sweeps never repeat parameters (~4-billion grid) and every fold is a distinct slice.

Optimizing the substrate would mean making a *rarely-taken* path *0.009% faster*.

## Measured on 300 REAL cached arrays (median 6.5 KB)

| substrate | p50 | verdict |
|---|---:|---|
| `dict` (floor) | 0.04 µs | not a real option |
| `shared_memory` | **0.36 µs** | 43× faster — but saves only 15 µs |
| **`.npy` /tmp (current)** | **15.32 µs** | baseline |
| tmpfs `/dev/shm` | 15.17 µs | **no gain** (already page-cache-resident) |
| **Redis** (real container) | **24.70 µs** | **1.6× SLOWER** |
| mmap | 29.24 µs | 1.9× slower |

Arrow Plasma excluded — **removed in Arrow 12.0.0** (GH-33243), verified not assumed.

The Redis container and `redis-py` were isolated and **removed afterwards**; the shared venv was not
modified.

## Correction to earlier work

#54 and the #58 issue both claimed the cache key's `mode` field caused **3× duplication**. **That is
false** — `_suggest_indicators` fixes `mode` to the schema default and never searches it, so no mode
duplication exists. I asserted it twice without checking; reading the code disproved it. This PR
supersedes that claim.

What *is* real: per-fold recomputation (but sharing across folds is **not result-neutral** — fold-boundary
warm-up differs) and per-timeframe recomputation (mechanism real, but independent samplers mean ~zero
parameter overlap).

## Bonus finding

The caching that actually pays is the **in-process `_VOTE_MEMO`**, not the disk cache. And the 201,354
files (4.3 GB) in the production cache are evidence of 201,354 *misses being written* — not of hits.

## Why a NO-GO is a good outcome

It closes an open question with evidence and prevents future effort being spent there. §7 lists exactly
what would change the answer (a replay-shaped workload, e.g. champion re-validation or ablation grids,
where `shared_memory`'s 43× would become worth revisiting).

Report: `optimize/REPORT_cache_substrate_and_level.md` · §8 lists honest gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)