### PR TITLE
docs: wire the v5.2.0 Zenodo DOI into CITATION.cff + README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,9 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.21495142"
     description: "The v5.1.0 version DOI."
+  - type: doi
+    value: "10.5281/zenodo.21629856"
+    description: "The v5.2.0 version DOI."
 url: "https://github.com/mulhamfetna/trading-strategy-finder"
 repository-code: "https://github.com/mulhamfetna/trading-strategy-finder"
 keywords:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ per release via Zenodo (badge above).
 
 ```
 Fetna, M. (2026). Trading Strategy Finder: a reproducible quantitative-analysis framework for futures
-trading-strategy discovery and validation (Version 5.2.0) [Software].
-https://github.com/mulhamfetna/trading-strategy-finder
+trading-strategy discovery and validation (Version 5.2.0) [Software]. Zenodo.
+https://doi.org/10.5281/zenodo.21629856
 ```
+
+Cite the **version you actually used** (the DOI above is v5.2.0). To cite the project in general — always
+resolving to the newest release — use the concept DOI **`10.5281/zenodo.21473312`**. Every version DOI is
+listed in [`CITATION.cff`](CITATION.cff).


### PR DESCRIPTION
Zenodo has archived the v5.2.0 release.

| | |
|---|---|
| **v5.2.0 version DOI** | `10.5281/zenodo.21629856` (record 21629856, published 2026-07-27) |
| **Concept DOI** (unchanged) | `10.5281/zenodo.21473312` — always resolves to the newest release |
| Linkage | `isSupplementTo` → the `v5.2.0` tag ✅ |
| Both DOIs | verified resolving (HTTP 302 → Zenodo) ✅ |

**`CITATION.cff`** — adds the v5.2.0 version DOI to `identifiers` (now concept + v5.0.0 + v5.1.0 + v5.2.0). Validated as parseable YAML.

**`README.md`** — the citation block carried **no DOI at all**. It now cites the v5.2.0 DOI and explains when to use the version DOI (cite what you used) vs the concept DOI (the project in general).

The DOI badge needs no change — it is repo-id based (`latestdoi`) and auto-resolves.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)