### PR TITLE
chore: closeout — pull all artifacts, update authoritative docs, handoff report

### DIFF
--- a/docs/CLOSEOUT-2026-07-27-indicator-performance.md
+++ b/docs/CLOSEOUT-2026-07-27-indicator-performance.md
@@ -1,0 +1,185 @@
+# Closeout — Indicator Performance Workstream (2026-07-27)
+
+**Issues:** #54 (root) → #56, #57, #58 · **PRs:** #55, #59, #60, #61 (all merged to `dev`)
+**Open follow-up:** #62 · **Status:** ✅ **CLOSED — clean handoff point**
+
+---
+
+## 1. The question that started it
+
+> *"Our optimizer spends ~98% of its time computing indicators and only ~2% backtesting. Should we
+> pre-compute every indicator once and store it — files? a database? a vector DB? a graph DB? Redis? RAM?
+> GPU VRAM? — and would a GPU, an NVIDIA box, or an ARM box help?"*
+
+## 2. The answer
+
+**No pre-computed store. No new hardware.** The 98% was neither a storage problem nor an
+arithmetic-throughput problem. It was **one indicator implemented as an extremely slow Python loop.**
+
+| | |
+|---|---|
+| Root cause | `dfa` — a triple-nested loop calling `np.polyfit` ~10⁸ times, **81% of all indicator compute** |
+| Fix | closed-form OLS + Numba, one pass |
+| Result | **1,150–1,396×** faster, **zero** trading-decision changes |
+| End-to-end | a 3-trial profile went **208 s → 40 s (5.1×)** on identical work |
+| Hardware needed | **none** — ran on the CPU box we already own |
+
+---
+
+## 3. Everything measured (all on the real 486,969-bar NQ 1-minute frame, AMD server)
+
+### 3.1 The three structural findings
+
+| # | Finding | Evidence |
+|---|---|---|
+| 1 | **Pre-computing all combinations is impossible** | 165 indicators × their grids = **~4.0 billion** combos ≈ **3.9 PB** for one instrument — ~32,000× the server disk |
+| 2 | **The cache was already built** | `core._VOTE_MEMO` (memory) + `vote_cache.py` (disk) — the same two-level design Microsoft's Qlib uses |
+| 3 | **One indicator was 81% of the cost** | `dfa` = 167 s of 206 s cold compute in the first profile |
+
+### 3.2 Indicator accelerations (all vote-identical, all parity-gated)
+
+| indicator | before | after | speed-up | vote flips |
+|---|---:|---:|---:|:---:|
+| `dfa` n=400 | **756.6 s** (12.6 min) | 0.658 s | 1,150× | **0** |
+| `dfa` n=100 (default) | 248.3 s | 0.178 s | **1,396×** | **0** |
+| `dfa` n=20 | 57.0 s | 0.044 s | 1,309× | **0** |
+| `autocorr` n=200 | 9.47 s | 0.081 s | **116×** | **0** |
+| `hurst_exp` n=400 | 5.24 s | 0.233 s | **22×** | **0** |
+
+### 3.3 Whole-profile effect (identical work — same seed, same 233 cold computes)
+
+| | before | after |
+|---|---:|---:|
+| wall clock (3 trials) | 208 s | **40 s (5.1×)** |
+| cold compute | 206 s (99%) | 39 s |
+| `dfa` share of cold time | **81%** | **0.42%** |
+
+### 3.4 Worst-case parameter cost — the number to plan against
+
+| all 165 indicators, full frame | |
+|---|---:|
+| at **sampled** parameters | ~39 s |
+| at **worst-case** parameters | **123.6 s → 111.1 s** (after the tail fixes) |
+| over a 2 s budget | **19 → 17** indicators (73.1 s → 60.2 s) |
+
+### 3.5 Cache substrate — measured, NO-GO on everything
+
+| substrate | p50 read | verdict |
+|---|---:|---|
+| `shared_memory` | 0.36 µs | 43× faster — but saves only 15 µs |
+| **`.npy` (current)** | **15.32 µs** | keep |
+| tmpfs `/dev/shm` | 15.17 µs | noise |
+| **Redis** | **24.70 µs** | **1.6× slower** |
+| mmap | 29.24 µs | 1.9× slower |
+
+**Two independent kills:** a read is **0.009%** of the compute it replaces (15 µs vs ~167,000 µs), **and**
+the disk cache's hit rate in a fresh sweep is **0.00** (1,995 lookups / 30 trials) — sweeps never repeat
+parameters and every fold is a distinct slice. *Arrow Plasma excluded — removed in Arrow 12.0.0 (verified).*
+
+---
+
+## 4. Corrections we made to our own claims
+
+Recorded because each was asserted confidently before being checked:
+
+| Claim | Status |
+|---|---|
+| "`mode` in the cache key causes 3× confirm/veto/both duplication" (#54, #58) | ❌ **False** — `_suggest_indicators` fixes `mode` to the schema default and never searches it |
+| "There is no second `dfa`; the tail is diffuse, ~40→33 s, don't over-invest" (#54) | ⚠️ **Half wrong** — measured at *sampled* parameters. At grid edges **19 of 165** blow a 2 s budget (73 s) |
+| The standing hot list (`order_blocks`/`bollinger`/`cci`) | ❌ **Stale** — written at 21 indicators; now marked SUPERSEDED |
+| First worst-case scan reporting `dfa` at 5.52 s | ❌ **Measurement artifact** — timed the *first* call, extrapolating Numba JIT compile ×24. Caught only because an independently measured 0.178 s existed to contradict it |
+
+---
+
+## 5. What shipped
+
+### Code (`indicators/calc/quant.py`)
+`dfa`, `autocorr`, `hurst_exp` now dispatch to Numba closed-form fast paths. Originals retained **verbatim**
+as `dfa_reference` / `autocorr_reference` / `hurst_exp_reference` — the parity oracles. **Without numba the
+code falls back to the reference**, so a missing optional dependency can never change a number.
+`numba` added to `requirements.txt` as optional.
+
+### Harnesses (`optimize/perf/`, indexed in its `README.md`)
+`cache_probe.py` (result-neutral counters) · `run_baseline.py` (isolated real-optimizer profile) ·
+`bench_dfa.py` · `bench_worstcase.py` (grid-corner scan) · `bench_substrate.py` · 15 parity/probe tests.
+
+### Documentation
+| Document | Role |
+|---|---|
+| **`docs/EXPANSION_ROUND_PLAYBOOK.md`** | **The standing rules** — read before/after any expansion round |
+| `optimize/REPORT_indicator_cache_acceleration.md` | the #54 investigation end-to-end |
+| `optimize/REPORT_post_dfa_tail.md` | worst-case parameter picture (#56) |
+| `optimize/REPORT_cache_substrate_and_level.md` | substrate/level, measured (#58) |
+| `docs/PRIOR_ART_indicator_caching_gpu.md` | vectorbt / Qlib / talipp / wickra / RAPIDS deep scrape |
+| `optimize/perf/README.md` | every harness, artifact and raw log, with reproduction commands |
+| `docs/PERFORMANCE.md` **§10** | folded into the authoritative speed doc |
+| `optimize/REPORT_backtester_speed_optimization.md` | marked **⚠️ SUPERSEDED** (21-indicator era) |
+
+### Evidence
+8 raw server logs in `optimize/perf/logs/` (including **both control runs**) and 8 result JSONs in
+`optimize/perf/results/`. Every number in every report traces to one of them.
+
+---
+
+## 6. Correctness — how we know nothing changed
+
+- **Parity contract:** these are **veto** indicators, so the binding requirement is the veto *decision*, not
+  the float. `np.polyfit` goes through LAPACK, so bit-identity is impossible; **zero differing decisions
+  across each indicator's entire searched threshold grid** on the real series is what was proven.
+- **15 tests** green, including end-to-end tests driving the real Indicator objects.
+- **Control runs:** the full suite was run on identical trees with and without the changes. **Same 25
+  failures, empty diff both directions ⇒ zero regressions.**
+- **Those 25 failures are pre-existing** (`optimize/l2/*`, `test_intracandle_*`; none touch `quant`).
+  `test_parity_anchor.py` is a known-stale test; `test_intracandle_parity.py` had uncommitted local edits
+  before this work. Some may be an artifact of the server deploy excluding `*.csv`. **They were not
+  individually diagnosed** — the control established only that this work did not cause them. ⚠️ **This is
+  the top open risk for the next agent** (see §8).
+
+---
+
+## 7. Honest gaps
+
+1. **The 25 pre-existing test failures are undiagnosed** (proven not ours, but unexplained).
+2. **17 indicators remain over the 2 s budget** (~60 s worst-case) — tracked as **#62**.
+3. **Worst-case projections for those 17 are extrapolated** from a 20,000-bar subset (validated to within
+   3% on the two measured at full scale).
+4. **Only grid corners tested** (all-min / all-max / defaults) — a peak at a *mixed* parameter combination
+   could be missed.
+5. **Hit rate measured on a deliberately cold cache**; a production run against the accumulated 4.3 GB
+   cache could differ on repeated studies.
+6. **Per-fold `directions()` sharing was reasoned, not tested** — inferred non-result-neutral from how
+   warm-up works. That assumption is the thing to test first if anyone wants that win.
+7. **Single instrument (NQ)** — cost should be data-shape-independent for fixed parameters, unverified.
+
+---
+
+## 8. Handoff — state of the world
+
+**Branch state:** `dev` = `main` (this closeout), all four workstream PRs merged, all worktrees removed,
+server scratch cleaned.
+
+**If you are the next agent, read in this order:**
+1. `docs/EXPANSION_ROUND_PLAYBOOK.md` — the rules, especially before adding indicators
+2. `docs/PERFORMANCE.md` §10 — the current cost picture
+3. `optimize/perf/README.md` — how to re-measure anything here
+
+**Top open risks / next actions**
+
+| Priority | Item | Where |
+|---|---|---|
+| 🔴 **1** | **Diagnose the 25 failing tests.** Proven not caused by this work, but a suite with 25 red tests cannot gate anything. Start by checking whether they pass on a clean local `dev` with full `*.csv` results present. | — |
+| 🟡 2 | Work the 17 over-budget indicators down to 2 s; prioritize the ones expensive at **default** params (`sinewave`, `ifvg`, `cmo_chande_dmi`, `ichimoku_cloud`) | **#62** |
+| 🟡 3 | Wire `bench_worstcase.py` into CI / the expansion-round checklist so a new indicator cannot silently reintroduce a 12-minute compute | #62 |
+| 🟢 4 | Consider bumping `vote_cache.CACHE_VERSION` if any future indicator change is *not* vote-identical | — |
+
+**Explicitly closed — do not reopen without new evidence:** pre-computing all indicator combinations
+(impossible, 3.9 PB) · every cache substrate change (0.009% of cost, 0.00 hit rate) · GPU / NVIDIA / ARM
+hardware (the bottleneck was algorithmic, and the CPU fix beat published GPU speed-ups for comparable work).
+`REPORT_cache_substrate_and_level.md` §7 states exactly what evidence *would* reopen the substrate question.
+
+---
+
+## 9. The lesson, in one line
+
+> **Correctness is gated on every PR; cost is gated on none — so measure first. We were one decision away
+> from buying a GPU to fix a Python loop.**

--- a/subprojects/Parametric-Indicators/docs/PERFORMANCE.md
+++ b/subprojects/Parametric-Indicators/docs/PERFORMANCE.md
@@ -26,7 +26,12 @@ document **summarizes and cross-references** it rather than duplicating it. The 
 | ROI / "import-now-or-hold" decision | `perf/REPORT_optimization_roi_and_decision.md` |
 | Pinned status + golden baselines table | `perf/STATUS_optimization.md` |
 | Per-step before/after detail | `perf/UPDATE_step_*.md` (D, A1, A2, E, C′, B1, B2, B3a, B3b) |
-| Profiling deep analysis (where the 37 s went) | `optimize/REPORT_backtester_speed_optimization.md` |
+| Profiling deep analysis (where the 37 s went) | `optimize/REPORT_backtester_speed_optimization.md` ⚠️ **SUPERSEDED — 21-indicator era, see §8** |
+| **CURRENT indicator profile + the `dfa` fix (2026-07-27)** | **`optimize/REPORT_indicator_cache_acceleration.md`** |
+| **Worst-case-parameter cost of all 165 indicators** | **`optimize/REPORT_post_dfa_tail.md`** |
+| **Cache substrate / level — measured NO-GO** | **`optimize/REPORT_cache_substrate_and_level.md`** |
+| **Rules to run before/after any expansion round** | **`docs/EXPANSION_ROUND_PLAYBOOK.md`** |
+| **Perf harnesses + every measured artifact** | **`optimize/perf/README.md`** |
 | Vectorized fast engine (numpy first-touch exits) | `docs/VECTORIZATION.md` |
 | 1-minute indicator layer + its vectorization | `docs/ONEMIN_INDICATORS_AND_VECTORIZATION.md` |
 | Axis-B investigation + action plan | `perf/INVESTIGATION_axisB_per_decision_loop.md`, `perf/ACTION_PLAN_axisB.md` |
@@ -102,6 +107,14 @@ project's history:
   elsewhere (§7). The cache is still correct and useful (it eliminates a real recompute), but it was **not**
   the fleet bottleneck. Lesson, now a rule: **implement, measure, compare — do not declare a speedup from a
   plausible mechanism; prove it with a before/after rate.**
+- **The stale profile that nearly cost a GPU purchase (2026-07-27, #54).** After the library grew
+  **21 → 165 indicators** with no re-profiling, the standing hot list
+  (`order_blocks`/`bollinger`/`cci`) was **completely wrong**: one indicator, **`dfa`, was 81% of all
+  indicator compute** — a triple-nested Python loop calling `np.polyfit` ~10⁸ times, costing up to
+  **756 s (12.6 min) for a single compute**. The plan of record was to buy a GPU; a **3-minute profile**
+  redirected it to a one-function rewrite worth **1,396×**, free, with zero decision changes. Lesson, now
+  rule **P1** of `docs/EXPANSION_ROUND_PLAYBOOK.md`: **an old profile is INVALID after library growth —
+  re-profile before trusting any statement about what is slow.** See §8.
 
 ---
 
@@ -618,7 +631,92 @@ frequently-respawning sweeps. Votes are per-decision-bar (~2 KB), so the store i
 
 ---
 
-## 10. One-paragraph bottom line
+## 10. Indicator cold-compute — the 2026-07-27 re-profile (**CURRENT**)
+
+**Supersedes the hot list in `optimize/REPORT_backtester_speed_optimization.md`** (written at ~21
+indicators; the library is now **165** and the cost moved entirely). Full detail:
+`optimize/REPORT_indicator_cache_acceleration.md`, `REPORT_post_dfa_tail.md`,
+`REPORT_cache_substrate_and_level.md`; artifacts and harnesses: `optimize/perf/README.md`.
+
+### 10.1 What the measurement said (#54)
+
+A 3-trial NQ 4h profile (165 indicators, 1-minute frame, cold cache) on the AMD server:
+
+| | before | after the `dfa` fix |
+|---|---:|---:|
+| wall clock | 208 s | **40 s (5.1×)** |
+| cold indicator compute | 206 s (99% of wall) | 39 s |
+| cold computations | 233 | 233 *(identical work — apples-to-apples)* |
+| **`dfa`** | **167 s = 81% of all indicator time** | 0.161 s = 0.42% |
+
+`dfa` (`indicators/calc/quant.py`) was a triple-nested Python loop calling `np.polyfit` per segment per
+scale per bar — ~10⁸ least-squares solves. Replaced by the closed-form OLS slope + residual mean-square in
+one Numba pass:
+
+| `dfa` on the real 486,969-bar frame | before | after | speed-up | **vote flips** |
+|---|---:|---:|---:|:---:|
+| n=20 | 57.0 s | 0.044 s | 1,309× | **0** |
+| n=100 (default) | 248.3 s | 0.178 s | **1,396×** | **0** |
+| n=400 (grid max) | **756.6 s** | 0.658 s | 1,150× | **0** |
+
+### 10.2 The parity contract for this class of change
+
+`np.polyfit` solves via LAPACK, so a closed form is **not** bit-identical in the last float digits. The
+contract enforced is the **discretized decision**: `dfa`/`autocorr`/`hurst_exp` are **veto** indicators, so
+what must be identical is the veto boolean across the **entire searched threshold grid** on the real
+series — verified as **zero flips**. The original implementations are retained verbatim as
+`dfa_reference` / `autocorr_reference` / `hurst_exp_reference` (the parity oracles), and **without numba
+the code falls back to them**, so a missing optional dependency can never change a number.
+Regression-checked with a **control run** (identical suite on unmodified code): same 25 pre-existing
+failures, empty diff both ways ⇒ zero regressions.
+
+### 10.3 Worst-case parameter cost — the number to plan against (#56)
+
+Profiling at *sampled* parameters is what let `dfa` hide. Scanning **every** indicator at defaults /
+all-min / all-max (`optimize/perf/bench_worstcase.py`):
+
+| | all 165 indicators, full frame |
+|---|---:|
+| at sampled parameters | ~39 s |
+| **at worst-case parameters** | **123.6 s → 111.1 s** after the `autocorr`/`hurst_exp` fixes |
+| indicators over a 2 s budget | **19 → 17** (73.1 s → 60.2 s) |
+
+Fixed here: `autocorr` 9.47 s → 0.081 s (**116×**), `hurst_exp` 5.24 s → 0.233 s (**22×**), 0 vote flips.
+Remaining leaders: `sinewave` 6.6 s, `ifvg` 5.2 s, `proj_bands` 5.1 s, `ou_halflife` 4.4 s,
+`cmo_chande_dmi` 4.0 s — several expensive at **default** parameters, so paid on nearly every trial that
+enables them. (`ifvg` independently corroborates §9's ES-committee finding.) **Open follow-up: #62**, with
+a 2 s budget as the stopping rule (expected end state ~50 s worst-case).
+
+### 10.4 Caching: measured, and deliberately NOT changed (#58)
+
+| finding | number |
+|---|---|
+| cache **read** vs the **compute** it replaces | **15 µs vs ~167,000 µs = 0.009%** |
+| disk-cache **hit rate** in a fresh sweep | **0.00** over 1,995 lookups / 30 trials |
+| `.npy` (current) · tmpfs · `shared_memory` · **Redis** · mmap | 15.32 · 15.17 (noise) · 0.36 · **24.70 (1.6× slower)** · 29.24 µs |
+
+⇒ **NO-GO on every substrate and re-keying change.** Fresh sweeps never repeat parameters (~4-billion
+grid) and every fold is a distinct slice, so the disk cache is barely read; the caching that actually pays
+is the in-process `_VOTE_MEMO` (§7.4). The 201,354 files / 4.3 GB in the production cache are evidence of
+**misses written**, not hits. Two corrections to earlier claims: **`mode` is never searched** by
+`_suggest_indicators`, so there is no 3× confirm/veto/both duplication; and **precomputing all parameter
+combinations is impossible** — ~4.0 B combos ≈ **3.9 PB** for one instrument. *What would change this:* a
+replay-shaped workload (champion re-validation, ablation grids), where `shared_memory`'s 43× becomes worth
+revisiting.
+
+### 10.5 Standing rules produced by this work
+
+`docs/EXPANSION_ROUND_PLAYBOOK.md` — read before/after **any** expansion round. Most load-bearing:
+**P1** an old profile is invalid after growth · **P2** no `np.polyfit`/`np.corrcoef`/`np.linalg.*` inside a
+per-bar loop · **P3** multiply per-bar cost by **486,969** · **P4** profile the **worst-case** parameter ·
+**P5** multiply the grid out before proposing any "store everything" design · **P9** measure before buying
+hardware · **C5** run a **control** before calling a test failure "pre-existing". ⚠️ When timing anything,
+**warm up first** — an unwarmed benchmark extrapolated Numba JIT compile ×24 and reported `dfa` at 5.52 s
+against a measured 0.178 s.
+
+---
+
+## 11. One-paragraph bottom line
 
 Speed work here is governed by one rule — **prove byte-identical results, never assume them** — enforced by
 the 6-TF golden gate (L1 4h anchor ~$142,203 / 214 trades) and the fast↔slow engine parity locks. Two
@@ -634,4 +732,13 @@ fleet, golden 6/6 byte-identical. The newest measured finding (§9) is the **cro
 ES contributor per-trial cost**: alignment/state are cheap and cached (514 ms once/worker), but the ES
 indicator committee recomputes per trial, and **two indicators — `ifvg` (58 s) and `breaker` (38 s) — are
 90% of a 106 s full-committee trial**; excluding them from the ES search space is a ~10× cut with zero
-impact on the contributor-free golden path.
+impact on the contributor-free golden path. **The current headline (§10, 2026-07-27) is the indicator
+cold-compute re-profile**: after the library grew 21→165 the standing hot list was stale, and **one
+indicator (`dfa`) was 81% of all indicator time** — a per-bar `np.polyfit` loop costing up to **756 s** for
+a single compute. A closed-form + Numba rewrite gave **1,150–1,396×** with **zero** vote changes, taking a
+3-trial profile **208 s → 40 s (5.1×)**; `autocorr` (116×) and `hurst_exp` (22×) followed. Measurement also
+closed the storage question for good — a cache read is **0.009%** of the compute it replaces and the disk
+cache's hit rate in a fresh sweep is **0.00**, so every substrate change (tmpfs, Redis, shared-memory,
+re-keying) is a **NO-GO**, and no GPU/ARM hardware is needed. The standing defence is
+`docs/EXPANSION_ROUND_PLAYBOOK.md`: **re-profile after every expansion round, and profile the worst-case
+parameter, not the default.**

--- a/subprojects/Parametric-Indicators/optimize/REPORT_backtester_speed_optimization.md
+++ b/subprojects/Parametric-Indicators/optimize/REPORT_backtester_speed_optimization.md
@@ -1,3 +1,22 @@
+> # ⚠️ SUPERSEDED — DO NOT OPTIMIZE FROM THIS PROFILE
+>
+> **Profile valid as of 2026-06-11, at ~21 indicators.** The library has since grown to **165**, and the
+> cost distribution moved **entirely**. This document's hot list (`smc.order_blocks` 18.5 s, `bollinger`
+> 10.7 s, `cci` 6 s) is **no longer where the time goes**.
+>
+> **What was actually true on 2026-07-27:** one indicator, **`dfa`, was 81% of all indicator compute**
+> (up to 756 s for a single compute) — it did not exist when this was written. See
+> **`REPORT_indicator_cache_acceleration.md`** for the current profile, and
+> **`REPORT_post_dfa_tail.md`** for the worst-case-parameter picture.
+>
+> This document is retained for its **method** (how to profile, the options taxonomy) and as the origin of
+> several still-valid conclusions — e.g. that GPU/Dask are the wrong tool for this workload, which the 2026-07
+> work independently re-confirmed. Its **numbers** are historical.
+>
+> Nearly optimizing from this stale report is the incident that produced
+> **`docs/EXPANSION_ROUND_PLAYBOOK.md`** (rule **P1**: never optimize from an old profile; re-profile after
+> every expansion round).
+
 # Backtester Speed Optimization — Deep Analysis & Improvement Study
 
 **Date:** 2026-06-11 · branch `dev` · relates to task #210

--- a/subprojects/Parametric-Indicators/optimize/RESEARCH_indicator_recurrence_relations.md
+++ b/subprojects/Parametric-Indicators/optimize/RESEARCH_indicator_recurrence_relations.md
@@ -1,5 +1,13 @@
 # Research — Indicator Incremental-Recurrence Study
 
+> **⚠️ SCOPE NOTE (added 2026-07-27):** this study classifies the **original 21** indicator functions. The
+> library is now **165**, and the indicators that actually dominate cost today (`dfa`, `autocorr`,
+> `hurst_exp`, `sinewave`, `ifvg`, …) **are not covered here**. Its *conclusions remain valid for the
+> functions it examines* — and one of them proved directly load-bearing: it correctly identified that the
+> expensive cases are **batch recomputation**, not streaming, which is why the 2026-07 fixes used
+> closed-form/Numba rather than an incremental rewrite. For the current cost picture see
+> `REPORT_indicator_cache_acceleration.md` and `REPORT_post_dfa_tail.md`.
+
 **Date:** 2026-06-11 · task #210 side-research · branch `dev`
 **Question.** Our indicators are computed over a **moving window**. For each one, does it admit an
 **incremental recurrence** — i.e. can `Uₙ` be obtained from the *previous* output `Uₙ₋₁` (or a small,

--- a/subprojects/Parametric-Indicators/optimize/perf/README.md
+++ b/subprojects/Parametric-Indicators/optimize/perf/README.md
@@ -1,0 +1,82 @@
+# `optimize/perf/` — performance harnesses & artifacts
+
+Everything here was produced by the 2026-07-27 indicator-performance workstream (**#54 → #56/#57/#58**).
+All measurements ran on the AMD server (`ssh amd-trading`, 32 cores / 123 GB RAM, no GPU) against the real
+**486,969-bar NQ 1-minute frame**. Nothing here runs in the production optimizer path; every accelerator
+lives in `indicators/calc/quant.py` behind a numba-optional fallback.
+
+> **Read first:** [`docs/EXPANSION_ROUND_PLAYBOOK.md`](../../../../docs/EXPANSION_ROUND_PLAYBOOK.md) —
+> the rules these tools exist to enforce.
+
+---
+
+## Tools
+
+| File | What it does | Typical invocation |
+|---|---|---|
+| `cache_probe.py` | **Result-neutral** instrumentation. Wraps `vote_cache.get/put` and `runner._ind_vote` to count cache hits/misses, bytes, and **cold-compute wall-clock per indicator**. Arrays pass through unchanged. | used by `run_baseline.py` |
+| `run_baseline.py` | Runs the **real optimizer** for N trials with the probe installed, isolated via a throwaway `WSH_JOURNAL_DIR` + cold `vote_cache` (zero production pollution). Emits the cold/warm/IO split + per-indicator cold-cost ranking. | `python3 -m optimize.perf.run_baseline --tf 4h --trials 30` |
+| `bench_dfa.py` | Times `dfa` reference vs accelerated at n∈{20,100,400} on the real frame and re-verifies **zero vote flips** across the full threshold grid. | `python3 -m optimize.perf.bench_dfa` |
+| `bench_worstcase.py` | Scans **every** registered indicator at defaults / all-min / all-max, projects to the full frame, flags anything over a budget. **The automated form of playbook rule P4.** | `python3 -m optimize.perf.bench_worstcase --bars 20000 --budget-s 2.0` |
+| `bench_substrate.py` | Times cache retrieval through `.npy` / tmpfs / mmap / `shared_memory` / Redis / dict at 1 and N readers, on **real** cached arrays. | `python3 -m optimize.perf.bench_substrate --n-files 300 --readers 30` |
+| `cold_accel.py` | Thin aliases (`dfa_fast`, `dfa_reference`) so benchmarks read naturally and `indicators/` never imports `optimize/`. | — |
+
+**Tests:** `test_cache_probe.py` (probe is result-neutral), `test_cold_accel_parity.py` (`dfa` vote-identity),
+`test_tail_accel_parity.py` (`autocorr` / `hurst_exp` vote-identity). All gate on the **discretized vote**,
+not raw floats — see the parity note in `indicators/calc/quant.py`.
+
+⚠️ **When timing anything here, warm up first.** `bench_worstcase.py` calls each configuration twice and
+times only the second. The first version did not, so **Numba JIT compile time was extrapolated ×24** and it
+reported `dfa` at 5.52 s against a measured 0.178 s.
+
+---
+
+## Artifacts — `results/`
+
+| File | Produced by | What it shows |
+|---|---|---|
+| `baseline_NQ_4h_smoke3.json` | `run_baseline` (3 trials, **before** any fix) | **The finding that redirected the workstream:** cold = 206 s of 208 s wall (99%); **`dfa` = 167 s = 81% of all indicator compute** |
+| `baseline_NQ_4h_after_dfa.json` | `run_baseline` (3 trials, **after** the `dfa` fix) | Same seed ⇒ same trials, **same 233 cold computes** ⇒ apples-to-apples: wall **208 s → 40 s (5.1×)**; `dfa` 167 s → 0.161 s (81% → 0.42%) |
+| `baseline_NQ_4h_30trials.json` | `run_baseline` (30 trials) | The **hit-rate** measurement: 1,995 lookups, **hit_rate = 0.00**; wall 317 s, cold 301 s (95%) |
+| `dfa_bench_NQ_1m.json` | `bench_dfa` | `dfa` on the real frame: n=20 **1,309×**, n=100 **1,396×**, n=400 **1,150×** (756.6 s → 0.658 s), **0 vote flips** at every n |
+| `tail_bench.json` | ad-hoc (see `REPORT_post_dfa_tail.md`) | `autocorr` 9.47 s → 0.081 s (**116×**), `hurst_exp` 5.24 s → 0.233 s (**22×**), 0 vote flips |
+| `worstcase_scan.json` | `bench_worstcase` (**before** tail fixes) | **19 of 165** indicators over a 2 s budget = 73.1 s; all 165 worst-case = **123.6 s** |
+| `worstcase_scan_after.json` | `bench_worstcase` (**after** tail fixes) | **17** over budget = 60.2 s; all 165 = **111.1 s** |
+| `substrate_bench.json` | `bench_substrate` | `.npy` 15.32 µs · tmpfs 15.17 µs (noise) · `shared_memory` 0.36 µs · **Redis 24.70 µs (1.6× slower)** · mmap 29.24 µs |
+
+## Raw evidence — `logs/`
+
+Verbatim server output, kept so every number in the reports is traceable to a run.
+
+| File | Contents |
+|---|---|
+| `issue54_dfa_bench.log` | the `dfa` before/after timings as they were produced |
+| `issue54_rebaseline.log` | the 3-trial re-baseline proving 208 s → 40 s |
+| `issue54_full_pytest.log` | full suite **with** the `dfa` fix — 25 failed / 834 passed |
+| `issue54_ctrl_pytest.log`, `issue54_ctrl_targeted.log` | the **control** run on an identical tree with the *original* code — the same 25 failures, proving **zero regressions** |
+| `issue56_worstcase.log` | the worst-case parameter scan |
+| `issue56_full_pytest.log` | full suite with the tail fixes — 25 failed / 854 passed (same 25) |
+| `issue58_hitrate.log` | the 30-trial run showing `hit_rate = 0.00` throughout |
+
+**About those 25 failures:** they are **pre-existing** and unrelated to this work — proven by running the
+identical suite against unmodified code and diffing the failure sets (empty both directions). They sit in
+`optimize/l2/*` and `test_intracandle_*`; none touch `quant`. `test_parity_anchor.py` is a known-stale test
+and `test_intracandle_parity.py` had uncommitted local edits before this workstream began. Some may also be
+an artifact of the server deploy excluding `*.csv`. **They were not individually diagnosed** — the control
+established only that this work did not cause them.
+
+---
+
+## Reproducing
+
+```bash
+# on the server (the venv has numpy/pandas/optuna/scipy/numba)
+cd <deploy>/Parametric-Indicators
+export WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data
+/home/dev/Mulham/.venv/bin/python3 -m optimize.perf.run_baseline    --tf 4h --trials 30
+/home/dev/Mulham/.venv/bin/python3 -m optimize.perf.bench_worstcase --bars 20000 --budget-s 2.0
+/home/dev/Mulham/.venv/bin/python3 -m optimize.perf.bench_dfa
+```
+
+`run_baseline` isolates itself (throwaway journal store + cold cache) and cleans up after itself, so it is
+safe to run alongside production work.

--- a/subprojects/Parametric-Indicators/optimize/perf/results/worstcase_scan_after.json
+++ b/subprojects/Parametric-Indicators/optimize/perf/results/worstcase_scan_after.json
@@ -1,0 +1,1330 @@
+{
+  "bars_stage1": 20000,
+  "scale": 24.348,
+  "budget_s": 2.0,
+  "n_indicators": 165,
+  "n_over_budget": 17,
+  "ranked": [
+    {
+      "key": "sinewave",
+      "worst_config": "default",
+      "subset_s": 0.2699,
+      "projected_full_s": 6.57,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ifvg",
+      "worst_config": "default",
+      "subset_s": 0.2115,
+      "projected_full_s": 5.15,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "proj_bands",
+      "worst_config": "all_max",
+      "subset_s": 0.2099,
+      "projected_full_s": 5.11,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ou_halflife",
+      "worst_config": "all_max",
+      "subset_s": 0.1787,
+      "projected_full_s": 4.35,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "cmo_chande_dmi",
+      "worst_config": "all_max",
+      "subset_s": 0.1634,
+      "projected_full_s": 3.98,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "linreg_channel",
+      "worst_config": "all_max",
+      "subset_s": 0.1542,
+      "projected_full_s": 3.75,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "schaff_trend_cycle",
+      "worst_config": "all_max",
+      "subset_s": 0.1427,
+      "projected_full_s": 3.47,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ichimoku_cloud",
+      "worst_config": "default",
+      "subset_s": 0.1407,
+      "projected_full_s": 3.43,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ichimoku_tk_cross",
+      "worst_config": "all_max",
+      "subset_s": 0.1398,
+      "projected_full_s": 3.4,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "lsma",
+      "worst_config": "all_max",
+      "subset_s": 0.1274,
+      "projected_full_s": 3.1,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "linreg_r2",
+      "worst_config": "all_max",
+      "subset_s": 0.1252,
+      "projected_full_s": 3.05,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "order_block",
+      "worst_config": "all_min",
+      "subset_s": 0.1156,
+      "projected_full_s": 2.82,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "frama",
+      "worst_config": "all_min",
+      "subset_s": 0.1139,
+      "projected_full_s": 2.77,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "chande_kroll",
+      "worst_config": "all_max",
+      "subset_s": 0.1038,
+      "projected_full_s": 2.53,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "mama_fama",
+      "worst_config": "all_max",
+      "subset_s": 0.0957,
+      "projected_full_s": 2.33,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "smi",
+      "worst_config": "default",
+      "subset_s": 0.0895,
+      "projected_full_s": 2.18,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "ulcer",
+      "worst_config": "all_max",
+      "subset_s": 0.089,
+      "projected_full_s": 2.17,
+      "over_budget": true,
+      "notes": {}
+    },
+    {
+      "key": "hilbert_cycle",
+      "worst_config": "default",
+      "subset_s": 0.0746,
+      "projected_full_s": 1.82,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "fisher",
+      "worst_config": "all_min",
+      "subset_s": 0.0707,
+      "projected_full_s": 1.72,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rsi_connors",
+      "worst_config": "default",
+      "subset_s": 0.0644,
+      "projected_full_s": 1.57,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "linreg_slope",
+      "worst_config": "all_max",
+      "subset_s": 0.062,
+      "projected_full_s": 1.51,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "hma",
+      "worst_config": "all_max",
+      "subset_s": 0.0598,
+      "projected_full_s": 1.46,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "chandelier",
+      "worst_config": "default",
+      "subset_s": 0.0579,
+      "projected_full_s": 1.41,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kdj",
+      "worst_config": "default",
+      "subset_s": 0.0576,
+      "projected_full_s": 1.4,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "stoch_rsi",
+      "worst_config": "all_max",
+      "subset_s": 0.0543,
+      "projected_full_s": 1.32,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "qqe",
+      "worst_config": "default",
+      "subset_s": 0.0528,
+      "projected_full_s": 1.28,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "adx",
+      "worst_config": "all_min",
+      "subset_s": 0.0481,
+      "projected_full_s": 1.17,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "choppiness",
+      "worst_config": "default",
+      "subset_s": 0.0477,
+      "projected_full_s": 1.16,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "stochastic",
+      "worst_config": "default",
+      "subset_s": 0.0469,
+      "projected_full_s": 1.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "williams_r",
+      "worst_config": "default",
+      "subset_s": 0.0468,
+      "projected_full_s": 1.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "donchian",
+      "worst_config": "all_min",
+      "subset_s": 0.0467,
+      "projected_full_s": 1.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "aroon",
+      "worst_config": "all_max",
+      "subset_s": 0.0385,
+      "projected_full_s": 0.94,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "aroon_osc",
+      "worst_config": "all_max",
+      "subset_s": 0.0387,
+      "projected_full_s": 0.94,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "gmma",
+      "worst_config": "default",
+      "subset_s": 0.0355,
+      "projected_full_s": 0.86,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rvgi",
+      "worst_config": "all_min",
+      "subset_s": 0.0348,
+      "projected_full_s": 0.85,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vidya",
+      "worst_config": "all_max",
+      "subset_s": 0.0337,
+      "projected_full_s": 0.82,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vol_ratio",
+      "worst_config": "all_min",
+      "subset_s": 0.0328,
+      "projected_full_s": 0.8,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "di_cross",
+      "worst_config": "all_min",
+      "subset_s": 0.0326,
+      "projected_full_s": 0.79,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "gator",
+      "worst_config": "default",
+      "subset_s": 0.0319,
+      "projected_full_s": 0.78,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "alligator",
+      "worst_config": "default",
+      "subset_s": 0.0317,
+      "projected_full_s": 0.77,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "derivative_osc",
+      "worst_config": "all_min",
+      "subset_s": 0.0294,
+      "projected_full_s": 0.72,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "center_of_gravity",
+      "worst_config": "all_max",
+      "subset_s": 0.0291,
+      "projected_full_s": 0.71,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dfa",
+      "worst_config": "all_max",
+      "subset_s": 0.0264,
+      "projected_full_s": 0.64,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rvi_dorsey",
+      "worst_config": "default",
+      "subset_s": 0.0233,
+      "projected_full_s": 0.57,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "laguerre_rsi",
+      "worst_config": "all_min",
+      "subset_s": 0.0235,
+      "projected_full_s": 0.57,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tsi",
+      "worst_config": "all_max",
+      "subset_s": 0.0226,
+      "projected_full_s": 0.55,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ergodic_osc",
+      "worst_config": "default",
+      "subset_s": 0.0226,
+      "projected_full_s": 0.55,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kama",
+      "worst_config": "all_min",
+      "subset_s": 0.022,
+      "projected_full_s": 0.54,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rma",
+      "worst_config": "default",
+      "subset_s": 0.0217,
+      "projected_full_s": 0.53,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "supertrend",
+      "worst_config": "all_max",
+      "subset_s": 0.0219,
+      "projected_full_s": 0.53,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rmi",
+      "worst_config": "default",
+      "subset_s": 0.0216,
+      "projected_full_s": 0.53,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "atr_norm",
+      "worst_config": "default",
+      "subset_s": 0.0215,
+      "projected_full_s": 0.52,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "wma",
+      "worst_config": "default",
+      "subset_s": 0.0208,
+      "projected_full_s": 0.51,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "sine_wma",
+      "worst_config": "all_max",
+      "subset_s": 0.0191,
+      "projected_full_s": 0.47,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "trix",
+      "worst_config": "all_max",
+      "subset_s": 0.0194,
+      "projected_full_s": 0.47,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "asi",
+      "worst_config": "default",
+      "subset_s": 0.0194,
+      "projected_full_s": 0.47,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tma",
+      "worst_config": "all_max",
+      "subset_s": 0.0189,
+      "projected_full_s": 0.46,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "yang_zhang",
+      "worst_config": "all_max",
+      "subset_s": 0.018,
+      "projected_full_s": 0.44,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tema",
+      "worst_config": "default",
+      "subset_s": 0.0177,
+      "projected_full_s": 0.43,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "t3",
+      "worst_config": "all_min",
+      "subset_s": 0.0178,
+      "projected_full_s": 0.43,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ttm_squeeze",
+      "worst_config": "all_max",
+      "subset_s": 0.0175,
+      "projected_full_s": 0.43,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "roofing",
+      "worst_config": "all_min",
+      "subset_s": 0.0177,
+      "projected_full_s": 0.43,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ppo",
+      "worst_config": "default",
+      "subset_s": 0.0168,
+      "projected_full_s": 0.41,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "wavetrend",
+      "worst_config": "all_min",
+      "subset_s": 0.0167,
+      "projected_full_s": 0.41,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "efficiency_ratio",
+      "worst_config": "all_max",
+      "subset_s": 0.0162,
+      "projected_full_s": 0.4,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "stddev",
+      "worst_config": "all_max",
+      "subset_s": 0.0153,
+      "projected_full_s": 0.37,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "garch_ewma",
+      "worst_config": "default",
+      "subset_s": 0.0146,
+      "projected_full_s": 0.36,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "hist_vol",
+      "worst_config": "all_max",
+      "subset_s": 0.0143,
+      "projected_full_s": 0.35,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cyber_cycle",
+      "worst_config": "default",
+      "subset_s": 0.0146,
+      "projected_full_s": 0.35,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "emd",
+      "worst_config": "all_min",
+      "subset_s": 0.0143,
+      "projected_full_s": 0.35,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "keltner",
+      "worst_config": "all_min",
+      "subset_s": 0.0138,
+      "projected_full_s": 0.34,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "mcginley",
+      "worst_config": "all_min",
+      "subset_s": 0.0134,
+      "projected_full_s": 0.33,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "evwma",
+      "worst_config": "all_min",
+      "subset_s": 0.0136,
+      "projected_full_s": 0.33,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "klinger",
+      "worst_config": "default",
+      "subset_s": 0.0136,
+      "projected_full_s": 0.33,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dema",
+      "worst_config": "all_max",
+      "subset_s": 0.0119,
+      "projected_full_s": 0.29,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "elder_impulse",
+      "worst_config": "all_max",
+      "subset_s": 0.0119,
+      "projected_full_s": 0.29,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "parkinson",
+      "worst_config": "all_min",
+      "subset_s": 0.011,
+      "projected_full_s": 0.27,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "garman_klass",
+      "worst_config": "all_min",
+      "subset_s": 0.011,
+      "projected_full_s": 0.27,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rogers_satchell",
+      "worst_config": "all_min",
+      "subset_s": 0.011,
+      "projected_full_s": 0.27,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "starc",
+      "worst_config": "all_max",
+      "subset_s": 0.011,
+      "projected_full_s": 0.27,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "mass_index",
+      "worst_config": "default",
+      "subset_s": 0.0102,
+      "projected_full_s": 0.25,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "jma",
+      "worst_config": "all_min",
+      "subset_s": 0.0104,
+      "projected_full_s": 0.25,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "coppock",
+      "worst_config": "default",
+      "subset_s": 0.01,
+      "projected_full_s": 0.24,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "hurst_exp",
+      "worst_config": "all_max",
+      "subset_s": 0.0098,
+      "projected_full_s": 0.24,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "alma",
+      "worst_config": "all_max",
+      "subset_s": 0.0096,
+      "projected_full_s": 0.23,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "macd",
+      "worst_config": "default",
+      "subset_s": 0.0088,
+      "projected_full_s": 0.21,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rsi",
+      "worst_config": "default",
+      "subset_s": 0.0077,
+      "projected_full_s": 0.19,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "psar",
+      "worst_config": "all_max",
+      "subset_s": 0.0077,
+      "projected_full_s": 0.19,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bandpass",
+      "worst_config": "default",
+      "subset_s": 0.0077,
+      "projected_full_s": 0.19,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "nvi",
+      "worst_config": "all_min",
+      "subset_s": 0.0071,
+      "projected_full_s": 0.17,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pvi",
+      "worst_config": "all_min",
+      "subset_s": 0.0069,
+      "projected_full_s": 0.17,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ema_trend",
+      "worst_config": "all_min",
+      "subset_s": 0.0063,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cci",
+      "worst_config": "all_max",
+      "subset_s": 0.0062,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "zlema",
+      "worst_config": "all_min",
+      "subset_s": 0.006,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "chaikin_vol",
+      "worst_config": "all_min",
+      "subset_s": 0.006,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "chaikin_osc",
+      "worst_config": "default",
+      "subset_s": 0.0061,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "demand_index",
+      "worst_config": "all_min",
+      "subset_s": 0.0061,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vzo",
+      "worst_config": "default",
+      "subset_s": 0.006,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "fractals",
+      "worst_config": "default",
+      "subset_s": 0.0063,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "super_smoother",
+      "worst_config": "all_min",
+      "subset_s": 0.0062,
+      "projected_full_s": 0.15,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "apo",
+      "worst_config": "all_min",
+      "subset_s": 0.0059,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "expma",
+      "worst_config": "all_max",
+      "subset_s": 0.0059,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vol_osc",
+      "worst_config": "default",
+      "subset_s": 0.0059,
+      "projected_full_s": 0.14,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_floor",
+      "worst_config": "default",
+      "subset_s": 0.0053,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_woodie",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_demark",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_camarilla",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pivot_fib",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cpr",
+      "worst_config": "default",
+      "subset_s": 0.0054,
+      "projected_full_s": 0.13,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pvt",
+      "worst_config": "all_min",
+      "subset_s": 0.0049,
+      "projected_full_s": 0.12,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vwap",
+      "worst_config": "default",
+      "subset_s": 0.0044,
+      "projected_full_s": 0.11,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "anchored_vwap",
+      "worst_config": "default",
+      "subset_s": 0.0046,
+      "projected_full_s": 0.11,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "structure_trend",
+      "worst_config": "default",
+      "subset_s": 0.0041,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "fvg",
+      "worst_config": "all_max",
+      "subset_s": 0.0042,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cisd",
+      "worst_config": "default",
+      "subset_s": 0.0039,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "tvi",
+      "worst_config": "all_min",
+      "subset_s": 0.0041,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "zscore",
+      "worst_config": "all_max",
+      "subset_s": 0.004,
+      "projected_full_s": 0.1,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "mfi",
+      "worst_config": "all_max",
+      "subset_s": 0.0037,
+      "projected_full_s": 0.09,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bollinger",
+      "worst_config": "all_max",
+      "subset_s": 0.0033,
+      "projected_full_s": 0.08,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pgo",
+      "worst_config": "all_min",
+      "subset_s": 0.0032,
+      "projected_full_s": 0.08,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "autocorr",
+      "worst_config": "all_max",
+      "subset_s": 0.0033,
+      "projected_full_s": 0.08,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kalman",
+      "worst_config": "all_max",
+      "subset_s": 0.0031,
+      "projected_full_s": 0.08,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "elder_ray",
+      "worst_config": "default",
+      "subset_s": 0.0031,
+      "projected_full_s": 0.07,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "force_index",
+      "worst_config": "all_min",
+      "subset_s": 0.003,
+      "projected_full_s": 0.07,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "breaker",
+      "worst_config": "all_min",
+      "subset_s": 0.0025,
+      "projected_full_s": 0.06,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "td_sequential",
+      "worst_config": "default",
+      "subset_s": 0.0024,
+      "projected_full_s": 0.06,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "td_combo",
+      "worst_config": "default",
+      "subset_s": 0.0025,
+      "projected_full_s": 0.06,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "kst",
+      "worst_config": "all_min",
+      "subset_s": 0.0008,
+      "projected_full_s": 0.02,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "trend_intensity",
+      "worst_config": "all_min",
+      "subset_s": 0.0007,
+      "projected_full_s": 0.02,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ultimate_osc",
+      "worst_config": "default",
+      "subset_s": 0.0009,
+      "projected_full_s": 0.02,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "obv",
+      "worst_config": "all_min",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vwma",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ma_envelope",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "vortex",
+      "worst_config": "all_min",
+      "subset_s": 0.0005,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dma",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bbi",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rsi_cutler",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cmo",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "psy",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ad_line",
+      "worst_config": "all_min",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cmf",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "eom",
+      "worst_config": "all_min",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "twiggs_mf",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "wvad",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "volume_ratio_asia",
+      "worst_config": "all_min",
+      "subset_s": 0.0005,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "accel_osc",
+      "worst_config": "default",
+      "subset_s": 0.0003,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "demarker",
+      "worst_config": "all_min",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "td_rei",
+      "worst_config": "default",
+      "subset_s": 0.0004,
+      "projected_full_s": 0.01,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "sma_trend",
+      "worst_config": "default",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ma_displaced",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "dpo",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "momentum",
+      "worst_config": "all_min",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "roc",
+      "worst_config": "all_min",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "disparity",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bias",
+      "worst_config": "all_min",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "balance_of_power",
+      "worst_config": "all_min",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "accel_bands",
+      "worst_config": "default",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "bw_mfi",
+      "worst_config": "default",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "ichimoku_chikou",
+      "worst_config": "all_min",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "awesome_osc",
+      "worst_config": "default",
+      "subset_s": 0.0002,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "elliott_wave_osc",
+      "worst_config": "default",
+      "subset_s": 0.0001,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rolling_corr",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "rolling_beta",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "cointegration",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    },
+    {
+      "key": "pca_factor",
+      "worst_config": "default",
+      "subset_s": 0.0,
+      "projected_full_s": 0.0,
+      "over_budget": false,
+      "notes": {}
+    }
+  ],
+  "errors": {}
+}


### PR DESCRIPTION
Closes out the indicator-performance workstream (#54 → #56/#57/#58).

## Artifacts pulled from the server (local = source of truth)
- **8 raw server logs** → `optimize/perf/logs/`, including **both control runs** that prove zero regressions.
- `worstcase_scan_after.json` — was cited in a report but never committed.
- Verified nothing else was left behind (md5-checked the one apparent duplicate).

## Authoritative docs updated
- **`docs/PERFORMANCE.md`** ("the single source of truth for speed") — new **§10** with the CURRENT
  indicator profile, the parity contract for this class of change, worst-case parameter costs, the measured
  cache NO-GO, and the standing rules. §1.3 gains the stale-profile lesson; cross-reference map and bottom
  line rewritten.
- **`optimize/REPORT_backtester_speed_optimization.md`** — marked **⚠️ SUPERSEDED** with a header explaining
  it is the 21-indicator era. This is playbook rule **P1** applied to our own docs: the stale report that
  nearly cost a GPU purchase now says so at the top.
- **`optimize/RESEARCH_indicator_recurrence_relations.md`** — scope note (covers 21 of 165; its
  batch-vs-streaming conclusion proved load-bearing and is called out).
- **`optimize/perf/README.md`** (new) — indexes every harness, artifact and log: what each measurement
  shows, and the exact commands to reproduce it.

## Handoff
**`docs/CLOSEOUT-2026-07-27-indicator-performance.md`** — the single document a new agent should read:
question → answer → every number → **the corrections we made to our own claims** → what shipped →
correctness proof → **7 honest gaps** → prioritized next actions.

Top open risk is stated plainly: **25 pre-existing test failures**, proven not caused by this work (control
run, empty diff both directions) but **undiagnosed**. A suite with 25 red tests cannot gate anything.

## Not reopening without new evidence
Pre-computing all combinations (impossible — 3.9 PB) · every cache substrate change (0.009% of cost, 0.00
hit rate) · GPU/NVIDIA/ARM (the bottleneck was algorithmic). Each report states exactly what evidence
*would* reopen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)