### PR TITLE
research(#56): worst-case param scan corrects #54's tail claim; autocorr 116x, hurst_exp 22x

### DIFF
--- a/subprojects/Parametric-Indicators/indicators/calc/quant.py
+++ b/subprojects/Parametric-Indicators/indicators/calc/quant.py
@@ -15,8 +15,8 @@ def zscore(close, n):
         return (c - _sma(c, n)) / rolling_std(c, n)
 
 
-def hurst_exp(close, n):
-    """Rolling R/S Hurst of the window's returns. H≈0.5 random, >0.5 persistent, <0.5 mean-reverting."""
+def hurst_exp_reference(close, n):
+    """REFERENCE (slow) rolling R/S Hurst — kept verbatim as the parity oracle for `hurst_exp` (#56)."""
     c = np.asarray(close, float)
     N = len(c)
     out = np.full(N, np.nan)
@@ -174,8 +174,8 @@ def dfa(close, n):
     return _dfa_core(c, int(n), scales)
 
 
-def autocorr(close, n, lag=1):
-    """Lag-`lag` autocorrelation of returns over the last n returns."""
+def autocorr_reference(close, n, lag=1):
+    """REFERENCE (slow) lag-`lag` autocorrelation — kept verbatim as the parity oracle (#56)."""
     c = np.asarray(close, float)
     r = np.diff(c)
     N = len(c)
@@ -186,6 +186,103 @@ def autocorr(close, n, lag=1):
         if a.std() > 0 and b.std() > 0:
             out[i] = np.corrcoef(a, b)[0, 1]
     return out
+
+
+@_njit(cache=True, fastmath=False)
+def _autocorr_core(r, n, lag, N):
+    """Pearson r between w[lag:] and w[:-lag] per bar, via closed-form sums instead of np.corrcoef.
+    Mirrors the reference's guard (both legs must have non-zero population std)."""
+    out = np.full(N, np.nan)
+    m = n - lag                                  # length of each leg
+    if m < 2:
+        return out
+    for i in range(n + 1, N):
+        base = i - n
+        sa = 0.0
+        sb = 0.0
+        for k in range(m):
+            sa += r[base + lag + k]
+            sb += r[base + k]
+        ma = sa / m
+        mb = sb / m
+        vaa = 0.0
+        vbb = 0.0
+        vab = 0.0
+        for k in range(m):
+            da = r[base + lag + k] - ma
+            db = r[base + k] - mb
+            vaa += da * da
+            vbb += db * db
+            vab += da * db
+        if vaa > 0.0 and vbb > 0.0:              # == reference's a.std()>0 and b.std()>0
+            out[i] = vab / np.sqrt(vaa * vbb)
+    return out
+
+
+def autocorr(close, n, lag=1):
+    """Lag-`lag` autocorrelation of returns over the last n returns.
+
+    Fast path (numba, closed-form Pearson) when available; otherwise the verbatim reference. Proven
+    VOTE-identical to the reference across the searched threshold grid — see the parity note on `dfa`.
+    """
+    if not _HAVE_NUMBA:
+        return autocorr_reference(close, n, lag)
+    c = np.asarray(close, dtype=np.float64)
+    r = np.diff(c)
+    return _autocorr_core(r, int(n), int(lag), len(c))
+
+
+@_njit(cache=True, fastmath=False)
+def _hurst_core(c, n, N):
+    """Rolling R/S Hurst in one compiled pass (no per-bar numpy temporaries)."""
+    out = np.full(N, np.nan)
+    m = n - 1                                    # number of returns in the window
+    if m < 1:
+        return out
+    logm = np.log(float(m))
+    for i in range(n - 1, N):
+        base = i - n + 1
+        rmean = 0.0
+        for k in range(m):
+            rmean += c[base + 1 + k] - c[base + k]
+        rmean /= m
+        var = 0.0
+        for k in range(m):
+            d = (c[base + 1 + k] - c[base + k]) - rmean
+            var += d * d
+        s = np.sqrt(var / m)                     # population std, == ndarray.std()
+        if s <= 0.0:
+            continue
+        acc = 0.0
+        ymin = 0.0
+        ymax = 0.0
+        first = True
+        for k in range(m):
+            acc += (c[base + 1 + k] - c[base + k]) - rmean
+            if first:
+                ymin = acc
+                ymax = acc
+                first = False
+            else:
+                if acc < ymin:
+                    ymin = acc
+                if acc > ymax:
+                    ymax = acc
+        rng = ymax - ymin
+        if rng > 0.0:
+            out[i] = np.log(rng / s) / logm
+    return out
+
+
+def hurst_exp(close, n):
+    """Rolling R/S Hurst of the window's returns. H≈0.5 random, >0.5 persistent, <0.5 mean-reverting.
+
+    Fast path (numba) when available; otherwise the verbatim reference. Vote-identical — see `dfa`.
+    """
+    if not _HAVE_NUMBA:
+        return hurst_exp_reference(close, n)
+    c = np.asarray(close, dtype=np.float64)
+    return _hurst_core(c, int(n), len(c))
 
 
 def demarker(high, low, n):

--- a/subprojects/Parametric-Indicators/optimize/REPORT_post_dfa_tail.md
+++ b/subprojects/Parametric-Indicators/optimize/REPORT_post_dfa_tail.md
@@ -1,0 +1,161 @@
+# Report — Is the Post-`dfa` Tail Really Diffuse?
+
+**Date:** 2026-07-27 · **Issue:** #56 · **Branch:** `research/post-dfa-tail`
+**Claim under test (from #54):** *"There is no second `dfa`. The rest is diffuse — realistically
+~40 s → ~33 s. Don't over-invest."*
+
+---
+
+## 0. Verdict: **half right, and the wrong half mattered**
+
+| The #54 claim | Verdict |
+|---|---|
+| "There is no second `dfa`" (no single 756-second monster) | ✅ **Correct** — the worst remaining indicator is 6.6 s, not 756 s |
+| "The rest is diffuse … ~40 s → ~33 s. Don't over-invest." | ❌ **Too optimistic** — it was measured at the parameters the optimizer *happened to sample*. At **grid edges**, **19 of 165** indicators blow a 2-second budget, totalling **73 s** |
+
+**Why the original claim was wrong in the way it was wrong:** it repeated the exact mistake that let `dfa`
+hide for eight months — **profiling at sampled/default parameters instead of the worst case**. `dfa` cost
+57 s at `n=20` and 756 s at `n=400`. Any claim about cost that does not name the parameters is incomplete.
+
+**The corrected picture:** computing all 165 indicators once on the full 1-minute frame costs
+**~39 s at sampled parameters** but **123.6 s at worst-case parameters** — about **3× more** than the
+number #54 reasoned from. The optimizer *will* reach those corners; it searches the whole grid.
+
+---
+
+## 1. Method — the worst-case parameter scan
+
+`optimize/perf/bench_worstcase.py` times **every** registered indicator's `directions()` at three points in
+its own grid — **defaults**, **all-parameters-minimum**, **all-parameters-maximum** — takes the worst, and
+projects to the full 486,969-bar frame. Two stages so one pathological indicator cannot stall the scan,
+with a hard per-config timeout (a timeout is itself a finding).
+
+**A measurement trap caught during this work — worth recording.** The first scan reported `dfa` at
+**5.52 s**, against a *known measured* **0.178 s**. The cause: the scan timed the **first** call, which for
+a Numba indicator includes **JIT compilation**, then extrapolated that one-off cost ×24 to the full frame.
+JIT compile is amortized across an entire sweep, not per-bar work. The scan now calls each configuration
+**twice and times only the second**. Had this not been caught, the report would have "discovered" a
+regression in the indicator we had just made 1,396× faster.
+
+> This is exactly the *"verify, don't assume"* rule paying for itself: the anomaly was only visible because
+> an independently measured number existed to contradict it.
+
+---
+
+## 2. Results — worst-case cost across all 165 indicators
+
+**19 indicators over a 2-second full-frame budget** (before this issue's fixes):
+
+| indicator | worst config | projected full-frame | vs its cost at sampled params |
+|---|---|---:|---|
+| `autocorr` | all_max | **9.40 s** | 3.66 s → **2.6× worse at the edge** |
+| `sinewave` | default | 6.42 s | — |
+| `ifvg` | default | 5.30 s | 2.51 s |
+| `hurst_exp` | all_max | **5.09 s** | 2.93 s → 1.7× worse |
+| `proj_bands` | all_max | 4.78 s | 1.85 s |
+| `ou_halflife` | all_max | 4.16 s | 1.58 s |
+| `cmo_chande_dmi` | default | 3.88 s | — |
+| `linreg_channel` | all_max | 3.66 s | 1.41 s |
+| `ichimoku_tk_cross` | all_min | 3.34 s | — |
+| `ichimoku_cloud` | default | 3.33 s | — |
+| `schaff_trend_cycle` | default | 3.32 s | 1.34 s |
+| `lsma` | all_max | 3.07 s | — |
+| `linreg_r2` | all_max | 2.99 s | — |
+| `order_block` | all_min | 2.73 s | — |
+| `frama` | default | 2.69 s | 1.07 s |
+| `chande_kroll` | all_max | 2.47 s | 0.99 s |
+| `mama_fama` | default | 2.27 s | — |
+| `smi` | default | 2.14 s | — |
+| `ulcer` | all_max | 2.09 s | 0.79 s |
+
+**Totals:** 19 over budget summing **73.1 s**; all 165 indicators at worst case **123.6 s**.
+No timeouts, no errors — the scan is clean across the whole registry.
+
+```mermaid
+graph LR
+    A["At SAMPLED params<br/>~39 s total"] -->|"the number #54 reasoned from"| B["'tail is diffuse,<br/>don't over-invest'"]
+    C["At WORST-CASE params<br/>123.6 s total"] -->|"~3× more"| D["19 indicators over budget<br/>totalling 73 s"]
+```
+
+---
+
+## 3. What was fixed here
+
+The two worst offenders that share the known per-bar-loop pattern, treated exactly like `dfa`
+(closed-form / Numba, original kept verbatim as a `*_reference` oracle, graceful fallback without numba):
+
+| indicator | worst-case before | after | speed-up | **vote flips** |
+|---|---:|---:|---:|:---:|
+| `autocorr` (n=200) — `np.corrcoef` per bar → closed-form Pearson | **9.47 s** | 0.081 s | **116×** | **0** |
+| `hurst_exp` (n=400) — per-bar numpy temporaries → one compiled pass | **5.24 s** | 0.233 s | **22×** | **0** |
+
+**Parity:** identical finite/NaN masks, float-close values, and **zero** differing veto decisions across
+each indicator's entire searched threshold grid (`autocorr` 0.01→0.50; `hurst_exp` 0.30→0.70), on the real
+486,969-bar series. 8 parity tests green, including end-to-end tests driving the real Indicator objects.
+
+**Effect on the worst-case total:** **123.6 s → 111.1 s**; over-budget indicators **19 → 17**
+(summing 73.1 s → 60.2 s). Both fixed indicators dropped off the over-budget list entirely.
+
+---
+
+## 4. So — how much is actually left, honestly?
+
+**17 indicators remain over budget, totalling ~60 s at worst case.** The new leaders are `sinewave`
+(6.57 s), `ifvg` (5.15 s), `proj_bands` (5.11 s), `ou_halflife` (4.35 s), `cmo_chande_dmi` (3.98 s).
+
+**Is it worth continuing?** A qualified yes, with clear-eyed expectations:
+
+- **No single fix will be dramatic.** The largest remaining is 6.6 s (6% of the worst-case total). The era
+  of 1,396× wins ended with `dfa`.
+- **But the aggregate is real.** ~60 s of avoidable worst-case cost across 17 indicators, and the two fixes
+  here took roughly an hour each including parity proof. The pattern and the recipe are now established.
+- **The right stopping rule is a budget, not a feeling.** Fix indicators until none exceeds the 2 s
+  budget, then stop. That is a defined finish line; "the tail feels diffuse" is not.
+
+**Corrected ceiling estimate:** fixing the remaining 17 to budget would take the worst-case total from
+**111 s to roughly ~50 s**. That is a much better return than the "~40 → ~33 s" #54 projected — because
+#54 was measuring the wrong scenario.
+
+---
+
+## 5. What went well / what went wrong
+
+**Went well**
+- The worst-case scan **found the flaw in our own prior conclusion**, which is what it was built for.
+- The **JIT-warm-up artifact was caught before it became a reported finding**, only because a previously
+  measured number contradicted it.
+- The `dfa` recipe generalized cleanly: two more indicators fixed with the same pattern, same parity
+  contract, zero decision changes.
+
+**Went wrong / to watch**
+- **#54 asserted a cost ceiling from sampled-parameter data.** That is the same class of error that let
+  `dfa` hide. The playbook rule (P4, "profile the worst case, not the default") existed *because* of `dfa`
+  — and the very next report still violated it. Rules only work if applied to one's own conclusions too.
+- **`sinewave`, `ifvg`, `cmo_chande_dmi`, `ichimoku_*` are expensive at DEFAULT parameters**, meaning they
+  are paid on essentially every trial that enables them — arguably higher priority than grid-edge cases.
+- The projection is **linear extrapolation** from a 20,000-bar subset. Sound for fixed parameters
+  (per-bar work is constant), and spot-confirmed at full scale for `autocorr`/`hurst_exp` (9.40→9.47 s and
+  5.09→5.24 s projected vs measured — within 3%), but it is an estimate for the others.
+
+---
+
+## 6. Recommended next steps
+
+1. **Adopt the 2-second budget as a rule** and work the remaining 17 down to it, highest-first.
+   Prioritize the ones expensive at **default** parameters (`sinewave`, `ifvg`, `cmo_chande_dmi`,
+   `ichimoku_cloud`) over grid-edge-only offenders — they are paid far more often.
+2. **Wire `bench_worstcase.py` into the expansion-round checklist** (#57) so every new indicator is scanned
+   at its grid corners before merge. This is the automated version of playbook rule P4.
+3. **Correct the record:** #54's "~40 → ~33 s, don't over-invest" is superseded by this report.
+
+---
+
+## 7. Honest gaps
+
+1. **Projections for the 17 unfixed indicators are extrapolated**, not measured at full scale (validated
+   to within 3% on the two that were).
+2. **Only two configurations per indicator** (all-min / all-max) plus defaults. A cost peak at a *mixed*
+   parameter corner would be missed — the true worst case could be higher.
+3. **`directions()` only.** Cost inside the vote-sampling and gate assembly is not attributed here.
+4. **Single instrument (NQ), single 1-minute series.** Cost should be data-shape-independent for fixed
+   parameters, but this was not verified across instruments.

--- a/subprojects/Parametric-Indicators/optimize/REPORT_post_dfa_tail.md
+++ b/subprojects/Parametric-Indicators/optimize/REPORT_post_dfa_tail.md
@@ -96,6 +96,11 @@ each indicator's entire searched threshold grid (`autocorr` 0.01→0.50; `hurst_
 **Effect on the worst-case total:** **123.6 s → 111.1 s**; over-budget indicators **19 → 17**
 (summing 73.1 s → 60.2 s). Both fixed indicators dropped off the over-budget list entirely.
 
+**Full-suite regression check:** `25 failed, 854 passed, 1 skipped` — the failure set is **identical** to
+the control established in #54 (same 25, empty diff in both directions) ⇒ **zero regressions**. Those 25
+are pre-existing (`optimize/l2/*`, `test_intracandle_*`; none touch `quant`), and are unrelated to this
+work — see #54's report for their attribution.
+
 ---
 
 ## 4. So — how much is actually left, honestly?

--- a/subprojects/Parametric-Indicators/optimize/perf/bench_worstcase.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/bench_worstcase.py
@@ -1,0 +1,154 @@
+"""Issue #56 Question A — is there a SECOND `dfa` hiding at a parameter-grid edge?
+
+`dfa` hid in plain sight because profiling only ever saw the parameters the optimizer happened to sample.
+It cost 57 s at `n=20` and **756 s at `n=400`** — a 13× spread across its own grid. An indicator can look
+mid-table at defaults and be pathological at a corner the optimizer *will* eventually reach.
+
+This scans **every** registered indicator at three points in its grid — defaults, all-params-minimum,
+all-params-maximum — and reports the worst, extrapolated to the full 486,969-bar 1-minute frame.
+
+Two stages so one pathological indicator cannot stall the scan:
+  stage 1  cheap scan on a subset, with a hard per-config timeout; anything that times out is itself a
+           finding (it is already over any sane budget)
+  stage 2  re-measure the worst offenders at full scale for an exact number
+
+Cost is linear in series length for fixed parameters (per-bar work is constant), so subset → full-frame
+extrapolation is sound; stage 2 confirms it for the ones that matter.
+
+Run: WSH_DATA_BASE=/home/dev/Mulham/wsg-i /home/dev/Mulham/.venv/bin/python3 \
+       -m optimize.perf.bench_worstcase --bars 20000 --timeout 20
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import numpy as np
+
+from loader import load_data
+from indicators import library
+from indicators.runner import market_context
+from optimize import timeframes as TF
+
+FULL_BARS = 486_969
+
+
+class _Timeout(Exception):
+    pass
+
+
+def _alarm(_sig, _frm):
+    raise _Timeout()
+
+
+def _param_sets(key):
+    """(label, params) at defaults / all-min / all-max. Non-numeric or choice params keep the default."""
+    spec = library.SCHEMA[key]
+    ps = spec.get("params", [])
+    default = {p["name"]: p["default"] for p in ps}
+    lo, hi = dict(default), dict(default)
+    for p in ps:
+        if p.get("min") is not None and p.get("max") is not None:
+            lo[p["name"]] = p["min"]
+            hi[p["name"]] = p["max"]
+    out = [("default", default)]
+    if lo != default:
+        out.append(("all_min", lo))
+    if hi != default:
+        out.append(("all_max", hi))
+    return out
+
+
+def _time_directions(key, params, ctx, timeout_s):
+    """Seconds for one directions() call, or None on timeout / error (with the reason).
+
+    IMPORTANT — the call is made TWICE and only the second is timed. Any one-off first-call cost (most
+    notably **Numba JIT compilation**, which `dfa` now pays) is a fixed cost amortized over an entire
+    sweep, not per-bar work; including it and then extrapolating ×24 to the full frame inflates the
+    projection wildly. (Caught in practice: unwarmed, `dfa` projected 5.52 s against a measured 0.178 s.)
+    """
+    signal.signal(signal.SIGALRM, _alarm)
+    signal.alarm(int(timeout_s))
+    try:
+        ind = library.from_specs([{"key": key, "enabled": True,
+                                   "mode": library.SCHEMA[key]["mode"], "params": params}])[0]
+        ind.directions(ctx)                     # warm-up: JIT compile / lazy setup, NOT timed
+        t0 = time.perf_counter()
+        ind.directions(ctx)
+        return time.perf_counter() - t0, None
+    except _Timeout:
+        return None, f"TIMEOUT>{timeout_s}s"
+    except Exception as e:  # noqa: BLE001
+        return None, f"{type(e).__name__}: {e}"
+    finally:
+        signal.alarm(0)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bars", type=int, default=20000, help="stage-1 subset length")
+    ap.add_argument("--timeout", type=int, default=20, help="per-config seconds before giving up")
+    ap.add_argument("--budget-s", type=float, default=2.0, help="full-frame budget per compute")
+    ap.add_argument("--restage2", type=int, default=6, help="how many worst offenders to re-measure fully")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    base = os.environ.get("WSH_DATA_BASE", "/mnt/data/projects/trading")
+    csv = Path(base) / TF.RAW_DIR / "NQ_1m.csv"
+    df = load_data(str(csv)).sort_values("Date").reset_index(drop=True)
+    scale = FULL_BARS / args.bars
+    ctx = market_context(df.iloc[: args.bars])
+    print(f"[worstcase] {len(library.REGISTRY)} indicators | stage-1 on {args.bars:,} bars "
+          f"(extrapolation ×{scale:.1f} to {FULL_BARS:,}) | timeout {args.timeout}s/config", flush=True)
+
+    rows = []
+    for i, key in enumerate(library.REGISTRY, 1):
+        best_label, best_s, notes = None, -1.0, {}
+        for label, params in _param_sets(key):
+            secs, err = _time_directions(key, params, ctx, args.timeout)
+            if err:
+                notes[label] = err
+                if err.startswith("TIMEOUT"):
+                    best_label, best_s = label, float(args.timeout)   # at least this bad
+                continue
+            if secs > best_s:
+                best_label, best_s, = label, secs
+        proj = best_s * scale if best_s >= 0 else None
+        rows.append({"key": key, "worst_config": best_label,
+                     "subset_s": round(best_s, 4) if best_s >= 0 else None,
+                     "projected_full_s": round(proj, 2) if proj is not None else None,
+                     "over_budget": bool(proj is not None and proj > args.budget_s),
+                     "notes": notes})
+        if i % 25 == 0:
+            print(f"[worstcase] scanned {i}/{len(library.REGISTRY)}", flush=True)
+
+    ranked = sorted([r for r in rows if r["projected_full_s"] is not None],
+                    key=lambda r: -r["projected_full_s"])
+    over = [r for r in ranked if r["over_budget"]]
+    print(f"\n[worstcase] === {len(over)} indicator(s) OVER the {args.budget_s}s full-frame budget ===",
+          flush=True)
+    for r in ranked[:20]:
+        flag = "  <-- OVER BUDGET" if r["over_budget"] else ""
+        print(f"    {r['key']:24s} worst={r['worst_config']:8s} "
+              f"proj_full={r['projected_full_s']:8.2f}s{flag}", flush=True)
+
+    out = {"bars_stage1": args.bars, "scale": round(scale, 3), "budget_s": args.budget_s,
+           "n_indicators": len(library.REGISTRY), "n_over_budget": len(over),
+           "ranked": ranked, "errors": {r["key"]: r["notes"] for r in rows if r["notes"]}}
+    outp = Path(args.out) if args.out else (
+        Path(__file__).resolve().parent / "results" / "worstcase_scan.json")
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    outp.write_text(json.dumps(out, indent=2))
+    print(f"[worstcase] WROTE {outp}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/Parametric-Indicators/optimize/perf/results/tail_bench.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/tail_bench.json
@@ -1,0 +1,21 @@
+{
+  "n_bars": 486969,
+  "per_indicator": {
+    "autocorr": {
+      "n_max": 200,
+      "ref_s": 9.468,
+      "fast_s": 0.0814,
+      "speedup": 116.3,
+      "float_close": true,
+      "max_vote_flips": 0
+    },
+    "hurst_exp": {
+      "n_max": 400,
+      "ref_s": 5.237,
+      "fast_s": 0.2329,
+      "speedup": 22.5,
+      "float_close": true,
+      "max_vote_flips": 0
+    }
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/perf/results/worstcase_scan.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/worstcase_scan.json
@@ -1,0 +1,1330 @@
+{
+  "bars_stage1": 20000,
+  "scale": 24.348,
+  "budget_s": 2.0,
+  "n_indicators": 165,
+  "n_over_budget": 19,
+  "ranked": [
+    {
+      "key": "autocorr",
+      "worst_config": "all_max",
+      "subset_s": 0.3861,
+      "projected_full_s": 9.4,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "sinewave",
+      "worst_config": "default",
+      "subset_s": 0.2638,
+      "projected_full_s": 6.42,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ifvg",
+      "worst_config": "default",
+      "subset_s": 0.2175,
+      "projected_full_s": 5.3,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "hurst_exp",
+      "worst_config": "all_max",
+      "subset_s": 0.209,
+      "projected_full_s": 5.09,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "proj_bands",
+      "worst_config": "all_max",
+      "subset_s": 0.1964,
+      "projected_full_s": 4.78,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ou_halflife",
+      "worst_config": "all_max",
+      "subset_s": 0.1709,
+      "projected_full_s": 4.16,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "cmo_chande_dmi",
+      "worst_config": "default",
+      "subset_s": 0.1595,
+      "projected_full_s": 3.88,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "linreg_channel",
+      "worst_config": "all_max",
+      "subset_s": 0.1503,
+      "projected_full_s": 3.66,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ichimoku_tk_cross",
+      "worst_config": "all_min",
+      "subset_s": 0.1372,
+      "projected_full_s": 3.34,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ichimoku_cloud",
+      "worst_config": "default",
+      "subset_s": 0.1366,
+      "projected_full_s": 3.33,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "schaff_trend_cycle",
+      "worst_config": "default",
+      "subset_s": 0.1364,
+      "projected_full_s": 3.32,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "lsma",
+      "worst_config": "all_max",
+      "subset_s": 0.126,
+      "projected_full_s": 3.07,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "linreg_r2",
+      "worst_config": "all_max",
+      "subset_s": 0.123,
+      "projected_full_s": 2.99,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "order_block",
+      "worst_config": "all_min",
+      "subset_s": 0.1121,
+      "projected_full_s": 2.73,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "frama",
+      "worst_config": "default",
+      "subset_s": 0.1107,
+      "projected_full_s": 2.69,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "chande_kroll",
+      "worst_config": "all_max",
+      "subset_s": 0.1015,
+      "projected_full_s": 2.47,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "mama_fama",
+      "worst_config": "default",
+      "subset_s": 0.0931,
+      "projected_full_s": 2.27,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "smi",
+      "worst_config": "default",
+      "subset_s": 0.0879,
+      "projected_full_s": 2.14,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ulcer",
+      "worst_config": "all_max",
+      "subset_s": 0.0859,
+      "projected_full_s": 2.09,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "hilbert_cycle",
+      "worst_config": "all_min",
+      "subset_s": 0.0742,
+      "projected_full_s": 1.81,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "fisher",
+      "worst_config": "default",
+      "subset_s": 0.0687,
+      "projected_full_s": 1.67,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rsi_connors",
+      "worst_config": "all_max",
+      "subset_s": 0.063,
+      "projected_full_s": 1.53,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "linreg_slope",
+      "worst_config": "all_max",
+      "subset_s": 0.0603,
+      "projected_full_s": 1.47,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "hma",
+      "worst_config": "default",
+      "subset_s": 0.0582,
+      "projected_full_s": 1.42,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "chandelier",
+      "worst_config": "all_max",
+      "subset_s": 0.0564,
+      "projected_full_s": 1.37,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kdj",
+      "worst_config": "all_min",
+      "subset_s": 0.0561,
+      "projected_full_s": 1.37,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "stoch_rsi",
+      "worst_config": "default",
+      "subset_s": 0.0532,
+      "projected_full_s": 1.29,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "qqe",
+      "worst_config": "all_max",
+      "subset_s": 0.0524,
+      "projected_full_s": 1.27,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "alligator",
+      "worst_config": "default",
+      "subset_s": 0.0506,
+      "projected_full_s": 1.23,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "adx",
+      "worst_config": "all_min",
+      "subset_s": 0.0464,
+      "projected_full_s": 1.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "stochastic",
+      "worst_config": "all_max",
+      "subset_s": 0.0459,
+      "projected_full_s": 1.12,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "williams_r",
+      "worst_config": "default",
+      "subset_s": 0.0459,
+      "projected_full_s": 1.12,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "choppiness",
+      "worst_config": "default",
+      "subset_s": 0.0459,
+      "projected_full_s": 1.12,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "donchian",
+      "worst_config": "default",
+      "subset_s": 0.0458,
+      "projected_full_s": 1.12,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "aroon",
+      "worst_config": "all_max",
+      "subset_s": 0.0377,
+      "projected_full_s": 0.92,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "aroon_osc",
+      "worst_config": "all_max",
+      "subset_s": 0.0378,
+      "projected_full_s": 0.92,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "gator",
+      "worst_config": "default",
+      "subset_s": 0.0362,
+      "projected_full_s": 0.88,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "gmma",
+      "worst_config": "default",
+      "subset_s": 0.0352,
+      "projected_full_s": 0.86,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kama",
+      "worst_config": "all_min",
+      "subset_s": 0.0349,
+      "projected_full_s": 0.85,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rvgi",
+      "worst_config": "all_min",
+      "subset_s": 0.034,
+      "projected_full_s": 0.83,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vidya",
+      "worst_config": "all_max",
+      "subset_s": 0.0335,
+      "projected_full_s": 0.81,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "di_cross",
+      "worst_config": "default",
+      "subset_s": 0.0321,
+      "projected_full_s": 0.78,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vol_ratio",
+      "worst_config": "default",
+      "subset_s": 0.0319,
+      "projected_full_s": 0.78,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "derivative_osc",
+      "worst_config": "all_min",
+      "subset_s": 0.0288,
+      "projected_full_s": 0.7,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "center_of_gravity",
+      "worst_config": "all_max",
+      "subset_s": 0.0286,
+      "projected_full_s": 0.7,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dfa",
+      "worst_config": "all_max",
+      "subset_s": 0.0258,
+      "projected_full_s": 0.63,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "laguerre_rsi",
+      "worst_config": "all_min",
+      "subset_s": 0.0228,
+      "projected_full_s": 0.56,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ergodic_osc",
+      "worst_config": "all_max",
+      "subset_s": 0.0224,
+      "projected_full_s": 0.55,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tsi",
+      "worst_config": "default",
+      "subset_s": 0.0223,
+      "projected_full_s": 0.54,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rvi_dorsey",
+      "worst_config": "default",
+      "subset_s": 0.0223,
+      "projected_full_s": 0.54,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "supertrend",
+      "worst_config": "all_max",
+      "subset_s": 0.0215,
+      "projected_full_s": 0.52,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rmi",
+      "worst_config": "all_min",
+      "subset_s": 0.0214,
+      "projected_full_s": 0.52,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rma",
+      "worst_config": "default",
+      "subset_s": 0.0209,
+      "projected_full_s": 0.51,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "atr_norm",
+      "worst_config": "all_max",
+      "subset_s": 0.0211,
+      "projected_full_s": 0.51,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "wma",
+      "worst_config": "default",
+      "subset_s": 0.02,
+      "projected_full_s": 0.49,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "trix",
+      "worst_config": "all_min",
+      "subset_s": 0.0194,
+      "projected_full_s": 0.47,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "asi",
+      "worst_config": "all_min",
+      "subset_s": 0.0192,
+      "projected_full_s": 0.47,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "sine_wma",
+      "worst_config": "default",
+      "subset_s": 0.0188,
+      "projected_full_s": 0.46,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tma",
+      "worst_config": "all_max",
+      "subset_s": 0.0186,
+      "projected_full_s": 0.45,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "t3",
+      "worst_config": "all_min",
+      "subset_s": 0.0178,
+      "projected_full_s": 0.43,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ppo",
+      "worst_config": "default",
+      "subset_s": 0.0177,
+      "projected_full_s": 0.43,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tema",
+      "worst_config": "default",
+      "subset_s": 0.0172,
+      "projected_full_s": 0.42,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "yang_zhang",
+      "worst_config": "all_max",
+      "subset_s": 0.0174,
+      "projected_full_s": 0.42,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ttm_squeeze",
+      "worst_config": "all_max",
+      "subset_s": 0.0172,
+      "projected_full_s": 0.42,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "wavetrend",
+      "worst_config": "all_max",
+      "subset_s": 0.0165,
+      "projected_full_s": 0.4,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "roofing",
+      "worst_config": "default",
+      "subset_s": 0.0166,
+      "projected_full_s": 0.4,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "efficiency_ratio",
+      "worst_config": "all_max",
+      "subset_s": 0.0159,
+      "projected_full_s": 0.39,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "garch_ewma",
+      "worst_config": "default",
+      "subset_s": 0.0147,
+      "projected_full_s": 0.36,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cyber_cycle",
+      "worst_config": "all_max",
+      "subset_s": 0.0142,
+      "projected_full_s": 0.35,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "emd",
+      "worst_config": "all_min",
+      "subset_s": 0.0144,
+      "projected_full_s": 0.35,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "hist_vol",
+      "worst_config": "all_max",
+      "subset_s": 0.0141,
+      "projected_full_s": 0.34,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "keltner",
+      "worst_config": "default",
+      "subset_s": 0.0135,
+      "projected_full_s": 0.33,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "evwma",
+      "worst_config": "all_min",
+      "subset_s": 0.0136,
+      "projected_full_s": 0.33,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "stddev",
+      "worst_config": "all_max",
+      "subset_s": 0.0137,
+      "projected_full_s": 0.33,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "klinger",
+      "worst_config": "all_max",
+      "subset_s": 0.0135,
+      "projected_full_s": 0.33,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "mcginley",
+      "worst_config": "all_min",
+      "subset_s": 0.0132,
+      "projected_full_s": 0.32,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dema",
+      "worst_config": "default",
+      "subset_s": 0.0116,
+      "projected_full_s": 0.28,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "elder_impulse",
+      "worst_config": "default",
+      "subset_s": 0.0117,
+      "projected_full_s": 0.28,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "parkinson",
+      "worst_config": "all_min",
+      "subset_s": 0.0109,
+      "projected_full_s": 0.27,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rogers_satchell",
+      "worst_config": "all_min",
+      "subset_s": 0.011,
+      "projected_full_s": 0.27,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "garman_klass",
+      "worst_config": "all_max",
+      "subset_s": 0.0109,
+      "projected_full_s": 0.26,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "starc",
+      "worst_config": "default",
+      "subset_s": 0.0106,
+      "projected_full_s": 0.26,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "jma",
+      "worst_config": "all_min",
+      "subset_s": 0.0101,
+      "projected_full_s": 0.25,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "coppock",
+      "worst_config": "default",
+      "subset_s": 0.0097,
+      "projected_full_s": 0.24,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "alma",
+      "worst_config": "all_max",
+      "subset_s": 0.0096,
+      "projected_full_s": 0.23,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "macd",
+      "worst_config": "default",
+      "subset_s": 0.0084,
+      "projected_full_s": 0.21,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "psar",
+      "worst_config": "all_max",
+      "subset_s": 0.0077,
+      "projected_full_s": 0.19,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rsi",
+      "worst_config": "default",
+      "subset_s": 0.0074,
+      "projected_full_s": 0.18,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bandpass",
+      "worst_config": "all_max",
+      "subset_s": 0.0073,
+      "projected_full_s": 0.18,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "nvi",
+      "worst_config": "all_min",
+      "subset_s": 0.0071,
+      "projected_full_s": 0.17,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pvi",
+      "worst_config": "all_min",
+      "subset_s": 0.0069,
+      "projected_full_s": 0.17,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cci",
+      "worst_config": "all_max",
+      "subset_s": 0.0066,
+      "projected_full_s": 0.16,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "fractals",
+      "worst_config": "default",
+      "subset_s": 0.0067,
+      "projected_full_s": 0.16,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "zscore",
+      "worst_config": "all_max",
+      "subset_s": 0.0067,
+      "projected_full_s": 0.16,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ema_trend",
+      "worst_config": "default",
+      "subset_s": 0.0063,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "apo",
+      "worst_config": "default",
+      "subset_s": 0.006,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "demand_index",
+      "worst_config": "all_min",
+      "subset_s": 0.006,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "zlema",
+      "worst_config": "default",
+      "subset_s": 0.0058,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "expma",
+      "worst_config": "all_max",
+      "subset_s": 0.0058,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "mass_index",
+      "worst_config": "default",
+      "subset_s": 0.0059,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "chaikin_osc",
+      "worst_config": "default",
+      "subset_s": 0.0059,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vol_osc",
+      "worst_config": "default",
+      "subset_s": 0.0058,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vzo",
+      "worst_config": "default",
+      "subset_s": 0.0059,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "super_smoother",
+      "worst_config": "default",
+      "subset_s": 0.0058,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_floor",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_woodie",
+      "worst_config": "default",
+      "subset_s": 0.0053,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_demark",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_camarilla",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_fib",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cpr",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pvt",
+      "worst_config": "all_min",
+      "subset_s": 0.0048,
+      "projected_full_s": 0.12,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "fvg",
+      "worst_config": "all_max",
+      "subset_s": 0.0046,
+      "projected_full_s": 0.11,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "anchored_vwap",
+      "worst_config": "default",
+      "subset_s": 0.0045,
+      "projected_full_s": 0.11,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vwap",
+      "worst_config": "default",
+      "subset_s": 0.0043,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "structure_trend",
+      "worst_config": "all_min",
+      "subset_s": 0.004,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tvi",
+      "worst_config": "all_min",
+      "subset_s": 0.0041,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "mfi",
+      "worst_config": "all_max",
+      "subset_s": 0.0037,
+      "projected_full_s": 0.09,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cisd",
+      "worst_config": "default",
+      "subset_s": 0.0039,
+      "projected_full_s": 0.09,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bollinger",
+      "worst_config": "all_max",
+      "subset_s": 0.0034,
+      "projected_full_s": 0.08,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pgo",
+      "worst_config": "all_min",
+      "subset_s": 0.0032,
+      "projected_full_s": 0.08,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "elder_ray",
+      "worst_config": "default",
+      "subset_s": 0.003,
+      "projected_full_s": 0.07,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "chaikin_vol",
+      "worst_config": "default",
+      "subset_s": 0.003,
+      "projected_full_s": 0.07,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "force_index",
+      "worst_config": "all_min",
+      "subset_s": 0.003,
+      "projected_full_s": 0.07,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kalman",
+      "worst_config": "all_min",
+      "subset_s": 0.003,
+      "projected_full_s": 0.07,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "breaker",
+      "worst_config": "all_min",
+      "subset_s": 0.0025,
+      "projected_full_s": 0.06,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "td_sequential",
+      "worst_config": "default",
+      "subset_s": 0.0025,
+      "projected_full_s": 0.06,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "td_combo",
+      "worst_config": "default",
+      "subset_s": 0.0024,
+      "projected_full_s": 0.06,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kst",
+      "worst_config": "all_min",
+      "subset_s": 0.0008,
+      "projected_full_s": 0.02,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "trend_intensity",
+      "worst_config": "all_min",
+      "subset_s": 0.0007,
+      "projected_full_s": 0.02,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ultimate_osc",
+      "worst_config": "default",
+      "subset_s": 0.0009,
+      "projected_full_s": 0.02,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "obv",
+      "worst_config": "all_min",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vwma",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ma_envelope",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vortex",
+      "worst_config": "all_min",
+      "subset_s": 0.0005,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dma",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bbi",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rsi_cutler",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cmo",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "psy",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ad_line",
+      "worst_config": "all_min",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cmf",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "eom",
+      "worst_config": "all_min",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "twiggs_mf",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "wvad",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "volume_ratio_asia",
+      "worst_config": "all_min",
+      "subset_s": 0.0005,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "accel_osc",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "demarker",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "td_rei",
+      "worst_config": "all_min",
+      "subset_s": 0.0005,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "sma_trend",
+      "worst_config": "default",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ma_displaced",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dpo",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "momentum",
+      "worst_config": "all_min",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "roc",
+      "worst_config": "all_min",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "disparity",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bias",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "balance_of_power",
+      "worst_config": "default",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "accel_bands",
+      "worst_config": "default",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bw_mfi",
+      "worst_config": "default",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ichimoku_chikou",
+      "worst_config": "all_min",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "awesome_osc",
+      "worst_config": "default",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "elliott_wave_osc",
+      "worst_config": "default",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rolling_corr",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rolling_beta",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cointegration",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pca_factor",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    }
+  ],
+  "errors": {}
+}

--- a/subprojects/Parametric-Indicators/optimize/perf/test_tail_accel_parity.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/test_tail_accel_parity.py
@@ -1,0 +1,84 @@
+"""Issue #56 parity gate: accelerated `autocorr` / `hurst_exp` reproduce the reference VOTE exactly.
+
+Same contract as `dfa` (#54): the closed-form/Numba paths are not bit-identical to `np.corrcoef` /
+per-bar numpy in the last float digits, so what is asserted is the DOWNSTREAM VETO DECISION —
+  autocorr:  both_veto(isfinite(v) & (abs(v) < threshold)),  threshold grid [0.01, 0.50] step 0.01
+  hurst_exp: both_veto(isfinite(v) & (v      < threshold)),  threshold grid [0.30, 0.70] step 0.01
+must be identical at every threshold the optimizer can search.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import numpy as np
+import pytest
+
+from indicators import library
+from indicators.calc import quant as Q
+
+
+def _walk(seed=0, n_bars=6000):
+    rng = np.random.default_rng(seed)
+    steps = rng.normal(0.0, 3.0, n_bars)
+    steps[: n_bars // 3] = np.cumsum(rng.normal(0.0, 0.3, n_bars // 3))   # trendy stretch
+    return 21000.0 + np.cumsum(steps)
+
+
+def _grid(key, name):
+    p = next(p for p in library.SCHEMA[key]["params"] if p["name"] == name)
+    return np.round(np.arange(p["min"], p["max"] + 1e-9, p["step"]), 4)
+
+
+def _assert_vote_identical(ref, fast, thresholds, absval=False):
+    fin_r, fin_f = np.isfinite(ref), np.isfinite(fast)
+    assert np.array_equal(fin_r, fin_f), "finite/NaN mask differs"
+    assert np.allclose(ref[fin_r], fast[fin_f], rtol=1e-6, atol=1e-8), "values not float-close"
+    r = np.abs(ref) if absval else ref
+    f = np.abs(fast) if absval else fast
+    for thr in thresholds:
+        flips = int(np.sum((fin_r & (r < thr)) != (fin_f & (f < thr))))
+        assert flips == 0, f"threshold {thr}: {flips} vote bars flipped"
+
+
+@pytest.mark.parametrize("n", [10, 50, 200])
+def test_autocorr_vote_identical(n):
+    c = _walk(seed=n)
+    _assert_vote_identical(Q.autocorr_reference(c, n), Q.autocorr(c, n),
+                           _grid("autocorr", "threshold"), absval=True)
+
+
+@pytest.mark.parametrize("n", [20, 100, 400])
+def test_hurst_vote_identical(n):
+    c = _walk(seed=n)
+    _assert_vote_identical(Q.hurst_exp_reference(c, n), Q.hurst_exp(c, n),
+                           _grid("hurst_exp", "threshold"))
+
+
+@pytest.mark.parametrize("key,params", [
+    ("autocorr", {"n": 50, "threshold": 0.1}),
+    ("hurst_exp", {"n": 100, "threshold": 0.5}),
+])
+def test_indicator_directions_match_reference_end_to_end(key, params):
+    """The gate at the level that matters: the Indicator object's emitted confirm/veto arrays."""
+    import pandas as pd
+    from indicators.runner import market_context
+    from indicators import votes as V
+
+    c = _walk(seed=7, n_bars=4000)
+    df = pd.DataFrame({"Date": pd.date_range("2020", periods=len(c), freq="min"),
+                       "Open": c, "High": c + 2, "Low": c - 2, "Close": c, "Volume": np.ones(len(c))})
+    ctx = market_context(df)
+    ind = library.from_specs([{"key": key, "enabled": True, "mode": "veto", "params": params}])[0]
+    cdir_fast, vdir_fast = ind.directions(ctx)
+
+    thr = float(params["threshold"])
+    if key == "autocorr":
+        ref = Q.autocorr_reference(c, int(params["n"]))
+        mask = np.isfinite(ref) & (np.abs(ref) < thr)
+    else:
+        ref = Q.hurst_exp_reference(c, int(params["n"]))
+        mask = np.isfinite(ref) & (ref < thr)
+    cdir_ref, vdir_ref = V.both_veto(mask)
+    assert np.array_equal(np.asarray(vdir_fast), np.asarray(vdir_ref))
+    assert np.array_equal(np.asarray(cdir_fast), np.asarray(cdir_ref))


### PR DESCRIPTION
Closes #56.

## Verdict: #54's tail claim was **half right, and the wrong half mattered**

| #54 claim | Verdict |
|---|---|
| "There is no second `dfa`" | ✅ **Correct** — worst remaining is 6.6 s, not 756 s |
| "The rest is diffuse … ~40 → ~33 s. Don't over-invest." | ❌ **Too optimistic** — measured at *sampled* parameters |

**Why it was wrong in the way it was wrong:** it repeated the exact mistake that let `dfa` hide for eight
months — profiling at the parameters the optimizer *happened to sample* rather than the **worst case**.
`dfa` cost 57 s at `n=20` and 756 s at `n=400`.

**Corrected picture:** all 165 indicators cost **~39 s at sampled parameters** but **123.6 s at worst-case
parameters** (~3× more), with **19 of 165 over a 2-second budget totalling 73 s**. The optimizer searches
the whole grid — it *will* reach those corners.

## New tool

`optimize/perf/bench_worstcase.py` — scans every indicator at defaults / all-min / all-max, projects to the
full 486,969-bar frame, hard per-config timeout. No timeouts or errors across the whole registry.

**Measurement trap caught (worth recording):** the first version timed the **first** call, so **Numba JIT
compile time** was extrapolated ×24 — it reported `dfa` at **5.52 s** against a *known measured* **0.178 s**.
It now warms up and times the second call. Without an independently measured number to contradict it, this
report would have "discovered" a regression in the indicator we had just made 1,396× faster.

## Fixed here (same recipe as `dfa`, same parity contract)

| indicator | worst-case before | after | speed-up | **vote flips** |
|---|---:|---:|---:|:---:|
| `autocorr` (n=200) — `np.corrcoef` per bar → closed-form Pearson | **9.47 s** | 0.081 s | **116×** | **0** |
| `hurst_exp` (n=400) — per-bar numpy temporaries → one compiled pass | **5.24 s** | 0.233 s | **22×** | **0** |

Zero differing veto decisions across each indicator's **entire searched threshold grid** on the real
486,969-bar series. Originals kept verbatim as `*_reference` oracles; graceful non-numba fallback.
8 parity tests green, including end-to-end Indicator-object vote equality.

**Worst-case total 123.6 s → 111.1 s; over-budget 19 → 17.** Both fixed indicators dropped off the list.

## How much is left (honestly)

17 indicators, ~60 s worst-case. Leaders: `sinewave` 6.6 s, `ifvg` 5.2 s, `proj_bands` 5.1 s. No single
future fix will be dramatic — the 1,396× era ended with `dfa` — but the aggregate is real, and several
(`sinewave`, `ifvg`, `cmo_chande_dmi`, `ichimoku_cloud`) are expensive at **default** parameters, so they
are paid on nearly every trial that enables them. **Recommended stopping rule: a 2 s budget, not a feeling.**

## Self-criticism

The playbook rule "profile the worst case, not the default" (#57, rule P4) exists *because* of `dfa` — and
the very next report (#54) still violated it. Rules only work if applied to one's own conclusions too.

Report: `optimize/REPORT_post_dfa_tail.md` · §7 lists honest gaps (projections are extrapolated for the 17
unfixed; only min/max corners tested, so a mixed-parameter peak could be missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)