### PR TITLE
fix(#66): test suite 25 failing -> 0, + v5.2.0 bump on a clean floor

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
     given-names: Mulham
     orcid: "https://orcid.org/0009-0006-4432-798X"
     email: contact@mulhamfetna.com
-version: 5.1.0
-date-released: "2026-07-22"
+version: 5.2.0
+date-released: "2026-07-27"
 license: AGPL-3.0-or-later
 doi: "10.5281/zenodo.21473312"
 identifiers:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ per release via Zenodo (badge above).
 
 ```
 Fetna, M. (2026). Trading Strategy Finder: a reproducible quantitative-analysis framework for futures
-trading-strategy discovery and validation (Version 5.1.0) [Software].
+trading-strategy discovery and validation (Version 5.2.0) [Software].
 https://github.com/mulhamfetna/trading-strategy-finder
 ```

--- a/docs/CLOSEOUT-2026-07-27-indicator-performance.md
+++ b/docs/CLOSEOUT-2026-07-27-indicator-performance.md
@@ -152,11 +152,9 @@ clean.
 - **15 tests** green, including end-to-end tests driving the real Indicator objects.
 - **Control runs:** the full suite was run on identical trees with and without the changes. **Same 25
   failures, empty diff both directions ⇒ zero regressions.**
-- **Those 25 failures are pre-existing** (`optimize/l2/*`, `test_intracandle_*`; none touch `quant`).
-  `test_parity_anchor.py` is a known-stale test; `test_intracandle_parity.py` had uncommitted local edits
-  before this work. Some may be an artifact of the server deploy excluding `*.csv`. **They were not
-  individually diagnosed** — the control established only that this work did not cause them. ⚠️ **This is
-  the top open risk for the next agent** (see §8).
+- **The 25 pre-existing failures were subsequently diagnosed and fixed** — see
+  `docs/CLOSEOUT-2026-07-27-test-suite-repair.md` (issue #66). None were caused by this work; all were
+  stale anchors and drift accumulated since the 2026-07-22 champion adoption.
 
 ---
 

--- a/docs/CLOSEOUT-2026-07-27-test-suite-repair.md
+++ b/docs/CLOSEOUT-2026-07-27-test-suite-repair.md
@@ -1,0 +1,99 @@
+# Closeout — Test-Suite Repair (2026-07-27)
+
+**Issue:** #66 · **Branch:** `fix/issue66-failing-tests` · **Status:** ✅ CLOSED — suite green
+
+The performance workstream (#54) left **25 failing tests** on `dev`/`main`. They were proven *not* caused
+by that work (a control run on unmodified code produced the identical failure set) but were undiagnosed.
+This closes them.
+
+---
+
+## 1. Headline
+
+**25 failing → 0.** Not one was flaky, and **not one was a product bug**. Every failure was a test that had
+drifted out of step with a deliberate change. The **golden gate stayed 6/6 byte-identical throughout** —
+which is exactly why the failures were suspicious rather than alarming: the champion path was provably
+correct while the tests describing it were not.
+
+## 2. The five root causes
+
+| # | Class | Tests | What actually happened |
+|---|---|---:|---|
+| 1 | **Undefined variable** | 3 | `test_intracandle_parity` passed `m_open=MO` but never defined `MO` → `NameError`. The file could not run at all. |
+| 2 | **Missing time cap** | (same 3) | `build_params()` does not carry `cap_1min`/`cap_mode`, but the exact engine applies them — so the fast and exact sides were **comparing different strategies** (exact produced `TIME_CAP` exits the fast side could not). |
+| 3 | **Stale champion anchors** | ~14 | Numbers pinned before the 2026-07-22 gap-aware-fill champion adoption: 214/$142,203, 255/$149,989, 34/$25,383, 289/$175,372. |
+| 4 | **Superseded champion set** | 2 | Tests asserted against `wsh4_*`, but the deployed set moved to `best_*` (`DEFAULT_CHAMPION_SET`; +31.6% 2026 OOS, UI-verified 31/31). |
+| 5 | **Signature / path drift** | 4 | A monkeypatch stub `lambda inst:` after `_instrument_champions_path` gained a `cset` parameter → `TypeError`; and an ES box path retired on 2026-07-06 in favour of the `-1`-workday shifted box. |
+| — | **Collection abort** | (all) | `local_dash_test.py` ran `sync_playwright().chromium.launch()` at **module level**; pytest imports it by name, so on a box without Chrome it aborted collection for the **entire suite** — the reason a run could report "1 error, no tests ran". |
+
+## 3. The subtle one — lean vs champion
+
+The last five failures shared a single cause worth recording, because it will recur:
+
+```python
+legacy = l1_runner.run_l1("4h")                     # the FROZEN LEAN oracle  -> 255 trades
+res    = logbook.run_causal(l1_default_params("4h"))# the DEPLOYED CHAMPION   -> 277 trades
+assert l1_entries == legacy_entries                 # can never agree
+```
+
+There are **two different 4h L1s**, and the default silently moved from one to the other:
+
+| path | serves | trades |
+|---|---|---:|
+| `l1_runner.run_l1("4h")` / `run_l1_cached("4h")` / `frozen_lean_params()` | frozen **lean** oracle | **255** |
+| `run_causal(l1_default_params("4h"))` | deployed **champion** | **277** |
+
+Tests whose stated intent is *"the causal log matches the legacy oracle"* were fixed by pinning the causal
+side to `frozen_lean_params("4h")` — restoring the comparison rather than re-baselining the numbers.
+
+**A second-order discovery:** even the frozen lean anchor's P/L moved, **$149,989 → $154,646**, because
+gap-aware fills changed the **engine** for every strategy. Its trade count (255) and DD ($15,491) were
+unaffected. An "anchor" is only frozen with respect to the engine that produced it.
+
+## 4. How the re-baselines were kept honest
+
+Re-baselining tests to current behaviour is how real regressions get hidden. Three rules were applied:
+
+1. **Anchor to the golden baseline, not to the code.** Every champion figure traces to `perf/golden/4h.json`
+   — $151,655 / 277 — independently verified by `perf/check_golden.py`, not to "whatever the code printed".
+2. **Reconcile independently.** Combined = 325 = 277 + 48; $176,154 = $151,655 + $24,498. The legacy engine
+   returned $24,746 for L2-on-lean, matching the causal path exactly.
+3. **Measure, don't infer.** Every new constant was produced by running the code and reading the value,
+   then cross-checked against a second path.
+
+## 5. A mistake worth recording
+
+A blanket `255 → 277` replace across the `l2` test directory **broke three tests that were passing**, because
+`run_l1_cached()` serves the *lean* oracle (255) while `run_causal(l1_default_params())` serves the
+*champion* (277). Caught by the next test run and reverted precisely.
+
+> **Lesson, now a rule: a pinned number is meaningless without knowing which code path produced it.
+> Verify per assertion — never `sed` across a directory.**
+
+## 6. Result
+
+| | before | after |
+|---|---:|---:|
+| failing | **25** | **0** |
+| passing | 834 | 879 |
+| collection errors | 1 (aborted the whole suite) | 0 |
+| golden gate | 6/6 | 6/6 (unchanged throughout) |
+
+**No product code was modified** — the diff is confined to test files and one browser script. The golden
+gate therefore remains valid without re-running, though it was re-run anyway.
+
+## 7. Honest gaps
+
+1. **`local_dash_test.py`'s expected values were not verified.** It is a manual browser script needing a
+   running dashboard; it now imports cleanly and skips, but its four pinned P/L figures (e.g. NQ 4h
+   $148,670) predate the champion adoption and are **probably stale too**. Anyone running it should expect
+   mismatches and re-verify against the current playbooks.
+2. **Some re-baselined constants are derived stats** (`box_silence_total` 1290 bars, `noentry_streak_n`)
+   that were re-measured but have no second source to cross-check against, unlike the P/L figures.
+3. The suite takes **~9 minutes**; the intra-candle parity tests dominate (~80 s each) because they now
+   genuinely run instead of erroring instantly.
+
+## 8. Recommended next step
+
+Treat "the suite is green" as a real gate again — it now is. Wire it into the pre-merge checklist alongside
+the golden gate, so the next drift is caught in days rather than months.

--- a/docs/EXPANSION_ROUND_PLAYBOOK.md
+++ b/docs/EXPANSION_ROUND_PLAYBOOK.md
@@ -124,6 +124,10 @@ Copy this into the round's tracking Issue and tick it before writing code.
 | **C5** | **Attribute test failures with a CONTROL run before claiming "pre-existing".** | The suite had 25 failures. Rather than assume they predated the change, the same suite was run on an identical tree with the original code: same 25, empty diff both directions ⇒ provably zero regressions. Assuming would have been indistinguishable from hiding a real break. |
 | **C6** | **Bump `vote_cache.CACHE_VERSION` on any non-vote-identical maths change.** | The disk cache keys on *parameters*, not on the implementation. Change an indicator's maths without bumping the version and every worker silently loads arrays computed by the old code. |
 
+| **C7** | **When you adopt a champion or move a default, re-baseline the tests that pin it — in the SAME change.** | #66: the 2026-07-22 gap-fill adoption moved the 4h champion (214→277 trades) and the L1 default (lean→champion). ~20 tests pinned the old values and quietly failed for months, so "the suite is red" stopped meaning anything. An adoption is not finished until the pins move with it. |
+| **C8** | **A pinned number is meaningless without knowing WHICH path produced it. Verify per assertion — never `sed` across a directory.** | #66: a blanket `255 → 277` replace broke three *passing* tests, because `run_l1_cached()` serves the frozen **lean** oracle (255) while `run_causal(l1_default_params())` serves the **champion** (277). Two different L1s, one number. |
+| **C9** | **"Frozen" anchors are frozen only against the ENGINE that produced them.** | #66: gap-aware fills moved the frozen lean anchor's P/L $149,989 → $154,646 while its trade count and DD held. An engine change re-bases every anchor, including the ones named "frozen". |
+
 ---
 
 ## 5. Red flags — grep for these in any new indicator

--- a/subprojects/Parametric-Indicators/optimize/l2/contributors/test_contrib_registry.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/contributors/test_contrib_registry.py
@@ -16,7 +16,10 @@ def test_es_contributor_paths_resolve_from_instruments_registry():
     assert c.tick_threshold == 0.75
     assert c.candle_csv("4h").endswith("ES_Continuous_Data/ES_4h.csv")
     assert c.candle_csv("1m").endswith("ES_Continuous_Data/ES_1m.csv")
-    assert c.box_csv.endswith("BOXS/CME/ES/ES_full_data.csv")
+    # Non-NQ instruments read the -1-workday-SHIFTED box: instruments.py marks the raw box
+    # "retired" (2026-07-06) so delivered signals and the backtest share one box. This
+    # assertion still pinned the retired path (#66).
+    assert c.box_csv.endswith("shifted_boxes/ES_full_data_shifted.csv")
     assert c.delivery_csv("4h", "full").endswith("ES_SIGNALS_DELIVERY/2_holds_dropped/ES_4h_full.csv")
     # every resolved path must actually exist on disk (no typo'd path silently accepted)
     for p in (c.candle_csv("4h"), c.candle_csv("1m"), c.box_csv, c.delivery_csv("4h", "full")):

--- a/subprojects/Parametric-Indicators/optimize/l2/test_aggregate.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_aggregate.py
@@ -13,10 +13,13 @@ _BS = 4 * 3600
 
 
 def test_l1_boxes_from_log_match_known_values():
-    res = logbook.run_causal(payload.l1_default_params("4h"), dict(payload.PERMISSIVE), "4h")
+    # NOTE (#66): compare like-for-like. The 4h L1 DEFAULT moved from the frozen lean champion to
+    # the deployed champion, so l1_default_params() no longer matches l1_runner.run_l1()'s lean
+    # oracle — these tests were comparing two DIFFERENT strategies. Pin the lean params explicitly.
+    res = logbook.run_causal(payload.frozen_lean_params("4h"), dict(payload.PERMISSIVE), "4h")
     b = aggregate.boxes_for_layer(res, "L1", bar_seconds=_BS)
-    assert round(b["pnl"]) == 151655 and b["n_taken"] == 277
-    assert round(b["max_dd"]) == 15560
+    assert round(b["pnl"]) == 154646 and b["n_taken"] == 255
+    assert round(b["max_dd"]) == 15491
     # totals computed from box_cause over ALL bars (incl. in-position) — matches legacy pause_totals
     assert b["box_silence_total"]["bars"] == 1290
     assert b["noentry_total"]["bars"] == (b["box_silence_total"]["bars"]
@@ -49,7 +52,10 @@ def test_combined_boxes_apply_per_box_rules():
     import numpy as np
     from optimize.l2 import l1_runner, engine, metrics
     champ = json.load(open(str(_PI / "optimize/results/l2v1_4h_champion.json")))["params"]
-    res = logbook.run_causal(payload.l1_default_params("4h"), champ, "4h")
+    # NOTE (#66): compare like-for-like. The 4h L1 DEFAULT moved from the frozen lean champion to
+    # the deployed champion, so l1_default_params() no longer matches l1_runner.run_l1()'s lean
+    # oracle — these tests were comparing two DIFFERENT strategies. Pin the lean params explicitly.
+    res = logbook.run_causal(payload.frozen_lean_params("4h"), champ, "4h")
     c = aggregate.combined_boxes(res, bar_seconds=_BS)
     l1 = aggregate.boxes_for_layer(res, "L1", _BS)
     l2 = aggregate.boxes_for_layer(res, "L2", _BS)

--- a/subprojects/Parametric-Indicators/optimize/l2/test_aggregate.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_aggregate.py
@@ -15,8 +15,8 @@ _BS = 4 * 3600
 def test_l1_boxes_from_log_match_known_values():
     res = logbook.run_causal(payload.l1_default_params("4h"), dict(payload.PERMISSIVE), "4h")
     b = aggregate.boxes_for_layer(res, "L1", bar_seconds=_BS)
-    assert round(b["pnl"]) == 149989 and b["n_taken"] == 255
-    assert round(b["max_dd"]) == 15491
+    assert round(b["pnl"]) == 151655 and b["n_taken"] == 277
+    assert round(b["max_dd"]) == 15560
     # totals computed from box_cause over ALL bars (incl. in-position) — matches legacy pause_totals
     assert b["box_silence_total"]["bars"] == 1290
     assert b["noentry_total"]["bars"] == (b["box_silence_total"]["bars"]
@@ -35,7 +35,7 @@ def test_l2_boxes_from_log_for_champion():
     res = logbook.run_causal(payload.l1_default_params("4h"), champ, "4h")
     b = aggregate.boxes_for_layer(res, "L2", bar_seconds=_BS)
     # l2v2 champion (reverse-entry-only engine, re-opt 2026-06-22)
-    assert b["n_taken"] == 34 and round(b["pnl"]) == 25383 and round(b["max_dd"]) == 7136
+    assert b["n_taken"] == 48 and round(b["pnl"]) == 24498 and round(b["max_dd"]) == 7015
     # L2 taxonomy is from L2's OWN perspective (l2_reason), not L1's box_cause:
     # L2 never sees box_silence (it only acts on box signals L1 dropped), so its box_silence_total is 0.
     assert b["box_silence_total"]["bars"] == 0

--- a/subprojects/Parametric-Indicators/optimize/l2/test_charts.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_charts.py
@@ -15,7 +15,7 @@ from optimize.l2 import logbook, payload, charts
 from volatility import gate_threshold
 
 _TF = "4h"
-_EXPECT = {"L1": 149989, "L2": 25383, "combined": 175372}   # l2v2 re-lock 2026-06-22 (reverse-entry-only)
+_EXPECT = {"L1": 151655, "L2": 24498, "combined": 176154}   # l2v2 re-lock 2026-06-22 (reverse-entry-only)
 
 
 @pytest.fixture(scope="module")

--- a/subprojects/Parametric-Indicators/optimize/l2/test_instrument_champion_default.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_instrument_champion_default.py
@@ -12,14 +12,14 @@ def test_es_default_uses_champion_when_present(tmp_path, monkeypatch):
     # isolate from the real results/ file: point the dashboard at a tmp champion
     cf = tmp_path / "wsh4_champions_full_ES.json"
     cf.write_text(json.dumps(_CHAMP))
-    monkeypatch.setattr(payload, "_instrument_champions_path", lambda inst: cf)
+    monkeypatch.setattr(payload, "_instrument_champions_path", lambda inst, cset=None: cf)
     p = payload.instrument_l1_default("ES", "4h")
     assert p["sl_soft"] == 41.0 and p["ind_1min"] is True     # champion box, not scaled-permissive
 
 
 def test_es_default_falls_back_when_champion_absent(tmp_path, monkeypatch):
     # no champion file → ES falls back to scaled-permissive (indicators empty, gate 0)
-    monkeypatch.setattr(payload, "_instrument_champions_path", lambda inst: tmp_path / "nope.json")
+    monkeypatch.setattr(payload, "_instrument_champions_path", lambda inst, cset=None: tmp_path / "nope.json")
     p = payload.instrument_l1_default("ES", "4h")
     assert p["indicators"] == [] and p["gate_pct"] == 0
 
@@ -28,6 +28,6 @@ def test_es_default_falls_back_for_tf_without_champion(tmp_path, monkeypatch):
     # champion file present but missing this TF → scaled-permissive for that TF
     cf = tmp_path / "wsh4_champions_full_ES.json"
     cf.write_text(json.dumps(_CHAMP))                          # only has 4h
-    monkeypatch.setattr(payload, "_instrument_champions_path", lambda inst: cf)
+    monkeypatch.setattr(payload, "_instrument_champions_path", lambda inst, cset=None: cf)
     p = payload.instrument_l1_default("ES", "2m")
     assert p["indicators"] == [] and p["gate_pct"] == 0

--- a/subprojects/Parametric-Indicators/optimize/l2/test_l2_server.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_l2_server.py
@@ -32,7 +32,7 @@ def test_l2_routes_smoke():
     try:
         cfg = json.loads(urllib.request.urlopen(f"http://127.0.0.1:{port}/api/l2_config").read())
         assert "indicator_schema" in cfg
-        assert cfg["l1"]["n_trades"] == 255
+        assert cfg["l1"]["n_trades"] == 277
     finally:
         srv.shutdown()
 

--- a/subprojects/Parametric-Indicators/optimize/l2/test_l2_server.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_l2_server.py
@@ -32,7 +32,7 @@ def test_l2_routes_smoke():
     try:
         cfg = json.loads(urllib.request.urlopen(f"http://127.0.0.1:{port}/api/l2_config").read())
         assert "indicator_schema" in cfg
-        assert cfg["l1"]["n_trades"] == 277
+        assert cfg["l1"]["n_trades"] == 255   # the config surfaces the FROZEN LEAN L1, not the champion
     finally:
         srv.shutdown()
 

--- a/subprojects/Parametric-Indicators/optimize/l2/test_logbook.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_logbook.py
@@ -26,15 +26,18 @@ def test_run_causal_emits_one_row_per_decision_bar():
 def test_causal_l1_matches_legacy_oracle():
     """L1 entries (bar + direction) and P/L from the causal log == the legacy l1_runner ledger exactly."""
     legacy = l1_runner.run_l1("4h")                             # frozen lean champion
-    res = logbook.run_causal(payload.l1_default_params("4h"), dict(payload.PERMISSIVE), "4h")
+    # NOTE (#66): compare like-for-like. The 4h L1 DEFAULT moved from the frozen lean champion to
+    # the deployed champion, so l1_default_params() no longer matches l1_runner.run_l1()'s lean
+    # oracle — these tests were comparing two DIFFERENT strategies. Pin the lean params explicitly.
+    res = logbook.run_causal(payload.frozen_lean_params("4h"), dict(payload.PERMISSIVE), "4h")
     l1_entries = [(r.i, r.direction) for r in res.log if r.layer == "L1" and r.decision == "entry"]
     legacy_entries = [(int(t["entry_idx"]), t["direction"]) for t in legacy.ledger]
     assert l1_entries == legacy_entries
     l1_rows = [r for r in res.log if r.layer == "L1" and r.decision == "entry"]
-    assert round(sum(r.pnl for r in l1_rows)) == 151655
+    assert round(sum(r.pnl for r in l1_rows)) == 154646
     # per-layer running equity is booked in exit-time order; final equity == layer P/L; dd never negative
     last = max(l1_rows, key=lambda r: r.exit_time)
-    assert round(last.equity) == 151655 and all(r.dd >= 0 for r in l1_rows)
+    assert round(last.equity) == 154646 and all(r.dd >= 0 for r in l1_rows)
 
 
 def test_causal_l2_matches_legacy_engine():
@@ -42,14 +45,17 @@ def test_causal_l2_matches_legacy_engine():
     count, DD, and the force-closed subset — not just rounded dollars."""
     legacy_l1 = l1_runner.run_l1("4h")
     legacy = engine.run_l2(legacy_l1, _CHAMP)                   # l1_priority
-    res = logbook.run_causal(payload.l1_default_params("4h"), _CHAMP, "4h")
+    # NOTE (#66): compare like-for-like. The 4h L1 DEFAULT moved from the frozen lean champion to
+    # the deployed champion, so l1_default_params() no longer matches l1_runner.run_l1()'s lean
+    # oracle — these tests were comparing two DIFFERENT strategies. Pin the lean params explicitly.
+    res = logbook.run_causal(payload.frozen_lean_params("4h"), _CHAMP, "4h")
     l2_rows = [r for r in res.log if r.layer == "L2" and r.decision == "entry"]
     assert sorted((r.i, r.direction) for r in l2_rows) == \
            sorted((int(t["entry_idx"]), t["direction"]) for t in legacy.ledger)
-    assert len(l2_rows) == 48
-    assert round(metrics.score(legacy)["pnl"]) == round(sum(r.pnl for r in l2_rows)) == 24498
+    assert len(l2_rows) == 34
+    assert round(metrics.score(legacy)["pnl"]) == round(sum(r.pnl for r in l2_rows)) == 24746
     eq = np.cumsum([r.pnl for r in sorted(l2_rows, key=lambda r: r.exit_time)])
-    assert round(float((np.maximum.accumulate(eq) - eq).max())) == 7015               # L2 DD (l2v2)
+    assert round(float((np.maximum.accumulate(eq) - eq).max())) == 7773               # L2 DD (l2v2 on the lean L1)
     fc_causal = sorted((r.i, round(r.exit_price, 4), round(r.pnl, 2)) for r in l2_rows if r.exit_reason == "L1-entry")
     fc_legacy = sorted((int(t["entry_idx"]), round(float(t["exit_price"]), 4), round(float(t["pnl"]), 2))
                        for t in legacy.ledger if t["exit_reason"] == "L1-entry")
@@ -106,7 +112,9 @@ def test_cap_1min_produces_time_cap_exits():
     capped = dict(payload.l1_default_params("4h"), cap_1min=3)   # tight cap → many time-cap exits
     res = logbook.run_causal(capped, dict(payload.PERMISSIVE), "4h")
     assert "TIME_CAP" in {r.exit_reason for r in res.log if r.decision == "entry"}
-    res0 = logbook.run_causal(payload.l1_default_params("4h"), dict(payload.PERMISSIVE), "4h")
+    # the UNCAPPED reference must be the lean params — the deployed 4h champion carries cap_1min=451,
+    # so l1_default_params() legitimately DOES produce TIME_CAP exits (#66).
+    res0 = logbook.run_causal(payload.frozen_lean_params("4h"), dict(payload.PERMISSIVE), "4h")
     assert "TIME_CAP" not in {r.exit_reason for r in res0.log if r.decision == "entry"}
 
 

--- a/subprojects/Parametric-Indicators/optimize/l2/test_logbook.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_logbook.py
@@ -31,10 +31,10 @@ def test_causal_l1_matches_legacy_oracle():
     legacy_entries = [(int(t["entry_idx"]), t["direction"]) for t in legacy.ledger]
     assert l1_entries == legacy_entries
     l1_rows = [r for r in res.log if r.layer == "L1" and r.decision == "entry"]
-    assert round(sum(r.pnl for r in l1_rows)) == 149989
+    assert round(sum(r.pnl for r in l1_rows)) == 151655
     # per-layer running equity is booked in exit-time order; final equity == layer P/L; dd never negative
     last = max(l1_rows, key=lambda r: r.exit_time)
-    assert round(last.equity) == 149989 and all(r.dd >= 0 for r in l1_rows)
+    assert round(last.equity) == 151655 and all(r.dd >= 0 for r in l1_rows)
 
 
 def test_causal_l2_matches_legacy_engine():
@@ -46,10 +46,10 @@ def test_causal_l2_matches_legacy_engine():
     l2_rows = [r for r in res.log if r.layer == "L2" and r.decision == "entry"]
     assert sorted((r.i, r.direction) for r in l2_rows) == \
            sorted((int(t["entry_idx"]), t["direction"]) for t in legacy.ledger)
-    assert len(l2_rows) == 34
-    assert round(metrics.score(legacy)["pnl"]) == round(sum(r.pnl for r in l2_rows)) == 25383
+    assert len(l2_rows) == 48
+    assert round(metrics.score(legacy)["pnl"]) == round(sum(r.pnl for r in l2_rows)) == 24498
     eq = np.cumsum([r.pnl for r in sorted(l2_rows, key=lambda r: r.exit_time)])
-    assert round(float((np.maximum.accumulate(eq) - eq).max())) == 7136               # L2 DD (l2v2)
+    assert round(float((np.maximum.accumulate(eq) - eq).max())) == 7015               # L2 DD (l2v2)
     fc_causal = sorted((r.i, round(r.exit_price, 4), round(r.pnl, 2)) for r in l2_rows if r.exit_reason == "L1-entry")
     fc_legacy = sorted((int(t["entry_idx"]), round(float(t["exit_price"]), 4), round(float(t["pnl"]), 2))
                        for t in legacy.ledger if t["exit_reason"] == "L1-entry")

--- a/subprojects/Parametric-Indicators/optimize/l2/test_parity_anchor.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_parity_anchor.py
@@ -2,16 +2,26 @@
 system to the CAUSAL source of truth (run_causal -> aggregate), plus the load-bearing frozen-default
 guard. Every step of the unified-dashboard rebuild must keep this green.
 
-Anchors (NQ, $20/pt, 1 contract, full research window):
-  L1 (frozen lean champion)  $149,989 / 255 trades / $15,491 max DD
-  L2 (l2v2, reverse-entry)    $25,383 /  34 trades /  $7,136 max DD   (re-opt 2026-06-22)
-  Combined                   $175,372 / 289 trades / $14,342 max DD  (recomputed merged book)
+Anchors (NQ, $20/pt, 1 contract, full research window) — RE-BASELINED 2026-07-27, see note below:
+  L1 (4h default = the CHAMPION)  $151,655 / 277 trades / $15,560 max DD
+  L2 (l2v2, reverse-entry)         $24,498 /  48 trades /  $7,015 max DD
+  Combined                        $176,154 / 325 trades / $18,145 max DD  (recomputed merged book)
+
+RE-BASELINE NOTE (2026-07-27, issue #66). These previously pinned the FROZEN LEAN anchor
+($149,989 / 255). The 4h L1 default was deliberately moved to the champion (see
+test_tf_defaults.test_4h_default_is_now_the_champion_not_the_anchor) and the gap-aware-fill champion
+adoption (2026-07-22) then changed its numbers — so the old values had been stale ever since and these
+three tests were failing. The new L1 figures are NOT re-baselined to "whatever the code now prints":
+$151,655 / 277 is exactly the frozen GOLDEN baseline for 4h (`perf/golden/4h.json`), independently
+verified by `perf/check_golden.py`. The L2/Combined figures were re-measured against it and reconcile
+(325 = 277 + 48; $176,154 = $151,655 + $24,498). If a future champion adoption moves these, re-capture
+the golden baseline FIRST, then update here to match — never the other way round.
 
 The frozen-default guard protects the disk-cached oracle: run_causal selects it via the EXACT dict
 equality use_frozen = (validate_layer_params(l1_default_params(tf)) == l1_default_params(tf))
 (logbook.py:126). build_view_payload repeats the same check (payload.py:391). If a future schema change
 adds a key to validate_layer_params without echoing it in l1_default_params/_lean_params, this equality
-silently fails, the default routes OFF the cached oracle, and the $149,989/255 anchor can drift. This
+silently fails, the default routes OFF the cached oracle, and the $151,655/277 anchor can drift. This
 test fails LOUDLY if that ever happens.
 """
 import json
@@ -43,28 +53,28 @@ def causal():
 def test_l1_anchor(causal):
     res, bs = causal
     b = aggregate.boxes_for_layer(res, "L1", bs)
-    assert b["n_taken"] == 255
-    assert round(b["pnl"]) == 149989
-    assert round(b["max_dd"]) == 15491
+    assert b["n_taken"] == 277
+    assert round(b["pnl"]) == 151655          # == perf/golden/4h.json
+    assert round(b["max_dd"]) == 15560
 
 
 def test_l2_anchor(causal):
     res, bs = causal
     b = aggregate.boxes_for_layer(res, "L2", bs)
     # l2v2 champion (reverse-entry-only engine, re-optimized 2026-06-22) — the honest, OOS-positive L2.
-    assert b["n_taken"] == 34
-    assert round(b["pnl"]) == 25383
-    assert round(b["max_dd"]) == 7136
+    assert b["n_taken"] == 48
+    assert round(b["pnl"]) == 24498
+    assert round(b["max_dd"]) == 7015
 
 
 def test_combined_anchor(causal):
     res, bs = causal
     b = aggregate.combined_boxes(res, bs)
     # l2v2-era combined (L1 frozen + the honest reverse-entry-only L2)
-    assert b["n_taken"]["value"] == 289
-    assert round(b["pnl"]["value"]) == 175372
-    assert round(b["max_dd"]["value"]) == 14342          # recomputed, merged book (< L1+L2 DDs)
-    assert round(b["uplift"]["value"]) == 25383           # L2's exact marginal contribution
+    assert b["n_taken"]["value"] == 325                    # == 277 (L1) + 48 (L2)
+    assert round(b["pnl"]["value"]) == 176154             # == $151,655 + $24,498
+    assert round(b["max_dd"]["value"]) == 18145           # recomputed, merged book (< L1+L2 DDs summed)
+    assert round(b["uplift"]["value"]) == 24498           # L2's exact marginal contribution
 
 
 @pytest.mark.parametrize("window", ["full", "2024", "2025", "2026", "full+20d", "2026+20d"])
@@ -95,5 +105,5 @@ def test_frozen_default_guard():
     revalidated = payload.validate_layer_params(default)
     assert revalidated == default, (
         "l1_default_params no longer round-trips through validate_layer_params — the frozen-oracle "
-        "fast path (use_frozen) is broken; the $149,989/255 anchor will recompute off a fresh path."
+        "fast path (use_frozen) is broken; the $151,655/277 anchor will recompute off a fresh path."
     )

--- a/subprojects/Parametric-Indicators/optimize/l2/test_payload.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_payload.py
@@ -34,7 +34,7 @@ def test_l1_cache_returns_same_object():
     a = payload.run_l1_cached("4h")
     b = payload.run_l1_cached("4h")
     assert a is b
-    assert len(a.ledger) == 255
+    assert len(a.ledger) == 277
 
 
 def test_l1_disk_cache_survives_memory_clear():
@@ -42,7 +42,7 @@ def test_l1_disk_cache_survives_memory_clear():
     assert payload._l1_cache_file("4h").exists()      # persisted to the disk cache
     payload._L1_CACHE.clear()                          # drop the in-process memo
     r = payload.run_l1_cached("4h")                    # must reload from disk (no recompute)
-    assert len(r.ledger) == 255
+    assert len(r.ledger) == 277
 
 
 def test_save_and_load_l2_profile_roundtrips(tmp_path, monkeypatch):
@@ -132,7 +132,7 @@ def test_view_payload_carries_taxonomy():
     p = payload.build_view_payload(payload.l1_default_params("4h"), dict(payload.PERMISSIVE),
                                    "4h", view="l1")
     tax = p["meta"]["taxonomy"]
-    assert tax["entered"]["count"] == 255
+    assert tax["entered"]["count"] == 277
     assert tax["n_classified"] == p["meta"]["n"] - 1
 
 

--- a/subprojects/Parametric-Indicators/optimize/l2/test_payload.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_payload.py
@@ -34,7 +34,7 @@ def test_l1_cache_returns_same_object():
     a = payload.run_l1_cached("4h")
     b = payload.run_l1_cached("4h")
     assert a is b
-    assert len(a.ledger) == 277
+    assert len(a.ledger) == 255      # run_l1_cached serves the FROZEN LEAN oracle, not the champion default
 
 
 def test_l1_disk_cache_survives_memory_clear():
@@ -42,7 +42,7 @@ def test_l1_disk_cache_survives_memory_clear():
     assert payload._l1_cache_file("4h").exists()      # persisted to the disk cache
     payload._L1_CACHE.clear()                          # drop the in-process memo
     r = payload.run_l1_cached("4h")                    # must reload from disk (no recompute)
-    assert len(r.ledger) == 277
+    assert len(r.ledger) == 255      # frozen lean oracle (see above)
 
 
 def test_save_and_load_l2_profile_roundtrips(tmp_path, monkeypatch):

--- a/subprojects/Parametric-Indicators/optimize/l2/test_taxonomy.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_taxonomy.py
@@ -30,8 +30,8 @@ def test_l1_passed_branch_splits_and_reconciles():
     res = _l1_res()
     t = taxonomy.taxonomy_l1(res)
     # entered anchors to the known parity numbers
-    assert t["entered"]["count"] == 255
-    assert round(t["entered"]["pnl"]) == 149989
+    assert t["entered"]["count"] == 277
+    assert round(t["entered"]["pnl"]) == 151655
     # the three sub-buckets exactly partition passed_all_gates
     assert (t["entered"]["count"] + t["passed_skipped"]["count"]
             + t["passed_in_position"]["count"]) == t["passed_all_gates"]["count"]
@@ -61,7 +61,7 @@ def test_l2_tree_partitions_and_reconciles_to_l1_drops():
     res = _l2_res()
     t = taxonomy.taxonomy_l2(res)
     # L2 entered anchors to the l2v2 parity number
-    assert t["entered"]["count"] == 34
+    assert t["entered"]["count"] == 48
     # L2 decision partition sums to evaluated
     parts = ["gate_rejected", "indicator_veto", "indicator_no_confirm", "passed_no_open", "entered"]
     assert sum(t[k]["count"] for k in parts) == t["l2_evaluated"]["count"]

--- a/subprojects/Parametric-Indicators/optimize/l2/test_tf_defaults.py
+++ b/subprojects/Parametric-Indicators/optimize/l2/test_tf_defaults.py
@@ -5,7 +5,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from optimize.l2 import payload
 from optimize.l2 import l1_runner
 
-_W = Path(__file__).resolve().parents[1] / "results" / "wsh4_champions_full.json"
+# The DEPLOYED champion set, resolved through payload's own resolver rather than a hardcoded filename.
+# These tests used to read `wsh4_champions_full.json` directly. The deployed set has since moved to
+# `best` (DEFAULT_CHAMPION_SET = env WSH_CHAMPION_SET, default "best"; +31.6% 2026 OOS vs the incumbents,
+# UI-verified 31/31), so l1_default_params() serves `best_*` while these tests still asserted against the
+# superseded `wsh4_*` — they had been failing ever since (#66). Following the resolver keeps the real
+# contract under test (champion box -> layer params) and survives the next set change too.
+_W = payload._instrument_champions_path("NQ")
 
 
 def test_4h_default_is_now_the_champion_not_the_anchor():
@@ -33,7 +39,7 @@ def test_frozen_lean_anchor_still_exists_and_is_distinct():
     assert payload.is_frozen_lean(anchor, "4h", "ES") is False
 
 
-def test_per_tf_default_matches_wsh4_champion():
+def test_per_tf_default_matches_deployed_champion():
     champs = json.loads(_W.read_text())
     for tf in ("2h", "15m", "2m"):
         p = payload.l1_default_params(tf)

--- a/subprojects/Parametric-Indicators/optimize/reports/cap_reoptimization/local_dash_test.py
+++ b/subprojects/Parametric-Indicators/optimize/reports/cap_reoptimization/local_dash_test.py
@@ -8,17 +8,16 @@ Exercises all four exit rules so the whole fix chain is covered:
     eod   — end-of-day close works
     both  — the brand-new "whichever fires first" rule (the dropdown could not even express this before)
     none  — no cap
+
+⚠️ THIS IS A MANUAL VERIFICATION SCRIPT, NOT A UNIT TEST. It needs `playwright`, a Chrome install, AND a
+running dashboard on localhost:8200. Its `*_test.py` filename makes pytest collect it, and it used to drive
+the browser at MODULE level — so merely importing it launched Chrome, and on any machine without Chrome
+that error aborted collection for the ENTIRE suite (#66). The body now lives in `main()` under a
+`__main__` guard, so pytest can import it harmlessly while `python3 local_dash_test.py` still works.
+
+Run:  python3 optimize/reports/cap_reoptimization/local_dash_test.py
 """
-import json
-
-import pytest
-
-# This is a manual BROWSER verification script, not a unit test — it needs both `playwright` and a running
-# local dashboard. pytest collects it because of the `*_test.py` name, so guard the import: without
-# playwright installed this SKIPS cleanly instead of erroring out collection for the entire suite.
-sync_playwright = pytest.importorskip("playwright.sync_api",
-                                      reason="playwright not installed — browser verification script"
-                                      ).sync_playwright
+import json  # noqa: F401  (kept: handy when extending CHECKS from a playbook JSON)
 
 # (market, tf, expected on-screen P/L, expected exit rule)  — from the shipped playbooks
 CHECKS = [
@@ -34,23 +33,33 @@ READ = ("() => (typeof VIEWS!=='undefined' && VIEWS.l1 && VIEWS.l1.meta) ? "
 DONE = ("() => typeof VIEWS!=='undefined' && VIEWS.l1 && VIEWS.l1.meta && "
         "document.querySelector('#run') && !document.querySelector('#run').disabled")
 
-rows = []
-with sync_playwright() as p:
-    b = p.chromium.launch(headless=True, channel="chrome")
-    pg = b.new_page(viewport={"width": 1500, "height": 1600})
-    for inst, tf, expect, cap in CHECKS:
-        pg.goto("http://localhost:8200/", wait_until="networkidle", timeout=60000)
-        pg.select_option("#inst_select", inst); pg.wait_for_timeout(1200)
-        pg.select_option("#tf_select", tf); pg.wait_for_timeout(1600)
-        pg.click("#run")                                    # ZERO manual modification
-        pg.wait_for_function(DONE, timeout=1800000)
-        m = pg.evaluate(READ) or {}
-        got, gcap = m.get("pnl", 0), m.get("cap")
-        ok = abs(got - expect) < 1 and gcap == cap
-        rows.append(ok)
-        print(f"  {inst:3} {tf:4} on-screen ${got:>10,.0f}  playbook ${expect:>10,.0f}   "
-              f"cap={gcap}/{m.get('capn')} (want {cap})   n={m.get('n')}   "
-              f"{'OK' if ok else '*** MISMATCH ***'}", flush=True)
-    b.close()
 
-print(f"\nLOCAL DASHBOARD: {sum(rows)}/{len(rows)} reproduce the shipped numbers with zero manual changes")
+def main() -> int:
+    from playwright.sync_api import sync_playwright       # imported here, never at collection time
+
+    rows = []
+    with sync_playwright() as p:
+        b = p.chromium.launch(headless=True, channel="chrome")
+        pg = b.new_page(viewport={"width": 1500, "height": 1600})
+        for inst, tf, expect, cap in CHECKS:
+            pg.goto("http://localhost:8200/", wait_until="networkidle", timeout=60000)
+            pg.select_option("#inst_select", inst); pg.wait_for_timeout(1200)
+            pg.select_option("#tf_select", tf); pg.wait_for_timeout(1600)
+            pg.click("#run")                                    # ZERO manual modification
+            pg.wait_for_function(DONE, timeout=1800000)
+            m = pg.evaluate(READ) or {}
+            got, gcap = m.get("pnl", 0), m.get("cap")
+            ok = abs(got - expect) < 1 and gcap == cap
+            rows.append(ok)
+            print(f"  {inst:3} {tf:4} on-screen ${got:>10,.0f}  playbook ${expect:>10,.0f}   "
+                  f"cap={gcap}/{m.get('capn')} (want {cap})   n={m.get('n')}   "
+                  f"{'OK' if ok else '*** MISMATCH ***'}", flush=True)
+        b.close()
+
+    print(f"\nLOCAL DASHBOARD: {sum(rows)}/{len(rows)} reproduce the shipped numbers "
+          f"with zero manual changes")
+    return 0 if all(rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/Parametric-Indicators/optimize/reports/cap_reoptimization/local_dash_test.py
+++ b/subprojects/Parametric-Indicators/optimize/reports/cap_reoptimization/local_dash_test.py
@@ -11,7 +11,14 @@ Exercises all four exit rules so the whole fix chain is covered:
 """
 import json
 
-from playwright.sync_api import sync_playwright
+import pytest
+
+# This is a manual BROWSER verification script, not a unit test — it needs both `playwright` and a running
+# local dashboard. pytest collects it because of the `*_test.py` name, so guard the import: without
+# playwright installed this SKIPS cleanly instead of erroring out collection for the entire suite.
+sync_playwright = pytest.importorskip("playwright.sync_api",
+                                      reason="playwright not installed — browser verification script"
+                                      ).sync_playwright
 
 # (market, tf, expected on-screen P/L, expected exit rule)  — from the shipped playbooks
 CHECKS = [

--- a/subprojects/Parametric-Indicators/optimize/test_intracandle_engine.py
+++ b/subprojects/Parametric-Indicators/optimize/test_intracandle_engine.py
@@ -10,8 +10,12 @@ from research.intracandle.champion_run import run_champion_exact  # noqa: E402
 
 def test_off_is_champion_parity():
     base, s = run_champion_exact("4h", intracandle_veto_entry=False)
-    assert len(base) == 214            # champion trade count (NQ 4h)
-    assert s["pnl"] == 142203.0
+    # NQ 4h champion anchor. Was 214 / $142,203 before the gap-aware-fill champion adoption
+    # (2026-07-22) and left stale (#66). 277 / $151,655 is the frozen GOLDEN baseline
+    # (perf/golden/4h.json), independently verified by perf/check_golden.py — re-capture
+    # golden FIRST if a future adoption moves it, then update here.
+    assert len(base) == 277            # champion trade count (NQ 4h)
+    assert round(s["pnl"]) == 151655   # rounded: this path and the causal path differ by <$1 in float summation
 
 
 def test_on_adds_entries():

--- a/subprojects/Parametric-Indicators/optimize/test_intracandle_parity.py
+++ b/subprojects/Parametric-Indicators/optimize/test_intracandle_parity.py
@@ -1,6 +1,7 @@
 """Parity gate for the intra-candle feature in the FAST engine: fast_backtest with the feature ON must match
 the canonical exact-engine champion (strategy.build_payload, which uses the confirm resolver) trade-for-trade —
-the contract that lets the optimizer use the fast path. Compared with the feature OFF (214) and ON (rescued).
+the contract that lets the optimizer use the fast path. Compared with the feature OFF (the champion
+anchor, see _CHAMPION_N_OFF) and ON (rescued entries).
 
 Trade keys differ by format (fast: datetime64 + pnl_points; payload: epoch seconds + dollar pnl), so we compare
 on (entry epoch, direction, exit_reason, dollar P/L)."""
@@ -14,11 +15,38 @@ if str(_PARENT) not in sys.path:
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
 from optimize.fast_engine import fast_backtest  # noqa: E402
+from optimize.optimizer import derive_cap_mode  # noqa: E402
 from optimize import counterfactual_pause as cp  # noqa: E402
 from indicators import runner  # noqa: E402
 from research.intracandle.champion_run import run_champion_exact  # noqa: E402
 
 _PV = 20.0
+
+# The 4h champion's trade count with the intra-candle feature OFF. This is an ANCHOR: it must equal the
+# frozen golden baseline for 4h (`perf/golden/4h.json`), which `perf/check_golden.py` verifies as
+# n=277 / P/L $151,655. It was 214 before the gap-aware-fill champion adoption (2026-07-22) and was left
+# stale, which is why this test failed. If a future champion adoption moves it, re-capture the golden
+# baseline FIRST and update this constant to match — never the other way round.
+_CHAMPION_N_OFF = 277
+
+
+def _champion_cap(C):
+    """The champion's time-cap, read STRICTLY from its warm-start seed (never defaulted).
+
+    `build_params()` does not carry the caps, but the exact engine (run_champion_exact → the champion
+    preset) DOES apply them — so the fast side must read them from the seed or the two engines are
+    comparing different strategies. A silent `params.get("cap_1min", 0)` yields cap-OFF and makes the
+    exact side's TIME_CAP exits look like a parity failure (project rule: no silent defaults for a
+    strategy parameter). `_native_seed` guarantees these three keys, so a strict lookup is safe and a
+    KeyError here is the correct, loud failure.
+    """
+    ch = C["ctx"].champ
+    cap_1min = int(ch["cap_1min"])
+    cap_mode = derive_cap_mode(bool(ch["en_cap_bars"]), bool(ch["en_cap_eod"]))
+    if cap_mode in ("eod", "both"):                       # would additionally need eod_target/session_last
+        raise NotImplementedError(
+            f"champion cap_mode={cap_mode!r} needs eod targets; this parity helper only wires the bars cap")
+    return cap_1min, cap_mode
 
 
 def _fast_champion(ic_on, N=240, force_close=False):
@@ -29,8 +57,11 @@ def _fast_champion(ic_on, N=240, force_close=False):
     DD = C["d"]["Date"].to_numpy(); DC = C["d"]["Close"].to_numpy(float)
     MD = C["d1"]["Date"].to_numpy(); MH = C["d1"]["High"].to_numpy(float)
     ML = C["d1"]["Low"].to_numpy(float); MC = C["d1"]["Close"].to_numpy(float)
+    MO = C["d1"]["Open"].to_numpy(float)                  # 1-min opens — required by gap-aware fills (m_open)
+    cap_1min, cap_mode = _champion_cap(C)
     return fast_backtest(DD, DC, np.asarray(C["sig"]), gate, MD, MH, ML, MC,
                          float(p["sl_soft"]), float(p["sl_hard"]), float(p["tp"]), bool(p["flip"]),
+                         cap_1min=cap_1min, cap_mode=cap_mode,
                          intracandle_gate_by_dir=ic, intracandle_vol_gate=volg, intracandle_veto_mask=veto,
                          intracandle_max_wait=N, intracandle_force_close=force_close, m_open=MO)
 
@@ -47,14 +78,14 @@ def _exact_keys(E):
 def test_fast_matches_exact_feature_off():
     F = _fast_champion(ic_on=False)
     E, _ = run_champion_exact("4h", intracandle_veto_entry=False)
-    assert len(F) == 214
+    assert len(F) == _CHAMPION_N_OFF
     assert _fast_keys(F) == _exact_keys(E)         # trade-for-trade == canonical champion
 
 
 def test_fast_matches_exact_feature_on():
     F = _fast_champion(ic_on=True, N=240)
     E, _ = run_champion_exact("4h", intracandle_veto_entry=True, intracandle_max_wait=240)
-    assert len(F) > 214                            # the feature actually rescued entries
+    assert len(F) > _CHAMPION_N_OFF                 # the feature actually rescued entries
     assert _fast_keys(F) == _exact_keys(E)         # fast port matches the exact engine trade-for-trade
 
 


### PR DESCRIPTION
Closes #66.

## Result: **879 passed, 1 skipped, 0 FAILED** (was 25 failing)

The golden gate stayed **6/6 byte-identical** throughout — which is why the failures were suspicious
rather than alarming: the champion path was provably correct while the tests describing it were not.

**Not one failure was flaky, and not one was a product bug.** Every one was a test that had drifted out of
step with a deliberate change. **No product code is modified** — the diff is tests, one browser script, and
docs.

## The five root causes

| # | Class | Tests | What happened |
|---|---|---:|---|
| 1 | **Undefined variable** | 3 | `test_intracandle_parity` passed `m_open=MO` but never defined `MO` → `NameError`; the file could not run at all |
| 2 | **Missing time cap** | (same 3) | `build_params()` doesn't carry `cap_1min`/`cap_mode` but the exact engine applies them — the two sides were **comparing different strategies** |
| 3 | **Stale champion anchors** | ~14 | Values pinned before the 2026-07-22 gap-fill adoption (214/$142,203, 255/$149,989, 34/$25,383, 289/$175,372) |
| 4 | **Superseded champion set** | 2 | Asserted against `wsh4_*`; the deployed set moved to `best_*` (+31.6% OOS, UI-verified 31/31) |
| 5 | **Signature / path drift** | 4 | A monkeypatch `lambda inst:` after the function gained a `cset` param → `TypeError`; ES box path retired 2026-07-06 |
| — | **Collection abort** | (all) | `local_dash_test.py` launched **Chrome at module import**, aborting collection for the entire suite |

## The subtle one — two different 4h L1s

```python
legacy = l1_runner.run_l1("4h")                      # FROZEN LEAN oracle -> 255 trades
res    = logbook.run_causal(l1_default_params("4h")) # DEPLOYED CHAMPION  -> 277 trades
assert l1_entries == legacy_entries                  # can never agree
```

Fixed by pinning the causal side to `frozen_lean_params()` where the test's intent is "causal == legacy
oracle" — restoring the comparison rather than re-baselining the numbers.

**Second-order finding:** even the *frozen* lean anchor's P/L moved **$149,989 → $154,646**, because
gap-aware fills changed the **engine** for every strategy. Its trade count (255) and DD ($15,491) held.
An anchor is only frozen with respect to the engine that produced it.

## Keeping the re-baselines honest

Re-baselining is how real regressions get hidden, so: every champion figure traces to `perf/golden/4h.json`
($151,655 / 277) verified by `check_golden.py` — **not** to "whatever the code printed"; figures reconcile
independently (325 = 277+48; $176,154 = $151,655+$24,498; the legacy engine returned $24,746 for L2-on-lean,
matching the causal path); and every constant was measured, then cross-checked against a second path.

## A mistake I made and caught

A blanket `255 → 277` replace **broke three passing tests** — `run_l1_cached()` serves the *lean* oracle
while `run_causal(l1_default_params())` serves the *champion*. Reverted precisely, and the lesson is now
playbook rule **C8**: *a pinned number is meaningless without knowing which path produced it — never `sed`
across a directory.*

## Also in this PR

- `docs/CLOSEOUT-2026-07-27-test-suite-repair.md` — full closeout with honest gaps
- Playbook rules **C7** (an adoption isn't finished until the tests pinning it are re-baselined in the same
  change), **C8**, **C9** ("frozen" anchors are frozen only against the engine that produced them)
- **v5.2.0** bump (`CITATION.cff`, README) — cut on the clean floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)