### PR TITLE
docs: sync v5.2.0 Zenodo DOI to main

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,9 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.21495142"
     description: "The v5.1.0 version DOI."
+  - type: doi
+    value: "10.5281/zenodo.21629856"
+    description: "The v5.2.0 version DOI."
 url: "https://github.com/mulhamfetna/trading-strategy-finder"
 repository-code: "https://github.com/mulhamfetna/trading-strategy-finder"
 keywords:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ per release via Zenodo (badge above).
 
 ```
 Fetna, M. (2026). Trading Strategy Finder: a reproducible quantitative-analysis framework for futures
-trading-strategy discovery and validation (Version 5.2.0) [Software].
-https://github.com/mulhamfetna/trading-strategy-finder
+trading-strategy discovery and validation (Version 5.2.0) [Software]. Zenodo.
+https://doi.org/10.5281/zenodo.21629856
 ```
+
+Cite the **version you actually used** (the DOI above is v5.2.0). To cite the project in general — always
+resolving to the newest release — use the concept DOI **`10.5281/zenodo.21473312`**. Every version DOI is
+listed in [`CITATION.cff`](CITATION.cff).


### PR DESCRIPTION
Docs-only: wires the newly-minted v5.2.0 Zenodo DOI (`10.5281/zenodo.21629856`) into `CITATION.cff` and the README citation block, keeping `main` == `dev`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated citation guidance for version 5.2.0 with its Zenodo DOI.
  * Clarified that users should cite the specific version they used, alongside the concept DOI.

* **Chores**
  * Added the version 5.2.0 DOI to the project’s citation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->