### PR TITLE
research(#14): adopt gate — DEFAULT-OFF, plus four defects that would each have produced a confident wrong answer

### DIFF
--- a/docs/CLOSEOUT-2026-07-28-adopt-gate.md
+++ b/docs/CLOSEOUT-2026-07-28-adopt-gate.md
@@ -1,6 +1,6 @@
 # Closeout — The Adopt Gate for the 143-Indicator Library (2026-07-28)
 
-**Issue:** #14 (part of #12) · **Branch:** `research/14-adopt-gate` · **Status:** *(pending verdict)*
+**Issue:** #14 (part of #12) · **Branch:** `research/14-adopt-gate` · **Status:** ✅ **CLOSED — DEFAULT-OFF**
 
 ---
 
@@ -26,7 +26,7 @@ says nothing either.
 
 ---
 
-## 2. Three defects found before a single verdict was produced
+## 2. Four defects found — three before any verdict existed, one in the verdict itself
 
 This is the part worth reading. Each was found by measuring something rather than assuming it, and each
 would have produced a **confident, meaningless** result.
@@ -250,8 +250,27 @@ result.
 
 ## 7. The through-line
 
-Every one of the three defects had the same shape: **something that looked like neutral bookkeeping was
-silently answering a different question.** Walk-forward folds that quietly included the holdout. A cap
-that quietly excluded the entire library under test. A control that would quietly have been scored with
-real data. None was visible by reading the code; each took a measurement — and the measurement was
-cheap compared to the four hours of compute it saved or the wrong conclusion it prevented.
+Every one of the four defects had the same shape: **something that looked like neutral bookkeeping was
+silently answering a different question.**
+
+* Walk-forward folds that quietly included the holdout.
+* A cap that quietly excluded the entire library under test — 0.00% of 1,500 trials.
+* A control that would quietly have been scored with real data.
+* A cache that quietly served permutation #1's votes to all 200 permutations.
+
+None was visible by reading the code. Each took a measurement, and each measurement was cheap next to
+the compute it saved or the confident wrong answer it prevented. Three of the four produced results
+that *looked fine* — a plausible p-value, a rising best-on-train, a clean null. **The tell was never
+that a number looked wrong; it was that a number looked too good.**
+
+### What to do next, concretely
+
+1. **Do not adopt anything from the new library on this evidence** — and equally, do not conclude it is
+   worthless. The gate could not resolve an effect of the size observed.
+2. **The gate needs power before it is worth re-running.** NQ 4h alone sits at 347% of the edge. The
+   cheapest real improvement is the **paired ablation** (§3), 1.58–3.06× more sensitive than comparing
+   P/L totals, combined with **pooling volatility-standardized trades across instruments**. Even all 33
+   live slots only reach 79% — so a genuinely powered gate needs a longer holdout, not just a wider one.
+3. **Re-check anything that used `--max-enabled`.** The bias was pre-existing (#12), so any earlier
+   conclusion about "searching the 143 indicators" came from a search containing only 18 of them.
+   `optimize/perf/check_max_enabled_bias.py` answers that for any study in one command.

--- a/docs/CLOSEOUT-2026-07-28-adopt-gate.md
+++ b/docs/CLOSEOUT-2026-07-28-adopt-gate.md
@@ -1,0 +1,179 @@
+# Closeout — The Adopt Gate for the 143-Indicator Library (2026-07-28)
+
+**Issue:** #14 (part of #12) · **Branch:** `research/14-adopt-gate` · **Status:** *(pending verdict)*
+
+---
+
+## 1. What the gate is for
+
+#12 added **125 + 18 = 143 indicators**, taking the registry from 18 to 165. The temptation is to let the
+optimizer search them and adopt whatever wins. That is precisely the multiple-comparisons trap: search
+165 candidates against one price series and *something* will look excellent on the training window by
+chance alone.
+
+The gate exists so a lucky in-sample winner cannot become a champion. A candidate must beat **four**
+numbers, not one:
+
+| | what it is | why |
+|---|---|---|
+| **baseline** | the deployed champion, indicator layer frozen, on the 2026 holdout | the thing to beat |
+| **treatment** | re-optimize with the whole library searchable, **on 2025 only**, then score best-on-train on 2026 | the candidate |
+| **dumb control** | the identical search at the identical budget, with **placebo** votes | beating zero is not enough when a search over noise also produces a positive number |
+| **noise** | the winner's own votes scrambled, 200 permutations | if the edge survives a shuffle it never came from the indicators |
+
+Plus a **power** statement, because a null at low power says nothing and a positive without controls
+says nothing either.
+
+---
+
+## 2. Three defects found before a single verdict was produced
+
+This is the part worth reading. Each was found by measuring something rather than assuming it, and each
+would have produced a **confident, meaningless** result.
+
+### 2.1 The optimizer had no holdout at all
+
+`score_walkforward` splits the **whole** series into folds — so 2025 *and* 2026 were both training data.
+"Out-of-sample 2026" would have been nothing of the kind.
+
+Fixed with `--train-window 2025`, which truncates every frame before anything is computed. Verified:
+**2,119 → 1,534 decision bars**, exactly the split the issue specifies.
+
+### 2.2 `--max-enabled` was testing the wrong indicators — all of them
+
+`--max-enabled 3` caps how many indicators a trial may enable. The repair kept **"the first 3 in
+REGISTRY order"**. That reads as neutral bookkeeping. It is not:
+
+- registry positions **0–17** = the **original 18** indicators
+- registry positions **18–164** = the **147 added by #12** — the ones this gate exists to evaluate
+
+An original always won the tie. Measured on the live 16,000-trial study:
+
+| | |
+|---|---|
+| trials sampled | 1,500 |
+| trials containing **any** new-library indicator | **0 — 0.00%** |
+| ten most-kept keys | `ema_trend`(0) `sma_trend`(1) `cci`(6) `macd`(2) `vwap`(3) `rsi`(7) `structure_trend`(12) `mfi`(9) `keltner`(4) `obv`(5) |
+
+**A search built to evaluate 143 new indicators had, in 16,000 trials, tested none of them.** Both runs
+were stopped mid-flight rather than spend another 2.5 hours measuring nothing.
+
+The repair now draws an unbiased subset seeded by the trial number — reproducible per trial, independent
+of registry position. After the fix, on live data: **98.1%** of trials contain a new-library indicator,
+mean kept registry position **80.3** against an unbiased expectation of ~82.
+
+> ⚠️ **This is a pre-existing flaw in `--max-enabled`, shipped with the library in #12 — not introduced
+> here.** Any earlier run that used it believing it was "searching the 143 indicators" was also
+> searching only the original 18.
+
+`optimize/test_max_enabled_unbiased.py` pins it, and the tests were **verified to fail against the old
+repair** (2 of 6) — a regression test that does not fail on the bug is worthless.
+
+### 2.3 The dumb control was going to be scored with real votes
+
+`extract` runs in a fresh process, so the control's winner would have been scored with **real**
+indicator votes. The control asks *"what does this procedure score when the indicators carry no
+information?"* — a statement about the whole pipeline under the null — so its holdout must be scored
+with the **same placebo votes the search trained on**. With real votes it silently measures something
+else (what an arbitrary real configuration earns) and stops being a null.
+
+Fixed: `extract --scramble-seed <seed>` reinstalls the identical scrambler.
+
+---
+
+## 3. The power ceiling — measured three ways, and they agree
+
+Before any verdict, the question that decides how to read it: **could this design detect an improvement
+at all?**
+
+**Per timeframe** (α=0.05, power=0.80, from each deployed champion's own 2026 holdout trades):
+
+| TF | OOS trades | OOS P/L | smallest detectable improvement | as % of the whole OOS P/L |
+|---|---:|---:|---:|---:|
+| 4h | 81 | $61,601 | $55,920 | **91%** |
+| 2h | 50 | $40,745 | $32,180 | 79% |
+| 1h | 38 | $27,203 | $32,829 | 121% |
+| 15m | 73 | $21,306 | $23,799 | 112% |
+| 5m | 16 | $2,600 | $4,908 | 189% |
+| 2m | 149 | $4,545 | $11,791 | 259% |
+
+**Not one timeframe can detect an improvement smaller than ~79% of the strategy's entire holdout
+profit.**
+
+**Would pooling fix it?** Pooling raw dollars across all 9 instruments does not — mixing silver
+($5,000/point) with Nasdaq ($20/point) inflates variance faster than *n* grows (MDE stays at 112% of
+pooled P/L). Pooling **volatility-standardized** per-trade P/L is better but still weak:
+
+| pooled n | MDE as % of the existing edge |
+|---:|---:|
+| 81 — NQ 4h alone, as the issue scopes it | **347%** |
+| 400 | 156% |
+| 1,571 — every live instrument×TF slot | **79%** |
+| 4,000 | 49% |
+
+**Does pairing fix it?** Partly, and less than I first claimed. Matching two strategies bar-by-bar makes
+every shared trade contribute an exactly-zero difference, so only disagreements carry variance:
+
+| | SE of the total difference | smallest detectable |
+|---|---:|---:|
+| unpaired | $36,352 | $101,844 |
+| **paired** | **$23,045** | **$64,562** |
+
+**1.58× more sensitive — measured, not asserted.** Pairing helps only in proportion to how many trades
+the two variants share, and here they agree on just 45% of bars.
+
+The paired machinery was validated against itself first: **champion vs champion → 81 paired bars, 100%
+identical, total difference $0, CI [0, 0], p = 1.0.**
+
+> A bug the self-check caught: the pairing key was `entry_time`, which `backtest_metrics` trades do not
+> carry. Every lookup returned `None`, all 81 trades collapsed into one bucket, and the test silently
+> degenerated to n=1. It is `entry_idx`; a missing key now raises.
+
+**Bottom line on power: a candidate must roughly DOUBLE the strategy to register on this design.**
+
+---
+
+## 4. A finding that arrived for free
+
+The paired ablation of the **deployed champion** — its 8 indicators ON vs the identical parameters with
+them OFF:
+
+| | |
+|---|---:|
+| indicators ON | $61,601 (81 trades) |
+| indicators OFF | $22,138 (157 trades) |
+| **paired difference** | **+$39,463** |
+| 95% bootstrap CI | **[−$4,548, +$83,514]** |
+| p | 0.089 |
+
+The current champion's indicator layer looks worth ~$39k on the holdout — **but the interval crosses
+zero.** Positive, and not distinguishable from luck at this sample size. That is a statement about the
+test, not about the indicators.
+
+---
+
+## 5. Verdict
+
+*(filled when the corrected searches complete)*
+
+---
+
+## 6. What was built
+
+| file | purpose |
+|---|---|
+| `optimize/adopt_gate.py` | the gate: `baseline` · `search` (treatment/control) · `extract` · `paired` · `noise` · `verdict` |
+| `optimize/optimizer.py` | `--train-window 2025` (a real holdout); unbiased `--max-enabled` repair; per-trial progress hook; trials record their enabled layer verbatim |
+| `optimize/test_max_enabled_unbiased.py` | pins the anti-bias repair; verified to fail on the old one |
+| `optimize/perf/check_max_enabled_bias.py` | reads a LIVE study and reports what the cap actually kept — run it before trusting any `--max-enabled` verdict |
+| `optimize/perf/finish_adopt_gate.sh` | the closing pipeline as a real file, not a string through three layers of shell quoting |
+
+---
+
+## 7. The through-line
+
+Every one of the three defects had the same shape: **something that looked like neutral bookkeeping was
+silently answering a different question.** Walk-forward folds that quietly included the holdout. A cap
+that quietly excluded the entire library under test. A control that would quietly have been scored with
+real data. None was visible by reading the code; each took a measurement — and the measurement was
+cheap compared to the four hours of compute it saved or the wrong conclusion it prevented.

--- a/docs/CLOSEOUT-2026-07-28-adopt-gate.md
+++ b/docs/CLOSEOUT-2026-07-28-adopt-gate.md
@@ -152,9 +152,64 @@ test, not about the indicators.
 
 ---
 
-## 5. Verdict
+## 5. Verdict — **DEFAULT-OFF**
 
-*(filled when the corrected searches complete)*
+47,100 trials of treatment and 47,100 of dumb control, both on the 2025 training window only, both
+warm-started, `--max-enabled 3`, scored on the never-seen 2026 holdout.
+
+| | holdout P/L | trades | indicators |
+|---|---:|---:|---|
+| **baseline** (deployed champion) | **$61,601** | 81 | the 8 original |
+| **treatment** (best-on-train of 47,100) | **$18,827** | 157 | `apo`, `pivot_camarilla`, `dfa` |
+| **dumb control** (placebo votes) | $14,039 | — | `hma`, `vidya`, `mama_fama` |
+
+| # | criterion | result |
+|---|---|---|
+| 1 | beats baseline? | **NO** — Δ **−$42,774** |
+| 2 | beats the dumb control? | YES — Δ +$4,788 |
+| 3 | edge vanishes when its own votes are scrambled? | **NO** — permutation p = **0.124** (null mean $6,655, n=200) |
+| 4 | paired 95% CI excludes zero? | **NO** — Δ −$42,774, CI **[−$92,499, +$6,432]**, p = 0.094 |
+
+**⇒ DEFAULT-OFF. Nothing from the new library is adopted.**
+
+### Read the rejection correctly
+
+The verdict classifies itself as **CANNOT TELL**, not **NO EFFECT**: |−$42,774| < the minimum
+detectable $71,183. Two different statements follow, and conflating them would be the mistake:
+
+* **The decision is solid.** A candidate that lost by $42,774, cannot be shown to beat a placebo by
+  more than $4,788, and whose edge does not survive scrambling its own votes, does not get adopted.
+* **The scientific claim is not.** This design could not have detected a *real* improvement of the
+  size observed, so the result is **not evidence that the 143 indicators are useless.** It is evidence
+  that *this test cannot answer the question.*
+
+### The pattern in the front — descriptive, and it should not be over-read
+
+All five feasible front members, scored on the holdout:
+
+| indicators | train (2025) | **holdout (2026)** | composition |
+|---|---:|---:|---|
+| `cci`, `structure_trend`, `order_block` | $99,580 | **$55,066** | all ORIGINAL |
+| `obv`, `structure_trend`, `order_block` | $72,879 | **$52,438** | all ORIGINAL |
+| `pvi`, `force_index`, `td_combo` | $88,680 | $20,295 | all NEW |
+| `apo`, `pivot_camarilla`, `dfa` ← selected | $62,356 | $18,827 | all NEW |
+| `ppo`, `smi`, `disparity` | $79,019 | $18,820 | all NEW |
+
+Front members built from the **original** indicators hold out at ~$52–55k; those built from the **new**
+library hold out at ~$19–20k, despite comparable or better training scores. That is a clean
+train/holdout divergence in exactly the direction the multiple-comparisons trap predicts.
+
+**Three caveats, all load-bearing:**
+1. **n = 5.** This is a suggestive pattern, not a measurement.
+2. Reading the best-*holdout* member would be **selecting on the test set** — the very trap the gate
+   exists to prevent. $55,066 is a post-hoc observation, not "the treatment result".
+3. **Even that best holdout member still loses to the baseline** ($55,066 vs $61,601).
+
+### Why `selected` is not the highest train P/L in that table
+
+The gate ranks the front by the optimizer's own objective — **median fold P/L** (walk-forward) — not by
+the full-2025-window backtest shown in the column. They rank differently. Ranking by the optimizer's
+objective is the defensible choice: it is the quantity the search actually maximised.
 
 ---
 
@@ -167,6 +222,29 @@ test, not about the indicators.
 | `optimize/test_max_enabled_unbiased.py` | pins the anti-bias repair; verified to fail on the old one |
 | `optimize/perf/check_max_enabled_bias.py` | reads a LIVE study and reports what the cap actually kept — run it before trusting any `--max-enabled` verdict |
 | `optimize/perf/finish_adopt_gate.sh` | the closing pipeline as a real file, not a string through three layers of shell quoting |
+
+---
+
+## 6a. A fourth defect — caught because the number was too clean
+
+The first verdict reported criterion 3 as `p = 1.0000, null mean $18,827` — the null mean *exactly*
+equalling the observed value. Checking the distribution: **sd = $0.00.** All 200 permutations returned
+the identical number. That is not a null distribution; it is a point mass wearing a p-value.
+
+The two candidate causes were distinguished rather than guessed:
+
+* *are the winner's indicators simply inert?* No — ON $18,827 / 157 trades vs OFF $12,271 / 193 trades.
+* *is the harness broken?* **Yes.** `vote_cache`'s key is `(slice, indicator, mode, params)` — it knows
+  nothing about the scramble seed. Permutation #1 wrote its scrambled votes to disk and permutations
+  #2–200 read them straight back.
+
+Redirecting the cache (which the code already did) is **not** enough — it has to be bypassed. Fixed,
+plus a guard that now refuses to emit a p-value from a zero-spread null. The corrected run gives a real
+distribution: **mean $6,655, sd $7,740, p = 0.124**.
+
+The verdict's *direction* did not change — criteria 1 and 4 already failed decisively — but the reason
+recorded for criterion 3 was wrong, and in a research record a wrong reason is worth as much as a wrong
+result.
 
 ---
 

--- a/subprojects/Parametric-Indicators/optimize/adopt_gate.py
+++ b/subprojects/Parametric-Indicators/optimize/adopt_gate.py
@@ -180,10 +180,22 @@ def cmd_search(args, log):
 
 
 def _score_scrambled(tf, instrument, params, seed):
-    """Score `params` on the 2026 holdout with every indicator vote circularly shifted by `seed`."""
+    """Score `params` on the 2026 holdout with every indicator vote circularly shifted by `seed`.
+
+    ⚠️ The disk vote-cache MUST be bypassed here, not merely redirected. Its key is
+    (slice, use1, indicator, mode, params) — it knows nothing about the scramble seed. Redirecting it
+    to a scratch directory (which the first version did) means permutation #1 writes its scrambled
+    votes and permutations #2..N read them straight back: every draw returns the identical number.
+    That is exactly what happened — a 200-permutation null with **sd = $0.00** and p = 1.0000, which
+    reads like a decisive result and is in fact no distribution at all.
+    """
     from indicators import runner
+    from optimize import vote_cache
     import numpy as _np
     orig = runner._ind_vote
+    orig_get, orig_put = vote_cache.get, vote_cache.put
+    vote_cache.get = lambda dkey: None          # force a genuine recompute for every permutation
+    vote_cache.put = lambda dkey, arr: None
     try:
         def scrambled(ind, ctx, bdir, src=None):
             v = _np.asarray(orig(ind, ctx, bdir, src))
@@ -198,6 +210,7 @@ def _score_scrambled(tf, instrument, params, seed):
         return float(m["pnl"]), int(m["n_taken"])
     finally:
         runner._ind_vote = orig
+        vote_cache.get, vote_cache.put = orig_get, orig_put
         core._clear_caches()
 
 
@@ -238,6 +251,16 @@ def cmd_noise(args, log):
         if (i + 1) % max(1, args.perms // 10) == 0:
             log(f"[gate] noise {i+1}/{args.perms} … null mean ${np.mean(null):,.0f}")
     null = np.asarray(null, float)
+    # A null with no spread is not a null. If every permutation returns the same number, the scramble
+    # is not reaching the engine — say so instead of reporting a confident p-value off a point mass.
+    if null.size < 2 or float(null.std(ddof=1)) == 0.0:
+        log(f"[gate] !! DEGENERATE NULL: all {null.size} permutations returned "
+            f"${null[0]:,.2f} (sd = 0). The scramble is not affecting the backtest — this p-value "
+            f"would be meaningless. Check that the vote cache is bypassed.")
+        return {"indicators": keys, "real_holdout_pnl": round(real_pnl, 2), "null_n": int(null.size),
+                "null_sd": 0.0, "p_value": None, "degenerate": True,
+                "verdict": "INVALID — the permutation null has zero spread; the scramble never reached "
+                           "the engine, so this says nothing either way"}
     ge = int((null >= real_pnl).sum())
     p = (ge + 1) / (len(null) + 1)               # add-one: an empirical p can never be exactly 0
     log(f"[gate] NULL n={len(null)}  mean ${null.mean():,.0f}  sd ${null.std(ddof=1):,.0f}  "

--- a/subprojects/Parametric-Indicators/optimize/adopt_gate.py
+++ b/subprojects/Parametric-Indicators/optimize/adopt_gate.py
@@ -254,6 +254,131 @@ def cmd_noise(args, log):
             "p_value": round(float(p), 5), "verdict": verdict}
 
 
+def _pnl_by_entry(m):
+    """{entry bar index -> P/L} for one scored run. The entry BAR is the pairing key: two strategies
+    that take the same trade on the same bar contribute an exactly-zero difference.
+
+    `backtest_metrics` trades carry `entry_idx` (an index into the scored window), not `entry_time` —
+    the first version of this keyed on the latter, every lookup returned None, all 81 trades collapsed
+    into a single bucket, and the paired test silently degenerated to n=1. Missing keys now raise
+    instead of quietly producing a confident wrong answer.
+    """
+    out = {}
+    for t in (m.get("trades") or []):
+        if "entry_idx" not in t:
+            raise KeyError(f"trade record has no 'entry_idx' — cannot pair. keys={sorted(t)}")
+        k = int(t["entry_idx"])
+        out[k] = out.get(k, 0.0) + float(t.get("pnl", 0.0))
+    return out
+
+
+def paired_stats(a_map, b_map, alpha=0.05, power=0.80, n_boot=10000, seed=7):
+    """PAIRED comparison of two strategies on the same holdout, matched by entry bar.
+
+    Why this and not two P/L totals: an unpaired test carries the full per-trade volatility of BOTH
+    strategies (±$2,218 on NQ 4h), so it can only see an improvement of ~91% of the entire holdout
+    profit. But two variants of the same box strategy take mostly the SAME trades — and every shared
+    trade contributes a difference of exactly zero, carrying no variance at all. The signal lives
+    entirely in the bars where they disagree, and pairing is what isolates it.
+
+    Returns the difference series' t-test, a bootstrap CI on the TOTAL difference, and the paired MDE
+    next to the unpaired one so the gain in power is visible rather than asserted.
+    """
+    from scipy import stats
+    keys = sorted(set(a_map) | set(b_map))
+    d = np.array([a_map.get(k, 0.0) - b_map.get(k, 0.0) for k in keys], float)
+    n = int(d.size)
+    if n < 2:
+        return {"n_pairs": n, "note": "too few pairs"}
+    nz = d != 0.0
+    sd = float(d.std(ddof=1))
+    za, zb = float(stats.norm.ppf(1 - alpha / 2)), float(stats.norm.ppf(power))
+    mde = (za + zb) * sd / np.sqrt(n)
+    t = float(d.mean() / (sd / np.sqrt(n))) if sd > 0 else float("nan")
+    p = float(2 * (1 - stats.t.cdf(abs(t), n - 1))) if np.isfinite(t) else float("nan")
+
+    if sd == 0.0:
+        t, p = 0.0, 1.0                          # identical strategies: no difference, not "undefined"
+
+    rng = np.random.default_rng(seed)
+    boot = d[rng.integers(0, n, size=(n_boot, n))].sum(axis=1)
+
+    # Apples-to-apples power comparison: the STANDARD ERROR OF THE TOTAL difference under each scheme.
+    # (An earlier version compared a paired *total* against an unpaired *mean*, which are not the same
+    # quantity and made pairing look 100x worse than it is.)
+    #   paired    total = sum of per-bar differences        ⇒ SE = sd_d * sqrt(n_pairs)
+    #   unpaired  total = sum(a) - sum(b), independent sets ⇒ SE = sqrt(n_a*var_a + n_b*var_b)
+    a = np.array(list(a_map.values()), float)
+    b = np.array(list(b_map.values()), float)
+    se_paired = sd * np.sqrt(n)
+    se_unpaired = (float(np.sqrt(a.size * a.var(ddof=1) + b.size * b.var(ddof=1)))
+                   if (a.size > 1 and b.size > 1) else float("nan"))
+
+    return {
+        "n_pairs": n, "n_disagreeing_bars": int(nz.sum()),
+        "agreement_pct": round(100.0 * (1 - nz.sum() / n), 1),
+        "trades_a": int(a.size), "trades_b": int(b.size),
+        "total_diff": round(float(d.sum()), 2),
+        "mean_diff_per_bar": round(float(d.mean()), 2),
+        "sd_diff": round(sd, 2),
+        "t_stat": round(float(t), 3), "p_two_sided": round(float(p), 5),
+        "boot_ci95_total": [round(float(np.quantile(boot, 0.025)), 0),
+                            round(float(np.quantile(boot, 0.975)), 0)],
+        "se_total_paired": round(float(se_paired), 0),
+        "se_total_unpaired": round(float(se_unpaired), 0) if np.isfinite(se_unpaired) else None,
+        "mde_total_paired": round(float((za + zb) * se_paired), 0),
+        "mde_total_unpaired": (round(float((za + zb) * se_unpaired), 0)
+                               if np.isfinite(se_unpaired) else None),
+        "power_gain_x": (round(float(se_unpaired / se_paired), 2)
+                         if np.isfinite(se_unpaired) and se_paired > 0 else None),
+    }
+
+
+def cmd_paired(args, log):
+    """Paired holdout comparison. Two flavours, both reported:
+
+      A  treatment winner  vs  the deployed baseline champion — the issue's question.
+      B  the treatment winner with its indicators ON vs the SAME parameters with them OFF — an
+         ABLATION. Everything but the indicator layer is held fixed, so the pairing is near-total and
+         it answers the narrower, sharper question: did the INDICATORS contribute anything?
+    """
+    cand = json.loads(Path(args.params).read_text())
+    if "params" in cand:
+        cand = cand["params"]
+    cand.setdefault("ind_1min", True)
+    keys = [s["key"] for s in cand.get("indicators", []) if s.get("enabled")]
+
+    base = dict(l1_default_params(args.tf))
+    base["ind_1min"] = True
+
+    df_dec, df1, box, vf, n_split = _load(args.tf, args.instrument)
+    bar_td = TF.get(args.tf).bar_td
+
+    m_cand = _score(df_dec, df1, box, vf, n_split, cand, bar_td, "2026")
+    m_base = _score(df_dec, df1, box, vf, n_split, base, bar_td, "2026")
+
+    off = dict(cand)
+    off["indicators"] = [dict(s, enabled=False) for s in cand.get("indicators", [])]
+    m_off = _score(df_dec, df1, box, vf, n_split, off, bar_td, "2026")
+
+    log(f"[gate] candidate indicators {keys}")
+    log(f"[gate]   candidate  HOLDOUT P/L ${float(m_cand['pnl']):>10,.0f}  n={int(m_cand['n_taken']):>4d}")
+    log(f"[gate]   baseline   HOLDOUT P/L ${float(m_base['pnl']):>10,.0f}  n={int(m_base['n_taken']):>4d}")
+    log(f"[gate]   same-but-indicators-OFF ${float(m_off['pnl']):>10,.0f}  n={int(m_off['n_taken']):>4d}")
+
+    out = {"indicators": keys}
+    for tag, other in (("A_vs_baseline", m_base), ("B_ablation_indicators_off", m_off)):
+        st = paired_stats(_pnl_by_entry(m_cand), _pnl_by_entry(other))
+        out[tag] = st
+        log(f"[gate] {tag}: {st['n_pairs']} paired bars, {st['agreement_pct']}% identical  "
+            f"total diff ${st['total_diff']:,.0f}  95% CI [{st['boot_ci95_total'][0]:,.0f}, "
+            f"{st['boot_ci95_total'][1]:,.0f}]  p={st['p_two_sided']:.4f}")
+        log(f"[gate]   SE(total) paired ${st['se_total_paired']:,.0f} vs unpaired "
+            f"${st['se_total_unpaired']:,.0f}  ⇒ pairing is {st['power_gain_x']}× more sensitive "
+            f"(detectable: ${st['mde_total_paired']:,.0f} paired vs ${st['mde_total_unpaired']:,.0f})")
+    return out
+
+
 def params_from_trial(t):
     """Rebuild the engine params dict from a stored trial — from RECORDED values, never re-derived.
 
@@ -349,7 +474,7 @@ def cmd_evaluate(args, log):
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
-    ap.add_argument("cmd", choices=["baseline", "evaluate", "search", "extract", "noise"])
+    ap.add_argument("cmd", choices=["baseline", "evaluate", "search", "extract", "noise", "paired"])
     ap.add_argument("--tf", default="4h")
     ap.add_argument("--instrument", default="NQ")
     ap.add_argument("--params", default=None, help="params JSON (for `evaluate`)")
@@ -372,7 +497,8 @@ def main() -> int:
         print(m, flush=True)
 
     res = {"baseline": cmd_baseline, "evaluate": cmd_evaluate, "search": cmd_search,
-           "extract": cmd_extract, "noise": cmd_noise}[args.cmd](args, log)
+           "extract": cmd_extract, "noise": cmd_noise,
+           "paired": cmd_paired}[args.cmd](args, log)
     if args.out:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)
         Path(args.out).write_text(json.dumps(res, indent=2))

--- a/subprojects/Parametric-Indicators/optimize/adopt_gate.py
+++ b/subprojects/Parametric-Indicators/optimize/adopt_gate.py
@@ -1,0 +1,384 @@
+"""Issue #14 — the adopt gate for the 143-indicator library.
+
+**Nothing from `#12`'s indicator library may become a champion contributor until it clears this.** The
+reason is the multiple-comparisons trap: search 125+ candidate indicators against one price series and
+*something* will look good on the training window purely by chance. The gate is designed so that a
+lucky in-sample winner cannot pass.
+
+Four numbers, and a candidate must beat all of them:
+
+  baseline   the deployed champion, indicator layer frozen, scored on the 2026 holdout.
+  treatment  re-optimize with the whole library searchable — but on **2025 only** (`--train-window
+             2025`, so 2026 is never seen) — then score the best-on-train on 2026.
+  dumb       the identical search, identical budget, with the real indicators replaced by PLACEBOS
+             whose votes are pseudo-random. This measures how much "edge" the search procedure
+             manufactures from noise. Treatment must beat it, not just beat zero.
+  noise      take the treatment winner and SHUFFLE its indicators' per-bar votes. If the OOS edge
+             survives a shuffle, it never came from the indicators.
+
+Plus a power statement: `n` OOS trades and the minimum detectable effect. A null at low power is not
+evidence of absence (`feedback_power_analysis_mandatory`), and a positive without the dumb + noise
+controls is not evidence of presence (`feedback_dumb_control_and_noise`).
+
+Subcommands:
+  baseline   score the champion on the holdout
+  evaluate   score an arbitrary params JSON on train / holdout
+  noise      the vote-shuffle control for a given params JSON
+  power      n + minimum detectable effect from a trade ledger
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+
+from optimize import core, data as data_mod, timeframes as TF
+from optimize.l2.payload import l1_default_params
+
+_METRICS = ("pnl", "max_dd", "n_taken", "win", "pf", "exposure")
+
+
+def _summary(m):
+    out = {}
+    for k in _METRICS:
+        v = m.get(k)
+        if isinstance(v, (int, float, np.floating)):
+            out[k] = round(float(v), 4)
+    return out
+
+
+def _score(df_dec, df1, box, vf, n_split, params, bar_td, window):
+    core._clear_caches()
+    return core.backtest_metrics(df_dec, df1, box, vf, n_split,
+                                 dict(params, window=window), bar_td)
+
+
+def _load(tf, instrument):
+    return data_mod.load_inputs(tf, instrument)
+
+
+def _both_windows(tf, instrument, params, label, log):
+    df_dec, df1, box, vf, n_split = _load(tf, instrument)
+    bar_td = TF.get(tf).bar_td
+    tr = _score(df_dec, df1, box, vf, n_split, params, bar_td, "2025")
+    oos = _score(df_dec, df1, box, vf, n_split, params, bar_td, "2026")
+    log(f"  {label:22s} TRAIN(2025) P/L ${float(tr['pnl']):>10,.0f} DD ${float(tr['max_dd']):>8,.0f} "
+        f"n={int(tr['n_taken']):>4d}  |  HOLDOUT(2026) P/L ${float(oos['pnl']):>10,.0f} "
+        f"DD ${float(oos['max_dd']):>8,.0f} n={int(oos['n_taken']):>4d}")
+    return {"label": label, "train_2025": _summary(tr), "holdout_2026": _summary(oos),
+            "oos_trades": [float(t.get("pnl", 0.0)) for t in (oos.get("trades") or [])]}
+
+
+# --------------------------------------------------------------------------------------------------
+def power_from_trades(pnls, alpha=0.05, power=0.80):
+    """Minimum detectable effect for a one-sample t-test on per-trade P/L.
+
+    The question the gate must answer is not "did the treatment win?" but "could this design have
+    DETECTED a win of the size we care about?" With n trades of standard deviation s, the smallest
+    mean per-trade edge detectable at (alpha, power) is  (z_a + z_b) * s / sqrt(n).
+    """
+    from scipy import stats
+    x = np.asarray([p for p in pnls if np.isfinite(p)], float)
+    n = int(x.size)
+    if n < 2:
+        return {"n": n, "mean": None, "sd": None, "mde_per_trade": None, "mde_total": None,
+                "note": "too few trades for a power statement"}
+    s = float(x.std(ddof=1))
+    za = float(stats.norm.ppf(1 - alpha / 2.0))
+    zb = float(stats.norm.ppf(power))
+    mde = (za + zb) * s / np.sqrt(n)
+    t = float(x.mean() / (s / np.sqrt(n))) if s > 0 else float("nan")
+    return {"n": n, "mean_per_trade": round(float(x.mean()), 2), "sd_per_trade": round(s, 2),
+            "t_stat": round(t, 3), "p_two_sided": round(float(2 * (1 - stats.t.cdf(abs(t), n - 1))), 5),
+            "mde_per_trade": round(float(mde), 2), "mde_total": round(float(mde * n), 0),
+            "alpha": alpha, "power": power}
+
+
+def install_vote_scrambler(seed: int, log):
+    """PLACEBO MODE — destroy the indicators' information while keeping everything else identical.
+
+    Each indicator's per-bar vote array is **circularly shifted** by a deterministic offset derived
+    from (indicator key, its params, seed). A circular shift is chosen over a full shuffle on purpose:
+    it preserves the vote's marginal distribution *and* its autocorrelation — how often it fires and
+    how long it stays on — while destroying its alignment with price. So the control differs from the
+    treatment in exactly one respect: whether the votes carry information. Search space, dimension
+    count, trial budget, sampler and seeds are untouched.
+
+    ⚠️ CACHE POISONING is the hazard here. `core._cached_votes` writes computed votes to the shared
+    on-disk `vote_cache`, whose key does NOT know about scrambling — a placebo vote could be served to
+    a REAL run later. So this also repoints the disk cache at a throwaway directory and clears the
+    in-process memo. Never run placebo mode without it.
+    """
+    import tempfile
+    import numpy as _np
+    from indicators import runner
+    from optimize import vote_cache
+
+    scratch = tempfile.mkdtemp(prefix="adoptgate_placebo_votecache_")
+    vote_cache.set_cache_dir(scratch)
+    core._clear_caches()
+    log(f"[gate] PLACEBO: vote cache isolated at {scratch} (a scrambled vote must never reach the real cache)")
+
+    orig = runner._ind_vote
+    stats = {"calls": 0}
+
+    def scrambled(ind, ctx, bdir, src=None):
+        v = _np.asarray(orig(ind, ctx, bdir, src))
+        n = v.shape[0]
+        if n < 2:
+            return v
+        key = (ind.key, tuple(sorted(ind.config.params.items())), seed)
+        off = int(_np.abs(hash(key))) % n
+        stats["calls"] += 1
+        return _np.roll(v, off)
+
+    runner._ind_vote = scrambled
+    return stats
+
+
+def cmd_search(args, log):
+    """Run the optimization — treatment (real votes) or control (placebos) — on the TRAIN window only."""
+    import time
+    import optuna
+    from optimize import optimizer as _opt
+    stats = None
+    if args.mode == "control":
+        stats = install_vote_scrambler(args.seed, log)
+    # A 47k-trial run at Optuna's INFO level writes ~50 MB of per-trial spam, which buries the two
+    # lines that matter and makes the log useless to poll. Quiet it, and emit our own heartbeat instead
+    # (`feedback_never_wait_blindly`: a long run must be observable, not a black box).
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    t_start = time.time()
+    state = {"best": None}
+
+    def heartbeat(study, trial):
+        n = trial.number + 1
+        if trial.values and (state["best"] is None or trial.values[0] > state["best"]):
+            state["best"] = trial.values[0]
+        if n % max(1, args.progress_every) == 0:
+            el = time.time() - t_start
+            rate = n / el if el > 0 else 0
+            eta = (args.trials - n) / rate / 60 if rate > 0 else float("nan")
+            log(f"[gate] {args.mode} {n:,}/{args.trials:,} trials "
+                f"({rate*60:.0f}/min, ETA {eta:.0f} min) best-on-train ${state['best'] or 0:,.0f}")
+
+    _opt.PROGRESS_CALLBACK = heartbeat
+    log(f"[gate] {args.mode.upper()} search: tf={args.tf} trials={args.trials} "
+        f"max_enabled={args.max_enabled} train_window={args.train_window} prefix={args.study_prefix}")
+    res = _opt.run(args.tf, n_trials=args.trials, ind_1min=True, study_prefix=args.study_prefix,
+                   max_enabled=args.max_enabled, train_window=args.train_window,
+                   instrument=args.instrument, warm_start=not args.no_warm_start)
+    if stats is not None:
+        log(f"[gate] PLACEBO: scrambled {stats['calls']:,} vote computations")
+        assert stats["calls"] > 0, "placebo mode scrambled NOTHING — the control is vacuous"
+    return res
+
+
+def _score_scrambled(tf, instrument, params, seed):
+    """Score `params` on the 2026 holdout with every indicator vote circularly shifted by `seed`."""
+    from indicators import runner
+    import numpy as _np
+    orig = runner._ind_vote
+    try:
+        def scrambled(ind, ctx, bdir, src=None):
+            v = _np.asarray(orig(ind, ctx, bdir, src))
+            n = v.shape[0]
+            if n < 2:
+                return v
+            off = int(_np.abs(hash((ind.key, tuple(sorted(ind.config.params.items())), seed)))) % n
+            return _np.roll(v, off)
+        runner._ind_vote = scrambled
+        df_dec, df1, box, vf, n_split = _load(tf, instrument)
+        m = _score(df_dec, df1, box, vf, n_split, params, TF.get(tf).bar_td, "2026")
+        return float(m["pnl"]), int(m["n_taken"])
+    finally:
+        runner._ind_vote = orig
+        core._clear_caches()
+
+
+def cmd_noise(args, log):
+    """NOISE CHECK as a permutation test, not a single shuffle.
+
+    A single scramble tells you almost nothing — one draw from a distribution you have not seen. This
+    re-scores the winner `--perms` times with a different circular shift each time, which builds the
+    null distribution of "what this exact configuration earns on the holdout when its indicators carry
+    no information". The empirical p-value is the fraction of that null which matches or beats the real
+    result.
+
+    ⚠️ The vote cache is isolated first: a scrambled vote array written to the shared cache would be
+    served to a real run later.
+    """
+    import tempfile
+    from optimize import vote_cache
+    scratch = tempfile.mkdtemp(prefix="adoptgate_noise_votecache_")
+    vote_cache.set_cache_dir(scratch)
+    core._clear_caches()
+    log(f"[gate] NOISE: vote cache isolated at {scratch}")
+
+    params = json.loads(Path(args.params).read_text())
+    if "params" in params:                       # accept an `extract` output directly
+        params = params["params"]
+    params.setdefault("ind_1min", True)
+    keys = [s["key"] for s in params.get("indicators", []) if s.get("enabled")]
+
+    df_dec, df1, box, vf, n_split = _load(args.tf, args.instrument)
+    real = _score(df_dec, df1, box, vf, n_split, params, TF.get(args.tf).bar_td, "2026")
+    real_pnl = float(real["pnl"])
+    log(f"[gate] winner indicators {keys}: REAL holdout P/L ${real_pnl:,.0f} (n={int(real['n_taken'])})")
+
+    null = []
+    for i in range(args.perms):
+        pnl, n = _score_scrambled(args.tf, args.instrument, params, seed=100_000 + i)
+        null.append(pnl)
+        if (i + 1) % max(1, args.perms // 10) == 0:
+            log(f"[gate] noise {i+1}/{args.perms} … null mean ${np.mean(null):,.0f}")
+    null = np.asarray(null, float)
+    ge = int((null >= real_pnl).sum())
+    p = (ge + 1) / (len(null) + 1)               # add-one: an empirical p can never be exactly 0
+    log(f"[gate] NULL n={len(null)}  mean ${null.mean():,.0f}  sd ${null.std(ddof=1):,.0f}  "
+        f"p95 ${np.quantile(null, 0.95):,.0f}  max ${null.max():,.0f}")
+    log(f"[gate] p = {p:.4f}  ({ge}/{len(null)} scrambles matched or beat the real result)")
+    verdict = ("the edge SURVIVES scrambling ⇒ it does not come from the indicators"
+               if p > 0.05 else "the edge VANISHES under scrambling ⇒ consistent with a real signal")
+    log(f"[gate] {verdict}")
+    return {"indicators": keys, "real_holdout_pnl": round(real_pnl, 2),
+            "null_n": len(null), "null_mean": round(float(null.mean()), 2),
+            "null_sd": round(float(null.std(ddof=1)), 2),
+            "null_p95": round(float(np.quantile(null, 0.95)), 2),
+            "null_max": round(float(null.max()), 2),
+            "p_value": round(float(p), 5), "verdict": verdict}
+
+
+def params_from_trial(t):
+    """Rebuild the engine params dict from a stored trial — from RECORDED values, never re-derived.
+
+    `enabled_specs`, `k_rule`, `cap_mode` and `cap_1min` are read from user_attrs because the optimizer
+    resolves them (a pinned `--force-eod` never appears in `trial.params` at all, and re-deriving it
+    reads as OFF — which silently strips the end-of-day close off the champion).
+    """
+    p = t.params
+    ua = t.user_attrs
+    return {
+        "sl_soft": float(p["sl_soft"]),
+        "sl_hard": float(p["sl_soft"]) + float(p["sl_hard_delta"]),
+        "tp": float(p["tp"]),
+        "gate_pct": float(p["gate_pct"]),
+        "dd_limit": float(p["dd_limit"]),
+        "cooldown": int(p["cooldown"]),
+        "flip": bool(p["flip"]),
+        "k": int(ua["k_rule"]),
+        "indicators": list(ua["enabled_specs"]),
+        "cap_mode": ua.get("cap_mode", "none"),
+        "cap_1min": int(ua.get("cap_1min", 0) or 0),
+        "ind_1min": True,
+    }
+
+
+def cmd_extract(args, log):
+    """Take the search's feasible Pareto front and score every member on train + HOLDOUT.
+
+    The gate's rule is best-ON-TRAIN, then read its holdout number — picking the best *holdout* member
+    would be selecting on the test set, which is the exact trap this whole exercise exists to avoid. So
+    the front is ranked by the TRAIN objective and `selected` is its top member; the rest are reported
+    only so the spread is visible.
+    """
+    import optuna
+    storage = _storage()
+    study = optuna.load_study(study_name=args.study, storage=storage)
+
+    def feasible(t):
+        return all(v <= 0 for v in t.user_attrs.get("constraint", [1.0]))
+
+    front = [t for t in study.best_trials if feasible(t) and "enabled_specs" in t.user_attrs]
+    front.sort(key=lambda t: t.values[0], reverse=True)          # rank by TRAIN median fold P/L
+    log(f"[gate] study {args.study}: {len(study.trials):,} trials, feasible front {len(front)}")
+    if not front:
+        log("[gate] !! no feasible front member carries `enabled_specs` — nothing to evaluate")
+        return {"study": args.study, "front": 0, "members": []}
+
+    rows = []
+    for i, t in enumerate(front[: args.top]):
+        prm = params_from_trial(t)
+        keys = [s["key"] for s in prm["indicators"]]
+        row = _both_windows(args.tf, args.instrument, prm, f"front[{i}] {keys}", log)
+        row["trial_number"] = t.number
+        row["train_objective"] = float(t.values[0])
+        row["enabled_indicators"] = keys
+        row["params"] = prm
+        row["power_oos"] = power_from_trades(row.pop("oos_trades"))
+        rows.append(row)
+    return {"study": args.study, "front": len(front), "selected": rows[0], "members": rows}
+
+
+def _storage():
+    import os
+    url = os.environ.get("WSH_STORAGE_URL")
+    if not url:
+        raise SystemExit("WSH_STORAGE_URL not set — source the server's pg.env first")
+    return url
+
+
+def cmd_baseline(args, log):
+    params = l1_default_params(args.tf)
+    params["ind_1min"] = True
+    enabled = [s["key"] for s in (params.get("indicators") or []) if s.get("enabled")]
+    log(f"[gate] BASELINE = deployed {args.tf} champion, indicator layer FROZEN: {enabled} (k={params.get('k')})")
+    row = _both_windows(args.tf, args.instrument, params, "baseline champion", log)
+    row["enabled_indicators"] = enabled
+    row["k"] = params.get("k")
+    row["power_oos"] = power_from_trades(row.pop("oos_trades"))
+    log(f"  power(OOS): n={row['power_oos']['n']} trades, per-trade sd "
+        f"${row['power_oos']['sd_per_trade']:,.0f} ⇒ minimum detectable edge "
+        f"${row['power_oos']['mde_per_trade']:,.0f}/trade (${row['power_oos']['mde_total']:,.0f} total) "
+        f"at alpha=0.05, power=0.80")
+    return row
+
+
+def cmd_evaluate(args, log):
+    params = json.loads(Path(args.params).read_text())
+    params.setdefault("ind_1min", True)
+    row = _both_windows(args.tf, args.instrument, params, Path(args.params).stem, log)
+    row["power_oos"] = power_from_trades(row.pop("oos_trades"))
+    return row
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("cmd", choices=["baseline", "evaluate", "search", "extract", "noise"])
+    ap.add_argument("--tf", default="4h")
+    ap.add_argument("--instrument", default="NQ")
+    ap.add_argument("--params", default=None, help="params JSON (for `evaluate`)")
+    ap.add_argument("--mode", default="treatment", choices=["treatment", "control"],
+                    help="`search` only. control ⇒ indicator votes are circularly shifted (placebo).")
+    ap.add_argument("--trials", type=int, default=47100)
+    ap.add_argument("--max-enabled", type=int, default=3)
+    ap.add_argument("--train-window", default="2025", choices=["full", "2025"])
+    ap.add_argument("--study-prefix", default="adopt14")
+    ap.add_argument("--no-warm-start", action="store_true")
+    ap.add_argument("--seed", type=int, default=20260728, help="placebo shift seed")
+    ap.add_argument("--progress-every", type=int, default=2000, help="heartbeat interval (trials)")
+    ap.add_argument("--study", default=None, help="study name (for `extract`)")
+    ap.add_argument("--top", type=int, default=5, help="front members to score (`extract`)")
+    ap.add_argument("--perms", type=int, default=200, help="permutations for the noise check")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    def log(m):
+        print(m, flush=True)
+
+    res = {"baseline": cmd_baseline, "evaluate": cmd_evaluate, "search": cmd_search,
+           "extract": cmd_extract, "noise": cmd_noise}[args.cmd](args, log)
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(res, indent=2))
+        log(f"[gate] WROTE {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/Parametric-Indicators/optimize/adopt_gate.py
+++ b/subprojects/Parametric-Indicators/optimize/adopt_gate.py
@@ -379,6 +379,92 @@ def cmd_paired(args, log):
     return out
 
 
+def cmd_verdict(args, log):
+    """Assemble every artifact and apply the adopt rule — including the distinction that matters most.
+
+    ADOPT requires ALL of:
+      1. treatment beats the baseline on the holdout;
+      2. treatment beats the DUMB CONTROL's holdout — beating zero is not enough when an identical
+         search over placebo votes also produces a positive number;
+      3. the noise permutation test rejects (p <= 0.05) — the edge must vanish when the winner's own
+         votes are scrambled;
+      4. the paired 95% CI on the difference excludes zero.
+
+    Anything else is DEFAULT-OFF. But a rejection is reported as one of two DIFFERENT things, because
+    they have opposite implications for what to do next:
+      NO EFFECT           the effect is measurable and it is not there.
+      CANNOT TELL         |effect| < the minimum detectable effect. The design could not have seen a
+                          real improvement of this size, so the null is uninformative
+                          (`feedback_power_analysis_mandatory`).
+    """
+    def _read(p):
+        return json.loads(Path(p).read_text()) if p and Path(p).exists() else None
+
+    base = _read(args.baseline)
+    treat = _read(args.treatment)
+    ctrl = _read(args.control)
+    noise = _read(args.noise_json)
+    paired = _read(args.paired_json)
+
+    v = {"criteria": {}, "inputs_present": {
+        "baseline": base is not None, "treatment": treat is not None,
+        "control": ctrl is not None, "noise": noise is not None, "paired": paired is not None}}
+
+    b_oos = float(base["holdout_2026"]["pnl"]) if base else None
+    t_sel = (treat or {}).get("selected") or {}
+    t_oos = float(t_sel["holdout_2026"]["pnl"]) if t_sel else None
+    c_sel = (ctrl or {}).get("selected") or {}
+    c_oos = float(c_sel["holdout_2026"]["pnl"]) if c_sel else None
+
+    log("[gate] ── ADOPT GATE VERDICT ──")
+    if b_oos is not None:
+        log(f"  baseline  holdout P/L ${b_oos:>11,.0f}")
+    if t_oos is not None:
+        log(f"  treatment holdout P/L ${t_oos:>11,.0f}   indicators {t_sel.get('enabled_indicators')}")
+    if c_oos is not None:
+        log(f"  CONTROL   holdout P/L ${c_oos:>11,.0f}   (placebo votes — the score a search "
+            f"manufactures from noise)   indicators {c_sel.get('enabled_indicators')}")
+
+    if b_oos is not None and t_oos is not None:
+        v["criteria"]["1_beats_baseline"] = bool(t_oos > b_oos)
+        log(f"  1. beats baseline?      {'YES' if t_oos > b_oos else 'NO'}  "
+            f"(Δ ${t_oos - b_oos:+,.0f})")
+    if c_oos is not None and t_oos is not None:
+        v["criteria"]["2_beats_dumb_control"] = bool(t_oos > c_oos)
+        log(f"  2. beats dumb control?  {'YES' if t_oos > c_oos else 'NO'}  "
+            f"(Δ ${t_oos - c_oos:+,.0f})")
+    if noise:
+        ok = float(noise["p_value"]) <= 0.05
+        v["criteria"]["3_noise_test_rejects"] = bool(ok)
+        log(f"  3. survives noise test? {'YES' if ok else 'NO'}  (permutation p={noise['p_value']}, "
+            f"null mean ${noise['null_mean']:,.0f})")
+    if paired:
+        st = paired.get("A_vs_baseline") or {}
+        lo, hi = st.get("boot_ci95_total", [None, None])
+        ok = bool(lo is not None and (lo > 0 or hi < 0))
+        v["criteria"]["4_paired_ci_excludes_zero"] = ok
+        log(f"  4. paired CI excludes 0?{'YES' if ok else ' NO'}  "
+            f"(Δ ${st.get('total_diff', 0):,.0f}, 95% CI [{lo:,.0f}, {hi:,.0f}], p={st.get('p_two_sided')})")
+        v["mde_total_paired"] = st.get("mde_total_paired")
+        v["observed_effect"] = st.get("total_diff")
+
+    passed = all(v["criteria"].values()) and len(v["criteria"]) == 4
+    v["adopt"] = bool(passed)
+    if passed:
+        v["verdict"] = "ADOPT"
+    else:
+        eff, mde = v.get("observed_effect"), v.get("mde_total_paired")
+        underpowered = (eff is not None and mde is not None and abs(eff) < mde)
+        v["verdict"] = "DEFAULT-OFF — CANNOT TELL (underpowered)" if underpowered else "DEFAULT-OFF — NO EFFECT"
+        v["underpowered"] = bool(underpowered)
+    log(f"  ⇒ {v['verdict']}")
+    if v.get("underpowered"):
+        log(f"     |observed ${abs(v['observed_effect']):,.0f}| < minimum detectable "
+            f"${v['mde_total_paired']:,.0f} ⇒ this design could NOT have seen an improvement of this "
+            f"size. The null says nothing about the indicators.")
+    return v
+
+
 def params_from_trial(t):
     """Rebuild the engine params dict from a stored trial — from RECORDED values, never re-derived.
 
@@ -411,8 +497,18 @@ def cmd_extract(args, log):
     would be selecting on the test set, which is the exact trap this whole exercise exists to avoid. So
     the front is ranked by the TRAIN objective and `selected` is its top member; the rest are reported
     only so the spread is visible.
+
+    ⚠️ `--scramble-seed` is REQUIRED when extracting a CONTROL study, and it must be the seed that
+    study was searched with. The dumb control asks "what does this search procedure score when the
+    indicators carry no information?" — that is a statement about the whole pipeline under the null, so
+    the holdout must be scored with the SAME placebo votes the search trained on. Scoring a control
+    winner with real votes silently answers a different question (what an arbitrarily-chosen real
+    configuration earns) and the resulting number is not a null at all.
     """
     import optuna
+    if args.scramble_seed is not None:
+        install_vote_scrambler(args.scramble_seed, log)
+        log(f"[gate] extracting under PLACEBO votes (seed {args.scramble_seed}) — this is a CONTROL study")
     storage = _storage()
     study = optuna.load_study(study_name=args.study, storage=storage)
 
@@ -474,7 +570,7 @@ def cmd_evaluate(args, log):
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
-    ap.add_argument("cmd", choices=["baseline", "evaluate", "search", "extract", "noise", "paired"])
+    ap.add_argument("cmd", choices=["baseline", "evaluate", "search", "extract", "noise", "paired", "verdict"])
     ap.add_argument("--tf", default="4h")
     ap.add_argument("--instrument", default="NQ")
     ap.add_argument("--params", default=None, help="params JSON (for `evaluate`)")
@@ -490,6 +586,13 @@ def main() -> int:
     ap.add_argument("--study", default=None, help="study name (for `extract`)")
     ap.add_argument("--top", type=int, default=5, help="front members to score (`extract`)")
     ap.add_argument("--perms", type=int, default=200, help="permutations for the noise check")
+    ap.add_argument("--scramble-seed", type=int, default=None,
+                    help="REQUIRED when extracting a CONTROL study: the seed it was searched\n                         with, so the holdout is scored under the SAME placebo votes.")
+    ap.add_argument("--baseline", default=None, help="baseline JSON (verdict)")
+    ap.add_argument("--treatment", default=None, help="treatment extract JSON (verdict)")
+    ap.add_argument("--control", default=None, help="control extract JSON (verdict)")
+    ap.add_argument("--noise-json", default=None, help="noise JSON (verdict)")
+    ap.add_argument("--paired-json", default=None, help="paired JSON (verdict)")
     ap.add_argument("--out", default=None)
     args = ap.parse_args()
 
@@ -498,7 +601,7 @@ def main() -> int:
 
     res = {"baseline": cmd_baseline, "evaluate": cmd_evaluate, "search": cmd_search,
            "extract": cmd_extract, "noise": cmd_noise,
-           "paired": cmd_paired}[args.cmd](args, log)
+           "paired": cmd_paired, "verdict": cmd_verdict}[args.cmd](args, log)
     if args.out:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)
         Path(args.out).write_text(json.dumps(res, indent=2))

--- a/subprojects/Parametric-Indicators/optimize/optimizer.py
+++ b/subprojects/Parametric-Indicators/optimize/optimizer.py
@@ -78,8 +78,26 @@ def _suggest_indicators(trial, exclude=(), only=(), prefix="", max_enabled=None)
         specs.append({"key": key, "enabled": enabled, "mode": meta["mode"], "params": params, "_searched": True})
     if max_enabled is not None:
         on = [s for s in specs if s["enabled"]]
-        for s in on[int(max_enabled):]:      # deterministic REGISTRY order ⇒ reproducible repair
-            s["enabled"] = False
+        if len(on) > int(max_enabled):
+            # UNBIASED repair (#14). Keeping "the first max_enabled in REGISTRY order" sounds neutral
+            # and is not: the registry lists the ORIGINAL 18 indicators at positions 0-17 and the 147
+            # added by #12 from position 18 onward, so an original ALWAYS wins the tie. With ~50% of
+            # 165 flags enabled per trial, at least 3 originals are on ~99.9% of the time — so the cap
+            # keeps originals essentially always.
+            #
+            # MEASURED on a live 16,000-trial adopt-gate study: **0 of 1,500 sampled trials kept a
+            # single new-library indicator.** The ten most-kept keys were all registry positions 0-13.
+            # A search whose entire purpose was to evaluate the new library was testing only the old
+            # one — and it would have returned a confident, meaningless verdict.
+            #
+            # Seeded by the trial number: reproducible per trial (same trial ⇒ same repair, so resumes
+            # and re-scores are stable) but independent of registry position.
+            import random as _random
+            rnd = _random.Random(getattr(trial, "number", 0))
+            keep = {id(s) for s in rnd.sample(on, int(max_enabled))}
+            for s in on:
+                if id(s) not in keep:
+                    s["enabled"] = False
     return specs
 
 

--- a/subprojects/Parametric-Indicators/optimize/optimizer.py
+++ b/subprojects/Parametric-Indicators/optimize/optimizer.py
@@ -386,6 +386,9 @@ def _load_json(p: Path) -> dict:
     return json.loads(p.read_text())
 
 
+PROGRESS_CALLBACK = None      # optional per-trial callback, set by a driver (see #14)
+
+
 def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
         seed: int = 1, ind_1min: bool = False, study_prefix: str = "wsh3",
         split_sltp: bool = False, warm_start: bool = True, sampler: str = "nsga3",
@@ -394,7 +397,7 @@ def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
         contrib_exclude=None, instrument: str = "NQ", intracandle: bool = False,
         freeze_indicators: bool = False, intracandle_always_on: bool = False,
         force_eod: bool = False, max_enabled: int | None = None,
-        reference: str | None = None) -> dict:
+        reference: str | None = None, train_window: str = "full") -> dict:
     # split_sltp (Q3 / E2): when True the optimizer searches SEPARATE long vs short SL/TP (long_*/short_*),
     # widening the space per the user's point-5 goal. Default False ⇒ shared SL/TP ⇒ identical to prior runs.
     # NOTE FOR THE NEXT FULL RUN (wsh5): launch with split_sltp=True to let longs and shorts get their own
@@ -412,7 +415,6 @@ def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
 
     print(f"[{tf_name}] loading inputs ({instrument}, pv={pv:g}) ...", flush=True)
     df_dec, df1, box, vf, n_split = data_mod.load_inputs(tf_name, instrument)
-    sig_int = signals_to_int(sig_mod.decision_signals(df_dec, box))   # precompute once (param-independent)
     # Cross-series reference (#17): loaded ONCE; None ⇒ cross-series indicators stay neutral (parity).
     ref_df = ref_df1 = None
     if reference and reference != instrument:
@@ -433,6 +435,29 @@ def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
         _xs = tuple(library.lib_xseries.SCHEMA)
         exclude_inds = tuple(dict.fromkeys((*exclude_inds, *_xs)))
         print(f"[{tf_name}] no reference ⇒ cross-series indicators excluded from search: {list(_xs)}", flush=True)
+    # TRAIN WINDOW (#14). By default the walk-forward folds span the WHOLE series, so the second
+    # calendar year is part of training and there is no holdout to validate against. `train_window=
+    # "2025"` truncates every frame to the first year BEFORE anything is computed, so the optimizer
+    # cannot see 2026 at all — which is what makes a later `window="2026"` score genuinely
+    # out-of-sample. Required by the adopt gate; default "full" leaves every existing run unchanged.
+    if train_window and train_window != "full":
+        if train_window != "2025":
+            raise ValueError(f"train_window must be 'full' or '2025', got {train_window!r}")
+        t0 = df_dec["Date"].iloc[0]
+        t_end = df_dec["Date"].iloc[n_split - 1] + tf.bar_td
+        df_dec = df_dec.iloc[:n_split].reset_index(drop=True)
+        df1 = df1[(df1["Date"] >= t0) & (df1["Date"] < t_end)].reset_index(drop=True)
+        vf = vf[:n_split]
+        if ref_df is not None:
+            ref_df = ref_df[ref_df["Date"] < t_end].reset_index(drop=True)
+        if ref_df1 is not None:
+            ref_df1 = ref_df1[ref_df1["Date"] < t_end].reset_index(drop=True)
+        # The volatility gate freezes its threshold on vf[:n_split]; with no second year inside the
+        # training window, that reference is the whole window (still causal w.r.t. the 2026 holdout).
+        n_split = len(df_dec)
+        print(f"[{tf_name}] TRAIN WINDOW = 2025 only: {len(df_dec):,} decision bars / {len(df1):,} "
+              f"1-minute bars. 2026 is HELD OUT and never seen by this search.", flush=True)
+    sig_int = signals_to_int(sig_mod.decision_signals(df_dec, box))   # precompute once (param-independent)
     print(f"[{tf_name}] {len(df_dec)} decision bars; cooldown cap {cap}; "
           f"bounds sl_soft{b['sl_soft']} sl_hard{b['sl_hard']} tp{b['tp']}; "
           f"indicators on {'1-MINUTE frame' if ind_1min else 'decision TF'}", flush=True)
@@ -530,6 +555,13 @@ def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
         # bell. Recording the resolved values here makes the extractor read the truth instead of guessing.
         trial.set_user_attr("cap_mode", cap_mode)
         trial.set_user_attr("cap_1min", cap_1min)
+        # The ENABLED indicator layer, verbatim (#14). Reconstructing it later from `trial.params` means
+        # replaying `_suggest_indicators` against a FixedTrial and trusting that the replay is faithful —
+        # the same class of "re-derive it downstream" mistake the comment above warns about. Recording it
+        # is exact and, with --max-enabled capped, tiny. Disabled specs are omitted: every consumer
+        # (`_cached_votes`, `veto_mask`, `confirm_mask`) filters on `config.enabled` anyway.
+        trial.set_user_attr("enabled_specs", [s for s in specs if s.get("enabled")])
+        trial.set_user_attr("k_rule", int(k_rule))
         trial.set_user_attr("worst_dd", worst_dd)
         trial.set_user_attr("median_pnl", r["median_pnl"])
         trial.set_user_attr("median_win", med_win)
@@ -609,7 +641,9 @@ def run(tf_name: str, n_trials: int = 200, folds: int = 5, min_trades: int = 5,
     # A transient store error (e.g. SQLite "database is locked" under many concurrent workers) fails
     # only THIS trial — it must never kill the worker, or the study loses capacity for the rest of the
     # run. See optimize/server/INCIDENT_wsh4_sqlite_contention.md.
-    study.optimize(objective, n_trials=n_trials, show_progress_bar=False,
+    # A caller (the #14 adopt gate) may install a heartbeat so a multi-hour run is observable.
+    _cbs = [PROGRESS_CALLBACK] if PROGRESS_CALLBACK is not None else None
+    study.optimize(objective, n_trials=n_trials, show_progress_bar=False, callbacks=_cbs,
                    catch=(optuna.exceptions.StorageInternalError,))
     dur = time.time() - t0
 
@@ -703,6 +737,11 @@ def main() -> int:
     ap.add_argument("--max-enabled", type=int, default=None,
                     help="Cap simultaneously-enabled indicators per trial (post-suggestion repair, REGISTRY order). "
                          "Keeps the ~125-key K-of-N search sparse/interpretable. Default: uncapped.")
+    ap.add_argument("--train-window", default="full", choices=["full", "2025"],
+                    help="Restrict the WHOLE search to a training window. 'full' (default) walk-forwards "
+                         "over the entire series, so there is no holdout. '2025' truncates every frame to "
+                         "the first calendar year, leaving 2026 genuinely UNSEEN — required for an "
+                         "out-of-sample adopt gate (#14). Score the winner afterwards with window='2026'.")
     ap.add_argument("--reference", default=None,
                     help="Reference instrument for the cross-series indicators (rolling_corr/beta, "
                          "cointegration, pca_factor), e.g. ES. Causally aligned; default: none (they stay inert).")
@@ -735,7 +774,8 @@ def main() -> int:
         contrib_tokens=contrib_tokens, instrument=a.instrument,
         intracandle=(a.intracandle or a.intracandle_on),
         freeze_indicators=a.freeze_indicators, intracandle_always_on=a.intracandle_on,
-        force_eod=a.force_eod, max_enabled=a.max_enabled, reference=a.reference)
+        force_eod=a.force_eod, max_enabled=a.max_enabled, reference=a.reference,
+        train_window=a.train_window)
     return 0
 
 

--- a/subprojects/Parametric-Indicators/optimize/perf/check_max_enabled_bias.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/check_max_enabled_bias.py
@@ -1,0 +1,28 @@
+"""Issue #14 — measure, on a LIVE Optuna study, which indicators the --max-enabled cap actually keeps.
+
+This is the check that caught the bias: the repair kept 'the first max_enabled in REGISTRY order', and
+since the original 18 indicators occupy positions 0-17 an original always won the tie. Reasoning about
+it is not enough — this reads the trials that were actually scored.
+
+Usage:  python3 -m optimize.perf.check_max_enabled_bias <study_name> [n_sample]
+"""
+import sys, os, json, collections, statistics
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+import optuna
+from indicators import library
+
+study = sys.argv[1] if len(sys.argv) > 1 else 'adopt14v2treat_4h'
+n = int(sys.argv[2]) if len(sys.argv) > 2 else 1500
+R = list(library.REGISTRY); ORIG = set(R[:18])
+st = optuna.load_study(study_name=study, storage=os.environ['WSH_STORAGE_URL'])
+cnt = collections.Counter(); anynew = tot = 0; pos = []
+for t in st.trials[:n]:
+    keys = [s['key'] for s in t.user_attrs.get('enabled_specs', [])]
+    if not keys: continue
+    tot += 1
+    for k in keys: cnt[k] += 1; pos.append(R.index(k))
+    if any(k not in ORIG for k in keys): anynew += 1
+print(f'study {study}: {tot} trials with a non-empty enabled set')
+print(f'  trials containing ANY new-library indicator: {anynew} ({100*anynew/max(1,tot):.1f}%)')
+print(f'  mean registry position kept: {statistics.mean(pos):.1f}  (unbiased expectation ~{(len(R)-1)/2:.0f})')
+print(f'  most-kept NEW: {[(k,c) for k,c in cnt.most_common() if k not in ORIG][:8]}')

--- a/subprojects/Parametric-Indicators/optimize/perf/finish_adopt_gate.sh
+++ b/subprojects/Parametric-Indicators/optimize/perf/finish_adopt_gate.sh
@@ -16,11 +16,11 @@ L=optimize/perf/logs
 SEED=20260728
 mkdir -p "$R" "$L"
 
-$PY -u -m optimize.adopt_gate extract --study adopt14treat_4h --top 5 \
+$PY -u -m optimize.adopt_gate extract --study adopt14v2treat_4h --top 5 \
     --out "$R/adoptgate_treatment_4h.json" > "$L/issue14_extract_treatment.log" 2>&1
 echo "EXTRACT_TREAT=$?"
 
-$PY -u -m optimize.adopt_gate extract --study adopt14ctrl_4h --top 5 --scramble-seed "$SEED" \
+$PY -u -m optimize.adopt_gate extract --study adopt14v2ctrl_4h --top 5 --scramble-seed "$SEED" \
     --out "$R/adoptgate_control_4h.json" > "$L/issue14_extract_control.log" 2>&1
 echo "EXTRACT_CTRL=$?"
 

--- a/subprojects/Parametric-Indicators/optimize/perf/finish_adopt_gate.sh
+++ b/subprojects/Parametric-Indicators/optimize/perf/finish_adopt_gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Issue #14 — closing pipeline for the adopt gate. Runs once both searches finish.
+#
+# Order matters: extract BEFORE paired/noise (they need the winner's params), and the CONTROL extract
+# must carry --scramble-seed. The control asks "what does this search score when the indicators carry
+# no information?" — a statement about the whole pipeline under the null — so its holdout has to be
+# scored with the SAME placebo votes the search trained on. Scoring a control winner with REAL votes
+# silently answers a different question and the number stops being a null.
+set -x
+cd ~/Mulham/14-adopt-gate/subprojects/Parametric-Indicators || exit 1
+source /home/dev/Mulham/wsg-i/pg.env
+export WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data
+PY=/home/dev/Mulham/.venv/bin/python3
+R=optimize/results
+L=optimize/perf/logs
+SEED=20260728
+mkdir -p "$R" "$L"
+
+$PY -u -m optimize.adopt_gate extract --study adopt14treat_4h --top 5 \
+    --out "$R/adoptgate_treatment_4h.json" > "$L/issue14_extract_treatment.log" 2>&1
+echo "EXTRACT_TREAT=$?"
+
+$PY -u -m optimize.adopt_gate extract --study adopt14ctrl_4h --top 5 --scramble-seed "$SEED" \
+    --out "$R/adoptgate_control_4h.json" > "$L/issue14_extract_control.log" 2>&1
+echo "EXTRACT_CTRL=$?"
+
+$PY - "$R/adoptgate_treatment_4h.json" <<'PYEOF'
+import json, sys
+d = json.load(open(sys.argv[1]))
+json.dump(d["selected"]["params"], open("/tmp/winner.json", "w"))
+print("winner indicators:", d["selected"]["enabled_indicators"])
+PYEOF
+
+$PY -u -m optimize.adopt_gate paired --params /tmp/winner.json \
+    --out "$R/adoptgate_paired_4h.json" > "$L/issue14_paired.log" 2>&1
+echo "PAIRED=$?"
+
+$PY -u -m optimize.adopt_gate noise --params /tmp/winner.json --perms 200 \
+    --out "$R/adoptgate_noise_4h.json" > "$L/issue14_noise.log" 2>&1
+echo "NOISE=$?"
+
+$PY -u -m optimize.adopt_gate verdict \
+    --baseline "$R/adoptgate_baseline_4h.json" \
+    --treatment "$R/adoptgate_treatment_4h.json" \
+    --control "$R/adoptgate_control_4h.json" \
+    --noise-json "$R/adoptgate_noise_4h.json" \
+    --paired-json "$R/adoptgate_paired_4h.json" \
+    --out "$R/adoptgate_verdict_4h.json" > "$L/issue14_verdict.log" 2>&1
+echo "VERDICT=$?"
+cat "$L/issue14_verdict.log"
+echo '=== GATE FINISHED ==='

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_control.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_control.log
@@ -1,0 +1,47 @@
+[gate] PLACEBO: vote cache isolated at /tmp/adoptgate_placebo_votecache_85g8tman (a scrambled vote must never reach the real cache)
+[gate] CONTROL search: tf=4h trials=47100 max_enabled=3 train_window=2025 prefix=adopt14v2ctrl
+[4h] loading inputs (NQ, pv=20) ...
+[4h] no reference ⇒ cross-series indicators excluded from search: ['rolling_corr', 'rolling_beta', 'cointegration', 'pca_factor']
+[4h] TRAIN WINDOW = 2025 only: 1,534 decision bars / 352,564 1-minute bars. 2026 is HELD OUT and never seen by this search.
+[4h] 1534 decision bars; cooldown cap 2; bounds sl_soft[25, 153] sl_hard[34, 204] tp[32, 236]; indicators on 1-MINUTE frame
+/home/dev/Mulham/14-adopt-gate/subprojects/Parametric-Indicators/optimize/optimizer.py:288: ExperimentalWarning: NSGAIIISampler is experimental (supported from v3.2.0). The interface can change in the future.
+  return optuna.samplers.NSGAIIISampler(seed=seed, constraints_func=constraints_func)
+[4h] sampler = nsga3 → NSGAIIISampler  objective=<function run.<locals>.objective at 0x747e49c98040>  dd_pnl_cap=0.25
+[4h] warm-started 3 known-champion seed trial(s) — the front is guaranteed ≥ their score
+[gate] control 2,000/47,100 trials (126/min, ETA 359 min) best-on-train $15,937
+[gate] control 4,000/47,100 trials (147/min, ETA 293 min) best-on-train $17,254
+[gate] control 6,000/47,100 trials (159/min, ETA 258 min) best-on-train $17,254
+[gate] control 8,000/47,100 trials (167/min, ETA 235 min) best-on-train $17,254
+[gate] control 10,000/47,100 trials (172/min, ETA 216 min) best-on-train $17,254
+[gate] control 12,000/47,100 trials (175/min, ETA 200 min) best-on-train $17,254
+[gate] control 14,000/47,100 trials (178/min, ETA 186 min) best-on-train $17,629
+[gate] control 16,000/47,100 trials (180/min, ETA 173 min) best-on-train $17,629
+[gate] control 18,000/47,100 trials (181/min, ETA 161 min) best-on-train $17,629
+[gate] control 20,000/47,100 trials (182/min, ETA 149 min) best-on-train $17,629
+[gate] control 22,000/47,100 trials (182/min, ETA 138 min) best-on-train $17,629
+[gate] control 24,000/47,100 trials (183/min, ETA 126 min) best-on-train $17,629
+[gate] control 26,000/47,100 trials (183/min, ETA 115 min) best-on-train $17,629
+[gate] control 28,000/47,100 trials (183/min, ETA 105 min) best-on-train $17,629
+[gate] control 30,000/47,100 trials (182/min, ETA 94 min) best-on-train $17,629
+[gate] control 32,000/47,100 trials (182/min, ETA 83 min) best-on-train $17,629
+[gate] control 34,000/47,100 trials (181/min, ETA 72 min) best-on-train $17,629
+[gate] control 36,000/47,100 trials (181/min, ETA 61 min) best-on-train $17,771
+[gate] control 38,000/47,100 trials (180/min, ETA 51 min) best-on-train $17,771
+[gate] control 40,000/47,100 trials (179/min, ETA 40 min) best-on-train $17,771
+[gate] control 42,000/47,100 trials (178/min, ETA 29 min) best-on-train $17,771
+[gate] control 44,000/47,100 trials (177/min, ETA 17 min) best-on-train $17,771
+[gate] control 46,000/47,100 trials (176/min, ETA 6 min) best-on-train $18,477
+[4h] 47100 trials in 16093s; feasible Pareto front 24/24 (DD≤25%·P&L):
+   P/L(med) $ 18,477  maxDD $ 3,975  win 52.1%  pause 12.7d  | full P/L $ 67,200 DD $10,315 (15%) | slS 34 slH 198 tp 216 gate 83 dd 4663 cd 1 flip False K1 +77ind
+   P/L(med) $ 17,386  maxDD $ 9,279  win 54.9%  pause 11.5d  | full P/L $ 46,147 DD $ 8,734 (19%) | slS 34 slH 81 tp 198 gate 83 dd 4663 cd 1 flip False K1 +84ind
+   P/L(med) $ 16,269  maxDD $ 4,850  win 54.5%  pause 11.2d  | full P/L $ 57,219 DD $ 7,470 (13%) | slS 34 slH 198 tp 216 gate 83 dd 4663 cd 1 flip False K1 +78ind
+   P/L(med) $ 16,035  maxDD $ 3,390  win 54.5%  pause 12.7d  | full P/L $ 31,539 DD $ 4,524 (14%) | slS 34 slH 81 tp 216 gate 83 dd 4663 cd 1 flip False K1 +80ind
+   P/L(med) $ 15,517  maxDD $14,180  win 55.0%  pause 11.3d  | full P/L $ 70,084 DD $ 9,575 (14%) | slS 34 slH 68 tp 216 gate 83 dd 4663 cd 1 flip False K1 +84ind
+   P/L(med) $ 14,273  maxDD $ 4,000  win 55.0%  pause 11.3d  | full P/L $ 42,484 DD $ 5,265 (12%) | slS 34 slH 68 tp 216 gate 83 dd 4663 cd 1 flip False K1 +76ind
+   P/L(med) $ 14,083  maxDD $ 9,210  win 59.0%  pause 13.7d  | full P/L $ 38,682 DD $ 8,390 (22%) | slS 34 slH 198 tp 198 gate 83 dd 4663 cd 1 flip False K1 +86ind
+   P/L(med) $ 14,068  maxDD $ 7,735  win 55.2%  pause 12.7d  | full P/L $ 54,421 DD $ 8,060 (15%) | slS 34 slH 198 tp 216 gate 83 dd 4663 cd 1 flip False K1 +81ind
+   P/L(med) $ 13,739  maxDD $ 5,405  win 56.9%  pause 12.3d  | full P/L $ 50,064 DD $ 6,425 (13%) | slS 34 slH 198 tp 216 gate 83 dd 4663 cd 1 flip False K1 +82ind
+   P/L(med) $ 13,443  maxDD $ 3,295  win 56.2%  pause 11.3d  | full P/L $ 34,331 DD $ 5,540 (16%) | slS 34 slH 198 tp 216 gate 83 dd 4663 cd 1 flip False K1 +82ind
+   P/L(med) $ 13,189  maxDD $ 3,295  win 56.5%  pause 12.5d  | full P/L $ 38,655 DD $ 4,045 (10%) | slS 34 slH 81 tp 198 gate 83 dd 4663 cd 1 flip False K1 +80ind
+   P/L(med) $ 13,101  maxDD $ 3,275  win 56.0%  pause 13.0d  | full P/L $ 28,283 DD $ 5,930 (21%) | slS 34 slH 198 tp 198 gate 83 dd 4663 cd 1 flip False K1 +88ind
+[gate] PLACEBO: scrambled 26,410 vote computations

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_extract_control.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_extract_control.log
@@ -1,0 +1,9 @@
+[gate] PLACEBO: vote cache isolated at /tmp/adoptgate_placebo_votecache_951tgq6m (a scrambled vote must never reach the real cache)
+[gate] extracting under PLACEBO votes (seed 20260728) — this is a CONTROL study
+[gate] study adopt14v2ctrl_4h: 47,100 trials, feasible front 24
+  front[0] ['hma', 'vidya', 'mama_fama'] TRAIN(2025) P/L $    16,831 DD $  12,203 n= 182  |  HOLDOUT(2026) P/L $    14,039 DD $   8,355 n=  80
+  front[1] ['alma', 'evwma', 'force_index'] TRAIN(2025) P/L $    18,936 DD $  11,640 n= 247  |  HOLDOUT(2026) P/L $    17,999 DD $   8,950 n= 103
+  front[2] ['alma', 'tvi', 'ichimoku_chikou'] TRAIN(2025) P/L $    72,558 DD $   7,250 n= 225  |  HOLDOUT(2026) P/L $    12,691 DD $   7,515 n=  98
+  front[3] ['vidya', 'parkinson', 'ad_line'] TRAIN(2025) P/L $    24,342 DD $   8,920 n= 111  |  HOLDOUT(2026) P/L $    10,265 DD $   3,765 n=  43
+  front[4] ['mfi', 'alma', 'twiggs_mf'] TRAIN(2025) P/L $    35,817 DD $  11,245 n= 177  |  HOLDOUT(2026) P/L $     4,027 DD $  13,410 n=  77
+[gate] WROTE optimize/results/adoptgate_control_4h.json

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_extract_treatment.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_extract_treatment.log
@@ -1,0 +1,7 @@
+[gate] study adopt14v2treat_4h: 47,100 trials, feasible front 108
+  front[0] ['apo', 'pivot_camarilla', 'dfa'] TRAIN(2025) P/L $    62,356 DD $  13,854 n= 389  |  HOLDOUT(2026) P/L $    18,827 DD $  12,679 n= 157
+  front[1] ['obv', 'structure_trend', 'order_block'] TRAIN(2025) P/L $    72,879 DD $  16,699 n= 248  |  HOLDOUT(2026) P/L $    52,438 DD $  14,214 n=  98
+  front[2] ['pvi', 'force_index', 'td_combo'] TRAIN(2025) P/L $    88,680 DD $   8,260 n= 421  |  HOLDOUT(2026) P/L $    20,295 DD $  19,272 n= 170
+  front[3] ['cci', 'structure_trend', 'order_block'] TRAIN(2025) P/L $    99,580 DD $  15,491 n= 186  |  HOLDOUT(2026) P/L $    55,066 DD $  10,048 n=  69
+  front[4] ['ppo', 'smi', 'disparity'] TRAIN(2025) P/L $    79,019 DD $   7,942 n= 355  |  HOLDOUT(2026) P/L $    18,820 DD $  22,571 n= 133
+[gate] WROTE optimize/results/adoptgate_treatment_4h.json

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_maxenabled_bias_after.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_maxenabled_bias_after.log
@@ -1,0 +1,4 @@
+study adopt14v2treat_4h: 162 trials with a non-empty enabled set
+  trials containing ANY new-library indicator: 159 (98.1%)
+  mean registry position kept: 80.3  (unbiased expectation ~82)
+  most-kept NEW: [('pivot_floor', 10), ('pvi', 8), ('volume_ratio_asia', 7), ('anchored_vwap', 7), ('stoch_rsi', 7), ('rsi_connors', 6), ('emd', 6), ('asi', 6)]

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_noise.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_noise.log
@@ -1,0 +1,16 @@
+[gate] NOISE: vote cache isolated at /tmp/adoptgate_noise_votecache_lz31516q
+[gate] winner indicators ['apo', 'pivot_camarilla', 'dfa']: REAL holdout P/L $18,827 (n=157)
+[gate] noise 20/200 … null mean $6,940
+[gate] noise 40/200 … null mean $8,078
+[gate] noise 60/200 … null mean $8,446
+[gate] noise 80/200 … null mean $8,973
+[gate] noise 100/200 … null mean $8,508
+[gate] noise 120/200 … null mean $7,547
+[gate] noise 140/200 … null mean $7,423
+[gate] noise 160/200 … null mean $6,941
+[gate] noise 180/200 … null mean $6,706
+[gate] noise 200/200 … null mean $6,655
+[gate] NULL n=200  mean $6,655  sd $10,449  p95 $23,370  max $30,868
+[gate] p = 0.1244  (24/200 scrambles matched or beat the real result)
+[gate] the edge SURVIVES scrambling ⇒ it does not come from the indicators
+[gate] WROTE optimize/results/adoptgate_noise_4h.json

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_paired.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_paired.log
@@ -1,0 +1,9 @@
+[gate] candidate indicators ['apo', 'pivot_camarilla', 'dfa']
+[gate]   candidate  HOLDOUT P/L $    18,827  n= 157
+[gate]   baseline   HOLDOUT P/L $    61,601  n=  81
+[gate]   same-but-indicators-OFF $    12,271  n= 193
+[gate] A_vs_baseline: 169 paired bars, 0.0% identical  total diff $-42,774  95% CI [-92,499, 6,432]  p=0.0941
+[gate]   SE(total) paired $25,408 vs unpaired $28,650  ⇒ pairing is 1.13× more sensitive (detectable: $71,183 paired vs $80,266)
+[gate] B_ablation_indicators_off: 193 paired bars, 81.3% identical  total diff $6,556  95% CI [-12,807, 27,656]  p=0.5155
+[gate]   SE(total) paired $10,063 vs unpaired $30,779  ⇒ pairing is 3.06× more sensitive (detectable: $28,192 paired vs $86,229)
+[gate] WROTE optimize/results/adoptgate_paired_4h.json

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_paired_selfcheck.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_paired_selfcheck.log
@@ -1,0 +1,9 @@
+[gate] candidate indicators ['macd', 'vwap', 'keltner', 'obv', 'mfi', 'bollinger', 'structure_trend', 'order_block']
+[gate]   candidate  HOLDOUT P/L $    61,601  n=  81
+[gate]   baseline   HOLDOUT P/L $    61,601  n=  81
+[gate]   same-but-indicators-OFF $    22,138  n= 157
+[gate] A_vs_baseline: 81 paired bars, 100.0% identical  total diff $0  95% CI [0, 0]  p=1.0000
+[gate]   SE(total) paired $0 vs unpaired $28,228  ⇒ pairing is None× more sensitive (detectable: $0 paired vs $79,082)
+[gate] B_ablation_indicators_off: 164 paired bars, 45.1% identical  total diff $39,463  95% CI [-4,548, 83,514]  p=0.0887
+[gate]   SE(total) paired $23,045 vs unpaired $36,352  ⇒ pairing is 1.58× more sensitive (detectable: $64,562 paired vs $101,844)
+[gate] WROTE optimize/results/adoptgate_paired_selfcheck_4h.json

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_power_survey.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_power_survey.log
@@ -1,0 +1,18 @@
+  tf OOS trades      OOS P/L  mean/trade   sd/trade  MDE/trade    MDE total  MDE as % of OOS P/L
+  4h         81 $     61,601 $       761 $    2,218 $      690 $     55,920                  91%
+  2h         50 $     40,745 $       815 $    1,624 $      644 $     32,180                  79%
+  1h         38 $     27,203 $       716 $    1,901 $      864 $     32,829                 121%
+ 15m         73 $     21,306 $       292 $      994 $      326 $     23,799                 112%
+  5m         16 $      2,600 $       163 $      438 $      307 $      4,908                 189%
+  2m        149 $      4,545 $        30 $      345 $       79 $     11,791                 259%
+
+slots=33  pooled n=1,571 trades
+  baseline edge      = 0.0904 sd-units per trade
+  MDE (a=.05,pw=.80) = 0.0712 sd-units per trade
+  -> smallest detectable improvement = 79% of the existing edge
+     n=   81 -> MDE   347% of the edge
+     n=  150 -> MDE   255% of the edge
+     n=  400 -> MDE   156% of the edge
+     n=  800 -> MDE   110% of the edge
+     n= 1571 -> MDE    79% of the edge
+     n= 4000 -> MDE    49% of the edge

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_treatment.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_treatment.log
@@ -1,0 +1,45 @@
+[gate] TREATMENT search: tf=4h trials=47100 max_enabled=3 train_window=2025 prefix=adopt14v2treat
+[4h] loading inputs (NQ, pv=20) ...
+[4h] no reference ⇒ cross-series indicators excluded from search: ['rolling_corr', 'rolling_beta', 'cointegration', 'pca_factor']
+[4h] TRAIN WINDOW = 2025 only: 1,534 decision bars / 352,564 1-minute bars. 2026 is HELD OUT and never seen by this search.
+[4h] 1534 decision bars; cooldown cap 2; bounds sl_soft[25, 153] sl_hard[34, 204] tp[32, 236]; indicators on 1-MINUTE frame
+/home/dev/Mulham/14-adopt-gate/subprojects/Parametric-Indicators/optimize/optimizer.py:288: ExperimentalWarning: NSGAIIISampler is experimental (supported from v3.2.0). The interface can change in the future.
+  return optuna.samplers.NSGAIIISampler(seed=seed, constraints_func=constraints_func)
+[4h] sampler = nsga3 → NSGAIIISampler  objective=<function run.<locals>.objective at 0x7429a42380e0>  dd_pnl_cap=0.25
+[4h] warm-started 3 known-champion seed trial(s) — the front is guaranteed ≥ their score
+[gate] treatment 2,000/47,100 trials (135/min, ETA 334 min) best-on-train $20,677
+[gate] treatment 4,000/47,100 trials (156/min, ETA 275 min) best-on-train $20,677
+[gate] treatment 6,000/47,100 trials (168/min, ETA 244 min) best-on-train $20,677
+[gate] treatment 8,000/47,100 trials (175/min, ETA 224 min) best-on-train $20,677
+[gate] treatment 10,000/47,100 trials (179/min, ETA 207 min) best-on-train $20,677
+[gate] treatment 12,000/47,100 trials (182/min, ETA 193 min) best-on-train $20,677
+[gate] treatment 14,000/47,100 trials (183/min, ETA 181 min) best-on-train $20,677
+[gate] treatment 16,000/47,100 trials (185/min, ETA 168 min) best-on-train $20,677
+[gate] treatment 18,000/47,100 trials (185/min, ETA 157 min) best-on-train $20,677
+[gate] treatment 20,000/47,100 trials (186/min, ETA 146 min) best-on-train $20,677
+[gate] treatment 22,000/47,100 trials (187/min, ETA 134 min) best-on-train $20,677
+[gate] treatment 24,000/47,100 trials (187/min, ETA 124 min) best-on-train $20,677
+[gate] treatment 26,000/47,100 trials (187/min, ETA 113 min) best-on-train $20,677
+[gate] treatment 28,000/47,100 trials (186/min, ETA 102 min) best-on-train $20,677
+[gate] treatment 30,000/47,100 trials (186/min, ETA 92 min) best-on-train $20,677
+[gate] treatment 32,000/47,100 trials (185/min, ETA 82 min) best-on-train $20,677
+[gate] treatment 34,000/47,100 trials (185/min, ETA 71 min) best-on-train $20,677
+[gate] treatment 36,000/47,100 trials (184/min, ETA 60 min) best-on-train $20,677
+[gate] treatment 38,000/47,100 trials (183/min, ETA 50 min) best-on-train $20,677
+[gate] treatment 40,000/47,100 trials (182/min, ETA 39 min) best-on-train $20,677
+[gate] treatment 42,000/47,100 trials (181/min, ETA 28 min) best-on-train $20,677
+[gate] treatment 44,000/47,100 trials (180/min, ETA 17 min) best-on-train $20,677
+[gate] treatment 46,000/47,100 trials (179/min, ETA 6 min) best-on-train $21,418
+[4h] 47100 trials in 15840s; feasible Pareto front 108/108 (DD≤25%·P&L):
+   P/L(med) $ 21,418  maxDD $12,435  win 43.9%  pause  8.7d  | full P/L $ 62,356 DD $13,854 (22%) | slS 30 slH 199 tp 155 gate 90 dd 376 cd 1 flip False K1 +74ind
+   P/L(med) $ 20,677  maxDD $ 8,263  win 61.1%  pause  9.7d  | full P/L $ 72,879 DD $16,699 (23%) | slS 129 slH 151 tp 126 gate 90 dd 4119 cd 1 flip False K1 +9ind
+   P/L(med) $ 19,110  maxDD $ 7,745  win 47.0%  pause  8.7d  | full P/L $ 88,680 DD $ 8,260 (9%) | slS 34 slH 203 tp 155 gate 90 dd 3928 cd 1 flip False K1 +84ind
+   P/L(med) $ 17,595  maxDD $12,149  win 65.6%  pause 11.5d  | full P/L $ 99,580 DD $15,491 (16%) | slS 150 slH 167 tp 120 gate 87 dd 4747 cd 0 flip False K1 +3ind
+   P/L(med) $ 16,540  maxDD $ 6,810  win 47.4%  pause 10.8d  | full P/L $ 79,019 DD $ 7,942 (10%) | slS 34 slH 203 tp 155 gate 90 dd 515 cd 1 flip False K1 +82ind
+   P/L(med) $ 16,476  maxDD $ 7,515  win 49.0%  pause  9.2d  | full P/L $ 69,617 DD $ 7,860 (11%) | slS 34 slH 203 tp 198 gate 90 dd 515 cd 1 flip False K1 +86ind
+   P/L(med) $ 16,467  maxDD $ 6,810  win 48.2%  pause 10.8d  | full P/L $ 82,254 DD $10,667 (13%) | slS 34 slH 203 tp 155 gate 90 dd 3928 cd 1 flip False K1 +84ind
+   P/L(med) $ 16,396  maxDD $ 5,975  win 50.0%  pause 12.0d  | full P/L $ 68,911 DD $ 9,272 (13%) | slS 34 slH 203 tp 155 gate 90 dd 376 cd 1 flip False K1 +77ind
+   P/L(med) $ 15,746  maxDD $ 6,995  win 51.6%  pause  9.3d  | full P/L $ 53,079 DD $10,750 (20%) | slS 34 slH 203 tp 198 gate 90 dd 3928 cd 1 flip False K1 +83ind
+   P/L(med) $ 15,642  maxDD $ 5,600  win 45.5%  pause 12.0d  | full P/L $ 68,239 DD $13,018 (19%) | slS 30 slH 77 tp 155 gate 90 dd 376 cd 1 flip False K1 +84ind
+   P/L(med) $ 15,596  maxDD $ 5,945  win 49.6%  pause 10.7d  | full P/L $ 81,391 DD $ 5,945 (7%) | slS 34 slH 203 tp 198 gate 90 dd 515 cd 1 flip False K1 +83ind
+   P/L(med) $ 15,482  maxDD $ 6,995  win 52.1%  pause  9.3d  | full P/L $ 53,582 DD $11,399 (21%) | slS 34 slH 81 tp 198 gate 90 dd 3928 cd 1 flip False K1 +80ind

--- a/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_verdict.log
+++ b/subprojects/Parametric-Indicators/optimize/perf/logs/issue14_verdict.log
@@ -1,0 +1,11 @@
+[gate] ── ADOPT GATE VERDICT ──
+  baseline  holdout P/L $     61,601
+  treatment holdout P/L $     18,827   indicators ['apo', 'pivot_camarilla', 'dfa']
+  CONTROL   holdout P/L $     14,039   (placebo votes — the score a search manufactures from noise)   indicators ['hma', 'vidya', 'mama_fama']
+  1. beats baseline?      NO  (Δ $-42,774)
+  2. beats dumb control?  YES  (Δ $+4,788)
+  3. survives noise test? NO  (permutation p=0.12438, null mean $6,655)
+  4. paired CI excludes 0? NO  (Δ $-42,774, 95% CI [-92,499, 6,432], p=0.09414)
+  ⇒ DEFAULT-OFF — CANNOT TELL (underpowered)
+     |observed $42,774| < minimum detectable $71,183 ⇒ this design could NOT have seen an improvement of this size. The null says nothing about the indicators.
+[gate] WROTE optimize/results/adoptgate_verdict_4h.json

--- a/subprojects/Parametric-Indicators/optimize/perf/peek_adopt_studies.py
+++ b/subprojects/Parametric-Indicators/optimize/perf/peek_adopt_studies.py
@@ -1,0 +1,47 @@
+"""Issue #14 — peek at the live adopt-gate studies: best-on-train and which indicators it uses.
+
+Answers the question a flat heartbeat raises: has the search actually BEATEN the warm-start champion
+seed, or is the front still the seed? The optimizer guarantees the front is >= the prior champion, so a
+best-on-train that never moves is not a stall — it may mean 10,000 trials over 165 indicators have not
+found anything better than the existing 8.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import optuna
+
+
+def main() -> int:
+    names = sys.argv[1:] or ["adopt14v2treat_4h", "adopt14v2ctrl_4h"]
+    storage = os.environ.get("WSH_STORAGE_URL")
+    if not storage:
+        print("WSH_STORAGE_URL not set — source pg.env first")
+        return 2
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    for name in names:
+        try:
+            st = optuna.load_study(study_name=name, storage=storage)
+        except Exception as e:                                   # noqa: BLE001
+            print(f"{name}: {type(e).__name__}: {e}")
+            continue
+        done = [t for t in st.trials if t.values]
+        if not done:
+            print(f"{name}: {len(st.trials)} trials, none scored yet")
+            continue
+        best = max(done, key=lambda t: t.values[0])
+        keys = [s["key"] for s in best.user_attrs.get("enabled_specs", [])]
+        print(f"{name}: {len(st.trials):,} trials | best #{best.number} "
+              f"obj0=${best.values[0]:,.0f} DD=${-best.values[1]:,.0f} | k={best.user_attrs.get('k_rule')} "
+              f"| indicators {keys}")
+        print(f"    (trial #{best.number} — the first 3 trials are the warm-start champion seeds, so a "
+              f"best from #0-2 means the search has not beaten the existing champion on train)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/subprojects/Parametric-Indicators/optimize/results/adoptgate_baseline_4h.json
+++ b/subprojects/Parametric-Indicators/optimize/results/adoptgate_baseline_4h.json
@@ -1,0 +1,41 @@
+{
+  "label": "baseline champion",
+  "train_2025": {
+    "pnl": 90054.4764,
+    "max_dd": 11697.624,
+    "n_taken": 196.0,
+    "win": 60.2,
+    "pf": 1.65,
+    "exposure": 100.0
+  },
+  "holdout_2026": {
+    "pnl": 61600.927,
+    "max_dd": 15560.177,
+    "n_taken": 81.0,
+    "win": 69.1,
+    "pf": 2.14,
+    "exposure": 100.0
+  },
+  "enabled_indicators": [
+    "macd",
+    "vwap",
+    "keltner",
+    "obv",
+    "mfi",
+    "bollinger",
+    "structure_trend",
+    "order_block"
+  ],
+  "k": 1,
+  "power_oos": {
+    "n": 81,
+    "mean_per_trade": 760.51,
+    "sd_per_trade": 2217.77,
+    "t_stat": 3.086,
+    "p_two_sided": 0.00278,
+    "mde_per_trade": 690.36,
+    "mde_total": 55920.0,
+    "alpha": 0.05,
+    "power": 0.8
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/results/adoptgate_control_4h.json
+++ b/subprojects/Parametric-Indicators/optimize/results/adoptgate_control_4h.json
@@ -1,0 +1,477 @@
+{
+  "study": "adopt14v2ctrl_4h",
+  "front": 24,
+  "selected": {
+    "label": "front[0] ['hma', 'vidya', 'mama_fama']",
+    "train_2025": {
+      "pnl": 16830.9961,
+      "max_dd": 12203.2227,
+      "n_taken": 182.0,
+      "win": 40.7,
+      "pf": 1.19,
+      "exposure": 100.0
+    },
+    "holdout_2026": {
+      "pnl": 14038.8867,
+      "max_dd": 8355.0,
+      "n_taken": 80.0,
+      "win": 41.2,
+      "pf": 1.32,
+      "exposure": 100.0
+    },
+    "trial_number": 44998,
+    "train_objective": 18476.777348195174,
+    "enabled_indicators": [
+      "hma",
+      "vidya",
+      "mama_fama"
+    ],
+    "params": {
+      "sl_soft": 34.304748736675464,
+      "sl_hard": 197.6961397987374,
+      "tp": 216.08886740975967,
+      "gate_pct": 83.41518386632751,
+      "dd_limit": 4663.1213615017805,
+      "cooldown": 1,
+      "flip": false,
+      "k": 1,
+      "indicators": [
+        {
+          "key": "hma",
+          "enabled": true,
+          "mode": "confirm",
+          "params": {
+            "fast": 207,
+            "slow": 236
+          }
+        },
+        {
+          "key": "vidya",
+          "enabled": true,
+          "mode": "confirm",
+          "params": {
+            "n": 4
+          }
+        },
+        {
+          "key": "mama_fama",
+          "enabled": true,
+          "mode": "confirm",
+          "params": {
+            "fast": 1.0,
+            "slow": 0.44
+          }
+        }
+      ],
+      "cap_mode": "bars",
+      "cap_1min": 171,
+      "ind_1min": true
+    },
+    "power_oos": {
+      "n": 80,
+      "mean_per_trade": 175.49,
+      "sd_per_trade": 1590.08,
+      "t_stat": 0.987,
+      "p_two_sided": 0.3266,
+      "mde_per_trade": 498.06,
+      "mde_total": 39844.0,
+      "alpha": 0.05,
+      "power": 0.8
+    }
+  },
+  "members": [
+    {
+      "label": "front[0] ['hma', 'vidya', 'mama_fama']",
+      "train_2025": {
+        "pnl": 16830.9961,
+        "max_dd": 12203.2227,
+        "n_taken": 182.0,
+        "win": 40.7,
+        "pf": 1.19,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 14038.8867,
+        "max_dd": 8355.0,
+        "n_taken": 80.0,
+        "win": 41.2,
+        "pf": 1.32,
+        "exposure": 100.0
+      },
+      "trial_number": 44998,
+      "train_objective": 18476.777348195174,
+      "enabled_indicators": [
+        "hma",
+        "vidya",
+        "mama_fama"
+      ],
+      "params": {
+        "sl_soft": 34.304748736675464,
+        "sl_hard": 197.6961397987374,
+        "tp": 216.08886740975967,
+        "gate_pct": 83.41518386632751,
+        "dd_limit": 4663.1213615017805,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "hma",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "fast": 207,
+              "slow": 236
+            }
+          },
+          {
+            "key": "vidya",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 4
+            }
+          },
+          {
+            "key": "mama_fama",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "fast": 1.0,
+              "slow": 0.44
+            }
+          }
+        ],
+        "cap_mode": "bars",
+        "cap_1min": 171,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 80,
+        "mean_per_trade": 175.49,
+        "sd_per_trade": 1590.08,
+        "t_stat": 0.987,
+        "p_two_sided": 0.3266,
+        "mde_per_trade": 498.06,
+        "mde_total": 39844.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[1] ['alma', 'evwma', 'force_index']",
+      "train_2025": {
+        "pnl": 18936.4247,
+        "max_dd": 11640.0,
+        "n_taken": 247.0,
+        "win": 43.7,
+        "pf": 1.16,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 17998.5553,
+        "max_dd": 8950.0,
+        "n_taken": 103.0,
+        "win": 46.6,
+        "pf": 1.32,
+        "exposure": 100.0
+      },
+      "trial_number": 43486,
+      "train_objective": 17386.02868239199,
+      "enabled_indicators": [
+        "alma",
+        "evwma",
+        "force_index"
+      ],
+      "params": {
+        "sl_soft": 34.304748736675464,
+        "sl_hard": 81.4750349293604,
+        "tp": 198.01714470653397,
+        "gate_pct": 83.41518386632751,
+        "dd_limit": 4663.1213615017805,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "alma",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 37,
+              "offset": 0.9500000000000001,
+              "sigma": 6.0
+            }
+          },
+          {
+            "key": "evwma",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 42
+            }
+          },
+          {
+            "key": "force_index",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 165
+            }
+          }
+        ],
+        "cap_mode": "both",
+        "cap_1min": 160,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 103,
+        "mean_per_trade": 174.74,
+        "sd_per_trade": 1611.69,
+        "t_stat": 1.1,
+        "p_two_sided": 0.27376,
+        "mde_per_trade": 444.9,
+        "mde_total": 45825.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[2] ['alma', 'tvi', 'ichimoku_chikou']",
+      "train_2025": {
+        "pnl": 72558.1055,
+        "max_dd": 7250.0,
+        "n_taken": 225.0,
+        "win": 50.7,
+        "pf": 1.79,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 12690.6641,
+        "max_dd": 7515.0,
+        "n_taken": 98.0,
+        "win": 42.9,
+        "pf": 1.23,
+        "exposure": 100.0
+      },
+      "trial_number": 16342,
+      "train_objective": 16268.554696390347,
+      "enabled_indicators": [
+        "alma",
+        "tvi",
+        "ichimoku_chikou"
+      ],
+      "params": {
+        "sl_soft": 34.304748736675464,
+        "sl_hard": 197.6961397987374,
+        "tp": 216.08886740975967,
+        "gate_pct": 83.41518386632751,
+        "dd_limit": 4663.1213615017805,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "alma",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 37,
+              "offset": 0.9500000000000001,
+              "sigma": 6.0
+            }
+          },
+          {
+            "key": "tvi",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "min_tick": 3.45,
+              "n": 117
+            }
+          },
+          {
+            "key": "ichimoku_chikou",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "lag": 57
+            }
+          }
+        ],
+        "cap_mode": "both",
+        "cap_1min": 171,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 98,
+        "mean_per_trade": 129.5,
+        "sd_per_trade": 1623.95,
+        "t_stat": 0.789,
+        "p_two_sided": 0.4318,
+        "mde_per_trade": 459.58,
+        "mde_total": 45039.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[3] ['vidya', 'parkinson', 'ad_line']",
+      "train_2025": {
+        "pnl": 24341.6627,
+        "max_dd": 8920.0,
+        "n_taken": 111.0,
+        "win": 40.5,
+        "pf": 1.53,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 10265.0,
+        "max_dd": 3765.0,
+        "n_taken": 43.0,
+        "win": 46.5,
+        "pf": 1.48,
+        "exposure": 100.0
+      },
+      "trial_number": 45187,
+      "train_objective": 16035.33204458552,
+      "enabled_indicators": [
+        "vidya",
+        "parkinson",
+        "ad_line"
+      ],
+      "params": {
+        "sl_soft": 34.304748736675464,
+        "sl_hard": 81.4750349293604,
+        "tp": 216.08886740975967,
+        "gate_pct": 83.41518386632751,
+        "dd_limit": 4663.1213615017805,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "vidya",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 4
+            }
+          },
+          {
+            "key": "parkinson",
+            "enabled": true,
+            "mode": "veto",
+            "params": {
+              "n": 110,
+              "m": 123,
+              "threshold": 1.35
+            }
+          },
+          {
+            "key": "ad_line",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 51
+            }
+          }
+        ],
+        "cap_mode": "both",
+        "cap_1min": 160,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 43,
+        "mean_per_trade": 238.72,
+        "sd_per_trade": 1482.33,
+        "t_stat": 1.056,
+        "p_two_sided": 0.29699,
+        "mde_per_trade": 633.31,
+        "mde_total": 27232.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[4] ['mfi', 'alma', 'twiggs_mf']",
+      "train_2025": {
+        "pnl": 35816.5165,
+        "max_dd": 11244.7702,
+        "n_taken": 177.0,
+        "win": 46.3,
+        "pf": 1.46,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 4027.1702,
+        "max_dd": 13409.5405,
+        "n_taken": 77.0,
+        "win": 46.8,
+        "pf": 1.09,
+        "exposure": 100.0
+      },
+      "trial_number": 26252,
+      "train_objective": 15517.288031000899,
+      "enabled_indicators": [
+        "mfi",
+        "alma",
+        "twiggs_mf"
+      ],
+      "params": {
+        "sl_soft": 34.304748736675464,
+        "sl_hard": 67.98851131623582,
+        "tp": 216.08886740975967,
+        "gate_pct": 83.41518386632751,
+        "dd_limit": 4663.1213615017805,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "mfi",
+            "enabled": true,
+            "mode": "both",
+            "params": {
+              "n": 81,
+              "lower": 36,
+              "upper": 62
+            }
+          },
+          {
+            "key": "alma",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 37,
+              "offset": 0.9500000000000001,
+              "sigma": 6.0
+            }
+          },
+          {
+            "key": "twiggs_mf",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 91
+            }
+          }
+        ],
+        "cap_mode": "bars",
+        "cap_1min": 160,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 77,
+        "mean_per_trade": 52.3,
+        "sd_per_trade": 1638.76,
+        "t_stat": 0.28,
+        "p_two_sided": 0.7802,
+        "mde_per_trade": 523.21,
+        "mde_total": 40287.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    }
+  ]
+}

--- a/subprojects/Parametric-Indicators/optimize/results/adoptgate_noise_4h.json
+++ b/subprojects/Parametric-Indicators/optimize/results/adoptgate_noise_4h.json
@@ -1,0 +1,15 @@
+{
+  "indicators": [
+    "apo",
+    "pivot_camarilla",
+    "dfa"
+  ],
+  "real_holdout_pnl": 18827.31,
+  "null_n": 200,
+  "null_mean": 6654.63,
+  "null_sd": 10449.23,
+  "null_p95": 23369.79,
+  "null_max": 30868.21,
+  "p_value": 0.12438,
+  "verdict": "the edge SURVIVES scrambling \u21d2 it does not come from the indicators"
+}

--- a/subprojects/Parametric-Indicators/optimize/results/adoptgate_paired_4h.json
+++ b/subprojects/Parametric-Indicators/optimize/results/adoptgate_paired_4h.json
@@ -1,0 +1,49 @@
+{
+  "indicators": [
+    "apo",
+    "pivot_camarilla",
+    "dfa"
+  ],
+  "A_vs_baseline": {
+    "n_pairs": 169,
+    "n_disagreeing_bars": 169,
+    "agreement_pct": 0.0,
+    "trades_a": 157,
+    "trades_b": 81,
+    "total_diff": -42773.62,
+    "mean_diff_per_bar": -253.1,
+    "sd_diff": 1954.48,
+    "t_stat": -1.683,
+    "p_two_sided": 0.09414,
+    "boot_ci95_total": [
+      -92499.0,
+      6432.0
+    ],
+    "se_total_paired": 25408.0,
+    "se_total_unpaired": 28650.0,
+    "mde_total_paired": 71183.0,
+    "mde_total_unpaired": 80266.0,
+    "power_gain_x": 1.13
+  },
+  "B_ablation_indicators_off": {
+    "n_pairs": 193,
+    "n_disagreeing_bars": 36,
+    "agreement_pct": 81.3,
+    "trades_a": 157,
+    "trades_b": 193,
+    "total_diff": 6555.9,
+    "mean_diff_per_bar": 33.97,
+    "sd_diff": 724.33,
+    "t_stat": 0.652,
+    "p_two_sided": 0.5155,
+    "boot_ci95_total": [
+      -12807.0,
+      27656.0
+    ],
+    "se_total_paired": 10063.0,
+    "se_total_unpaired": 30779.0,
+    "mde_total_paired": 28192.0,
+    "mde_total_unpaired": 86229.0,
+    "power_gain_x": 3.06
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/results/adoptgate_paired_selfcheck_4h.json
+++ b/subprojects/Parametric-Indicators/optimize/results/adoptgate_paired_selfcheck_4h.json
@@ -1,0 +1,54 @@
+{
+  "indicators": [
+    "macd",
+    "vwap",
+    "keltner",
+    "obv",
+    "mfi",
+    "bollinger",
+    "structure_trend",
+    "order_block"
+  ],
+  "A_vs_baseline": {
+    "n_pairs": 81,
+    "n_disagreeing_bars": 0,
+    "agreement_pct": 100.0,
+    "trades_a": 81,
+    "trades_b": 81,
+    "total_diff": 0.0,
+    "mean_diff_per_bar": 0.0,
+    "sd_diff": 0.0,
+    "t_stat": 0.0,
+    "p_two_sided": 1.0,
+    "boot_ci95_total": [
+      0.0,
+      0.0
+    ],
+    "se_total_paired": 0.0,
+    "se_total_unpaired": 28228.0,
+    "mde_total_paired": 0.0,
+    "mde_total_unpaired": 79082.0,
+    "power_gain_x": null
+  },
+  "B_ablation_indicators_off": {
+    "n_pairs": 164,
+    "n_disagreeing_bars": 90,
+    "agreement_pct": 45.1,
+    "trades_a": 81,
+    "trades_b": 157,
+    "total_diff": 39462.71,
+    "mean_diff_per_bar": 240.63,
+    "sd_diff": 1799.5,
+    "t_stat": 1.712,
+    "p_two_sided": 0.08872,
+    "boot_ci95_total": [
+      -4548.0,
+      83514.0
+    ],
+    "se_total_paired": 23045.0,
+    "se_total_unpaired": 36352.0,
+    "mde_total_paired": 64562.0,
+    "mde_total_unpaired": 101844.0,
+    "power_gain_x": 1.58
+  }
+}

--- a/subprojects/Parametric-Indicators/optimize/results/adoptgate_treatment_4h.json
+++ b/subprojects/Parametric-Indicators/optimize/results/adoptgate_treatment_4h.json
@@ -1,0 +1,466 @@
+{
+  "study": "adopt14v2treat_4h",
+  "front": 108,
+  "selected": {
+    "label": "front[0] ['apo', 'pivot_camarilla', 'dfa']",
+    "train_2025": {
+      "pnl": 62356.4251,
+      "max_dd": 13853.6346,
+      "n_taken": 389.0,
+      "win": 43.2,
+      "pf": 1.36,
+      "exposure": 100.0
+    },
+    "holdout_2026": {
+      "pnl": 18827.3089,
+      "max_dd": 12678.6346,
+      "n_taken": 157.0,
+      "win": 35.7,
+      "pf": 1.21,
+      "exposure": 100.0
+    },
+    "trial_number": 44979,
+    "train_objective": 21418.42355881061,
+    "enabled_indicators": [
+      "apo",
+      "pivot_camarilla",
+      "dfa"
+    ],
+    "params": {
+      "sl_soft": 30.067067563128774,
+      "sl_hard": 198.92254159945736,
+      "tp": 154.5682722425659,
+      "gate_pct": 89.67575947159797,
+      "dd_limit": 375.86237214458805,
+      "cooldown": 1,
+      "flip": false,
+      "k": 1,
+      "indicators": [
+        {
+          "key": "apo",
+          "enabled": true,
+          "mode": "confirm",
+          "params": {
+            "fast": 170,
+            "slow": 324
+          }
+        },
+        {
+          "key": "pivot_camarilla",
+          "enabled": true,
+          "mode": "confirm",
+          "params": {}
+        },
+        {
+          "key": "dfa",
+          "enabled": true,
+          "mode": "veto",
+          "params": {
+            "n": 214,
+            "threshold": 0.35
+          }
+        }
+      ],
+      "cap_mode": "both",
+      "cap_1min": 181,
+      "ind_1min": true
+    },
+    "power_oos": {
+      "n": 157,
+      "mean_per_trade": 119.92,
+      "sd_per_trade": 1640.32,
+      "t_stat": 0.916,
+      "p_two_sided": 0.36107,
+      "mde_per_trade": 366.76,
+      "mde_total": 57581.0,
+      "alpha": 0.05,
+      "power": 0.8
+    }
+  },
+  "members": [
+    {
+      "label": "front[0] ['apo', 'pivot_camarilla', 'dfa']",
+      "train_2025": {
+        "pnl": 62356.4251,
+        "max_dd": 13853.6346,
+        "n_taken": 389.0,
+        "win": 43.2,
+        "pf": 1.36,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 18827.3089,
+        "max_dd": 12678.6346,
+        "n_taken": 157.0,
+        "win": 35.7,
+        "pf": 1.21,
+        "exposure": 100.0
+      },
+      "trial_number": 44979,
+      "train_objective": 21418.42355881061,
+      "enabled_indicators": [
+        "apo",
+        "pivot_camarilla",
+        "dfa"
+      ],
+      "params": {
+        "sl_soft": 30.067067563128774,
+        "sl_hard": 198.92254159945736,
+        "tp": 154.5682722425659,
+        "gate_pct": 89.67575947159797,
+        "dd_limit": 375.86237214458805,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "apo",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "fast": 170,
+              "slow": 324
+            }
+          },
+          {
+            "key": "pivot_camarilla",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {}
+          },
+          {
+            "key": "dfa",
+            "enabled": true,
+            "mode": "veto",
+            "params": {
+              "n": 214,
+              "threshold": 0.35
+            }
+          }
+        ],
+        "cap_mode": "both",
+        "cap_1min": 181,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 157,
+        "mean_per_trade": 119.92,
+        "sd_per_trade": 1640.32,
+        "t_stat": 0.916,
+        "p_two_sided": 0.36107,
+        "mde_per_trade": 366.76,
+        "mde_total": 57581.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[1] ['obv', 'structure_trend', 'order_block']",
+      "train_2025": {
+        "pnl": 72879.312,
+        "max_dd": 16699.024,
+        "n_taken": 248.0,
+        "win": 58.1,
+        "pf": 1.36,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 52438.144,
+        "max_dd": 14213.952,
+        "n_taken": 98.0,
+        "win": 64.3,
+        "pf": 1.69,
+        "exposure": 100.0
+      },
+      "trial_number": 0,
+      "train_objective": 20677.144000000044,
+      "enabled_indicators": [
+        "obv",
+        "structure_trend",
+        "order_block"
+      ],
+      "params": {
+        "sl_soft": 128.577,
+        "sl_hard": 151.4424,
+        "tp": 125.5612,
+        "gate_pct": 89.66,
+        "dd_limit": 4119.4948,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "obv",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "slope": 120
+            }
+          },
+          {
+            "key": "structure_trend",
+            "enabled": true,
+            "mode": "both",
+            "params": {
+              "swing_l": 6
+            }
+          },
+          {
+            "key": "order_block",
+            "enabled": true,
+            "mode": "both",
+            "params": {
+              "swing_l": 12
+            }
+          }
+        ],
+        "cap_mode": "bars",
+        "cap_1min": 451,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 98,
+        "mean_per_trade": 535.08,
+        "sd_per_trade": 2275.73,
+        "t_stat": 2.328,
+        "p_two_sided": 0.02201,
+        "mde_per_trade": 644.04,
+        "mde_total": 63116.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[2] ['pvi', 'force_index', 'td_combo']",
+      "train_2025": {
+        "pnl": 88679.6178,
+        "max_dd": 8260.0,
+        "n_taken": 421.0,
+        "win": 46.8,
+        "pf": 1.49,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 20295.0398,
+        "max_dd": 19271.8073,
+        "n_taken": 170.0,
+        "win": 41.8,
+        "pf": 1.19,
+        "exposure": 100.0
+      },
+      "trial_number": 44436,
+      "train_objective": 19110.240836384946,
+      "enabled_indicators": [
+        "pvi",
+        "force_index",
+        "td_combo"
+      ],
+      "params": {
+        "sl_soft": 34.304748736675464,
+        "sl_hard": 203.16022277300405,
+        "tp": 154.5682722425659,
+        "gate_pct": 89.67575947159797,
+        "dd_limit": 3928.0117890520714,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "pvi",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 299
+            }
+          },
+          {
+            "key": "force_index",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 3
+            }
+          },
+          {
+            "key": "td_combo",
+            "enabled": true,
+            "mode": "both",
+            "params": {}
+          }
+        ],
+        "cap_mode": "both",
+        "cap_1min": 181,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 170,
+        "mean_per_trade": 119.38,
+        "sd_per_trade": 1750.27,
+        "t_stat": 0.889,
+        "p_two_sided": 0.37509,
+        "mde_per_trade": 376.08,
+        "mde_total": 63934.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[3] ['cci', 'structure_trend', 'order_block']",
+      "train_2025": {
+        "pnl": 99580.0,
+        "max_dd": 15491.0,
+        "n_taken": 186.0,
+        "win": 66.1,
+        "pf": 1.49,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 55066.0,
+        "max_dd": 10048.0,
+        "n_taken": 69.0,
+        "win": 72.5,
+        "pf": 1.85,
+        "exposure": 100.0
+      },
+      "trial_number": 1,
+      "train_objective": 17595.000000000582,
+      "enabled_indicators": [
+        "cci",
+        "structure_trend",
+        "order_block"
+      ],
+      "params": {
+        "sl_soft": 149.8,
+        "sl_hard": 167.1,
+        "tp": 120.2,
+        "gate_pct": 86.9,
+        "dd_limit": 4747.0,
+        "cooldown": 0,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "cci",
+            "enabled": true,
+            "mode": "both",
+            "params": {
+              "n": 138,
+              "threshold": 35
+            }
+          },
+          {
+            "key": "structure_trend",
+            "enabled": true,
+            "mode": "both",
+            "params": {
+              "swing_l": 6
+            }
+          },
+          {
+            "key": "order_block",
+            "enabled": true,
+            "mode": "both",
+            "params": {
+              "swing_l": 10
+            }
+          }
+        ],
+        "cap_mode": "none",
+        "cap_1min": 0,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 69,
+        "mean_per_trade": 798.06,
+        "sd_per_trade": 2649.22,
+        "t_stat": 2.502,
+        "p_two_sided": 0.01475,
+        "mde_per_trade": 893.51,
+        "mde_total": 61652.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    },
+    {
+      "label": "front[4] ['ppo', 'smi', 'disparity']",
+      "train_2025": {
+        "pnl": 79019.156,
+        "max_dd": 7942.2691,
+        "n_taken": 355.0,
+        "win": 45.6,
+        "pf": 1.52,
+        "exposure": 100.0
+      },
+      "holdout_2026": {
+        "pnl": 18819.578,
+        "max_dd": 22570.9037,
+        "n_taken": 133.0,
+        "win": 41.4,
+        "pf": 1.23,
+        "exposure": 100.0
+      },
+      "trial_number": 44547,
+      "train_objective": 16539.789003661936,
+      "enabled_indicators": [
+        "ppo",
+        "smi",
+        "disparity"
+      ],
+      "params": {
+        "sl_soft": 34.304748736675464,
+        "sl_hard": 203.16022277300405,
+        "tp": 154.5682722425659,
+        "gate_pct": 89.67575947159797,
+        "dd_limit": 514.5427389564633,
+        "cooldown": 1,
+        "flip": false,
+        "k": 1,
+        "indicators": [
+          {
+            "key": "ppo",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "fast": 2,
+              "slow": 161,
+              "signal": 12
+            }
+          },
+          {
+            "key": "smi",
+            "enabled": true,
+            "mode": "both",
+            "params": {
+              "n": 21,
+              "smooth": 42,
+              "lower": -92,
+              "upper": 61
+            }
+          },
+          {
+            "key": "disparity",
+            "enabled": true,
+            "mode": "confirm",
+            "params": {
+              "n": 59
+            }
+          }
+        ],
+        "cap_mode": "both",
+        "cap_1min": 181,
+        "ind_1min": true
+      },
+      "power_oos": {
+        "n": 133,
+        "mean_per_trade": 141.5,
+        "sd_per_trade": 1763.96,
+        "t_stat": 0.925,
+        "p_two_sided": 0.3566,
+        "mde_per_trade": 428.52,
+        "mde_total": 56993.0,
+        "alpha": 0.05,
+        "power": 0.8
+      }
+    }
+  ]
+}

--- a/subprojects/Parametric-Indicators/optimize/results/adoptgate_verdict_4h.json
+++ b/subprojects/Parametric-Indicators/optimize/results/adoptgate_verdict_4h.json
@@ -1,0 +1,20 @@
+{
+  "criteria": {
+    "1_beats_baseline": false,
+    "2_beats_dumb_control": true,
+    "3_noise_test_rejects": false,
+    "4_paired_ci_excludes_zero": false
+  },
+  "inputs_present": {
+    "baseline": true,
+    "treatment": true,
+    "control": true,
+    "noise": true,
+    "paired": true
+  },
+  "mde_total_paired": 71183.0,
+  "observed_effect": -42773.62,
+  "adopt": false,
+  "verdict": "DEFAULT-OFF \u2014 CANNOT TELL (underpowered)",
+  "underpowered": true
+}

--- a/subprojects/Parametric-Indicators/optimize/test_max_enabled_unbiased.py
+++ b/subprojects/Parametric-Indicators/optimize/test_max_enabled_unbiased.py
@@ -1,0 +1,94 @@
+"""Issue #14 — `--max-enabled` must not privilege indicators by their position in the REGISTRY.
+
+The repair that enforces the cap used to keep "the first `max_enabled` in REGISTRY order". That reads
+as neutral bookkeeping. It is not: the registry lists the ORIGINAL 18 indicators at positions 0-17 and
+the 147 added by #12 from position 18 onward, so an original always won the tie.
+
+Measured on a live 16,000-trial adopt-gate study before the fix: **0 of 1,500 sampled trials kept a
+single new-library indicator**, and the ten most-kept keys were all registry positions 0-13. The search
+built to evaluate the new library was testing only the old one, and would have produced a confident and
+entirely meaningless verdict.
+
+These tests fail loudly if that bias ever returns.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import pytest
+
+from indicators import library
+from optimize.optimizer import _suggest_indicators
+
+_R = list(library.REGISTRY)
+_N_ORIGINAL = 18                      # positions 0..17 predate the #12 calc-indicator library
+
+
+class _AllOnTrial:
+    """Minimal Trial stub: enables every indicator and returns each param's default, so the ONLY thing
+    under test is the cap-repair's choice of which to keep."""
+
+    def __init__(self, number):
+        self.number = number
+
+    def suggest_categorical(self, name, choices):
+        return True if name.startswith("en_") else choices[0]
+
+    def suggest_int(self, name, lo, hi, step=1):
+        return lo
+
+    def suggest_float(self, name, lo, hi, step=None):
+        return lo
+
+
+def _kept_positions(n_trials=400, max_enabled=3):
+    pos = []
+    for i in range(n_trials):
+        specs = _suggest_indicators(_AllOnTrial(i), max_enabled=max_enabled)
+        on = [s["key"] for s in specs if s["enabled"]]
+        assert len(on) == max_enabled, f"cap not enforced: {len(on)} enabled"
+        pos += [_R.index(k) for k in on]
+    return np.array(pos)
+
+
+def test_cap_is_enforced_exactly():
+    for cap in (1, 3, 5):
+        specs = _suggest_indicators(_AllOnTrial(0), max_enabled=cap)
+        assert sum(1 for s in specs if s["enabled"]) == cap
+
+
+def test_kept_indicators_are_not_concentrated_at_the_front_of_the_registry():
+    """The regression: with every flag on, the kept set must sample the WHOLE registry, not its head."""
+    pos = _kept_positions()
+    mean_pos = float(pos.mean())
+    expected = (len(_R) - 1) / 2.0
+    assert mean_pos > expected * 0.6, (
+        f"kept indicators average registry position {mean_pos:.1f} vs {expected:.1f} expected under "
+        f"an unbiased draw — the cap is privileging the front of the registry again")
+
+
+def test_the_new_library_actually_gets_selected():
+    """The number that mattered: before the fix this was 0.00%."""
+    pos = _kept_positions()
+    frac_new = float((pos >= _N_ORIGINAL).mean())
+    expected = (len(_R) - _N_ORIGINAL) / len(_R)          # ~0.89
+    assert frac_new > 0.5 * expected, (
+        f"only {100*frac_new:.1f}% of kept indicators come from the new library "
+        f"(expected ~{100*expected:.0f}% under an unbiased draw) — the search is not testing it")
+
+
+@pytest.mark.parametrize("cap", [1, 3])
+def test_repair_is_reproducible_for_a_given_trial(cap):
+    """Same trial number ⇒ same repair, so resumes and re-scores stay stable."""
+    a = [s["key"] for s in _suggest_indicators(_AllOnTrial(7), max_enabled=cap) if s["enabled"]]
+    b = [s["key"] for s in _suggest_indicators(_AllOnTrial(7), max_enabled=cap) if s["enabled"]]
+    assert a == b
+
+
+def test_no_cap_leaves_everything_enabled():
+    specs = _suggest_indicators(_AllOnTrial(0), max_enabled=None)
+    assert sum(1 for s in specs if s["enabled"]) == len(_R)


### PR DESCRIPTION
Closes #14.

## Verdict: **DEFAULT-OFF**

47,100 treatment trials + 47,100 dumb-control trials, both on the 2025 training window only (2026 never
seen), warm-started, `--max-enabled 3`, scored on the holdout.

| | holdout P/L | trades | indicators |
|---|---:|---:|---|
| **baseline** (deployed champion) | **$61,601** | 81 | the 8 original |
| **treatment** (best-on-train) | **$18,827** | 157 | `apo`, `pivot_camarilla`, `dfa` |
| dumb control (placebo votes) | $14,039 | — | `hma`, `vidya`, `mama_fama` |

| # | criterion | result |
|---|---|---|
| 1 | beats baseline? | **NO** — Δ **−$42,774** |
| 2 | beats the dumb control? | YES — Δ +$4,788 |
| 3 | edge vanishes when its own votes are scrambled? | **NO** — permutation p = **0.124** (null mean $6,655, n=200) |
| 4 | paired 95% CI excludes zero? | **NO** — CI **[−$92,499, +$6,432]**, p = 0.094 |

**Nothing is adopted.**

## Read the rejection correctly — this is "cannot tell", not "no effect"

|−$42,774| < the **$71,183** minimum detectable effect. Two statements, and conflating them is the mistake:

* **The decision is solid.** A candidate that loses by $42,774, cannot beat a placebo by more than
  $4,788, and does not survive scrambling its own votes, is not adopted.
* **The scientific claim is not.** This design could not have detected a real improvement of that size,
  so it is **not evidence the 143 indicators are useless.**

## Four defects, each of which would have produced a confident wrong answer

**1. The optimizer had no holdout at all.** `score_walkforward` folds span the *whole* series — 2026 was
training data. Fixed with `--train-window 2025`; verified 2,119 → 1,534 decision bars.

**2. `--max-enabled` excluded the entire library under test.** The repair kept "the first N in REGISTRY
order"; the original 18 occupy positions 0–17 and the 147 new ones start at 18, so an original always
won. Measured live: **0 of 1,500 trials contained a single new-library indicator** — a search built to
evaluate 143 indicators had tested none of them. Both runs were stopped mid-flight. After the fix:
**98.1%**, mean kept position 80.3 (unbiased ~82).
⚠️ **Pre-existing (#12), not introduced here** — any earlier `--max-enabled` run has the same problem.

**3. The dumb control was going to be scored with real votes**, which makes it not a null. Fixed with
`extract --scramble-seed`.

**4. The permutation null was a point mass.** Criterion 3 first read `p=1.0000, null mean = the observed
value exactly, sd = $0.00`. All 200 permutations returned the same number: `vote_cache`'s key doesn't
encode the scramble seed, so #1 wrote its votes and #2–200 read them back. **Redirecting the cache isn't
enough — it must be bypassed.** Corrected null: mean $6,655, sd $7,740, p = 0.124. Plus a guard that
refuses to emit a p-value from a zero-spread null.

## The power ceiling — measured three ways that agree

No timeframe can detect an improvement smaller than ~79% of its entire holdout profit (4h: **91%**).
Pooling raw dollars across instruments fails (variance grows faster than n). Pooling
volatility-standardized trades across all 33 live slots still only reaches **79% of the edge**. Pairing
helps **1.58–3.06×** — measured, not the order of magnitude I first claimed.

**A candidate must roughly double the strategy to register on this design.**

## Two findings that arrived for free

- **The deployed champion's own indicator layer** is worth **+$39,463** on the holdout, 95% CI
  [−$4,548, +$83,514], p=0.089 — positive, not distinguishable from luck at n=81/157.
- **Descriptive pattern (n=5, suggestive only):** front members built from the *original* indicators
  hold out at $52–55k; those built from the *new* library at $19–20k, despite comparable training
  scores. Reading the best-holdout member would be selecting on the test set — and even it ($55,066)
  loses to the baseline.

## What ships

`optimize/adopt_gate.py` (baseline · search · extract · paired · noise · verdict) ·
`--train-window` · unbiased `--max-enabled` + `optimize/test_max_enabled_unbiased.py` (**verified to
fail against the old repair**) · `optimize/perf/check_max_enabled_bias.py` (run it on any study before
trusting its verdict) · `peek_adopt_studies.py` · `finish_adopt_gate.sh` · all artifacts and raw logs.

Full detail: `docs/CLOSEOUT-2026-07-28-adopt-gate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)