### PR TITLE
Data unified on the server: DATA-AND-KNOWLEDGE-MAP + doc updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — Trading Strategy Finder · multi-agent operating manual
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 **This repository is developed primarily by AI agents working in parallel. This file is the contract
 that lets them do so without colliding. Read it fully before touching anything. GitHub renders it, and
 non-Claude agents read it too — it is the single source of truth for *how we work*, not just *what the

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -9,6 +9,8 @@ branch: research/legacy-18-baseline
 
 # START HERE — `legacy-18-baseline` workstream
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 **You are one of two agents working on this project on this device, at the same time.** The other
 agent works in `/mnt/data/projects/trading` on branch `dev`. You work **only** here, in
 `/mnt/data/projects/trading/legacy18`, on branch `research/legacy-18-baseline`.
@@ -122,8 +124,10 @@ by code.
 5. **Fresh seeds are not a formality.** An 8/8 result at +55% became 5/8 at −4% on unseen seeds. Two
    runs agreeing on the *same* seeds is not replication.
 6. **No heavy compute on this box without explicit permission.** Default to the server (§6).
-7. **LOCAL is the source of truth.** Every output produced on the server must be `scp`'d back and
-   committed. Nothing authoritative may live only on the server.
+7. **LOCAL (git) is the source of truth for CODE + EVIDENCE.** Every output produced on the server
+   must be `scp`'d back and committed. **MARKET DATA is the exception since 2026-08-22: it lives ONLY
+   on the server** (`docs/DATA-AND-KNOWLEDGE-MAP.md`); the local checkout has no data trees and must
+   never grow them back.
 8. **Stay in this worktree.** Never switch branches or worktrees unless told to out loud.
 9. **Verify, don't assume.** Never conclude from truncated output. ⚠️ `| head -N` on a long run
    **SIGPIPEs the process**, and a filter that misses stderr hides the reason.
@@ -214,9 +218,11 @@ numbers. **Compare against the server, or against your own baseline.**
 The exact package set is frozen in `.wsenv/requirements-lock.txt`. If you need bit-comparability with
 the sibling workstream, pin from theirs instead — but say so out loud when you do.
 
-**Data is symlinked, not copied:** `ALL_STOCKS`, `Full_Canldes_Data` and `data` point at
-`/mnt/data/projects/trading`. A git worktree checks out tracked files only, and the price data is
-untracked. Treat it as **read-only**.
+**Data is NOT local any more (2026-08-22):** `ALL_STOCKS`, `Full_Canldes_Data`, `data`, `2024_data`,
+`2026_last_20_days_data` and all delivery/vendor zips were merged onto the server and deleted here.
+Every data-backed run happens on `amd-trading` with `WSH_DATA_BASE=/home/dev/Mulham/wsg-i
+WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data` — exact paths and coverage in `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+A local `FileNotFoundError` under `/mnt/data/projects/trading/...` is the rule working, not a bug.
 
 ⚠️ **A residual of #94 lives here:** at least one code path builds a data path from the *checkout*
 rather than from `roots.py`'s `DATA_ROOT` (`tests/test_smc_numba_parity.py` wanted

--- a/docs/DATA-AND-KNOWLEDGE-MAP.md
+++ b/docs/DATA-AND-KNOWLEDGE-MAP.md
@@ -1,0 +1,168 @@
+# DATA & KNOWLEDGE MAP — where everything lives (authoritative, 2026-08-22)
+
+**Read this before any workstream touches data.** On 2026-08-22 the owner unified all market
+data on the AMD server and deleted the local copies. Two consequences every future agent must
+internalize:
+
+1. **Market data exists ONLY on the server** (`ssh amd-trading`, user `dev`). The local
+   checkout `/mnt/data/projects/trading/` has **no** `Full_Canldes_Data/`, `ALL_STOCKS/`,
+   `data/`, `2024_data/`, `2026_last_20_days_data/`, delivery bundles, or vendor zips — and
+   must never grow them back. `roots.py` still *defaults* the data root to the checkout, so a
+   local data-backed run fails with `FileNotFoundError` **by design** (the no-local-compute
+   rule). That failure is not a bug in the code; it is the rule working.
+2. **Code, evidence and records live in git** (branches `research/legacy-18-baseline` →
+   `dev` → `main`) and are mirrored into server worktrees. "Local = source of truth" means
+   *git*; "server = source of truth" means *data*. Never confuse the two.
+
+Machine-generated inventory behind this page: `optimize/fwd/phase0_data_audit.py` (per-frame
+coverage) and the 2026-08-22 checksum merge (131 identical / 0 conflicts / 28 pushed / 22
+archives verified) recorded on issue #176.
+
+---
+
+## 1. The machine and how to reach it
+
+| item | value |
+|---|---|
+| host | `ssh amd-trading` (78.89.209.212 / LAN 192.168.50.62), user `dev`, 32 cores / 123 GB RAM, **no GPU** |
+| python | `/home/dev/Mulham/.venv/bin/python3` (numpy 2.4 · pandas 3.0 · optuna 4.9 · numba 0.65 · playwright + chromium-1228 in `~/.cache/ms-playwright`) |
+| code worktrees | `~/Mulham/code` = production checkout (serves dashboard **:8200**) · `~/Mulham/earn1` = `research/legacy-18-baseline` (branch dashboard **:8250**) · `~/Mulham/wsg-i` = the **data root** (also an old rsync checkout — ⚠️ its code is STALE, never run from it) |
+| env for ANY data-backed run | `WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data WSH_16Y_ROOT=/home/dev/Mulham/data_2010_1s` |
+| env for the EXTENDED tape | `WSH_DATA_BASE=/home/dev/Mulham/wsg-i/FWD_EXTENDED WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/FWD_EXTENDED/data TMPDIR=/home/dev/Mulham/wsg-i/FWD_EXTENDED/tmp` |
+| optimizer storage | Postgres container `wsh-pg` at `127.0.0.1:55432`, creds `~/Mulham/wsg-i/pg.env` (⚠️ `get_all_study_summaries()` hangs — use `docker exec wsh-pg psql`) |
+| dashboards | :8200 prod (`~/Mulham/wsg-i/dash.sh refresh` / supervisor), :8250 branch (`cd ~/Mulham/earn1/subprojects/Parametric-Indicators && nohup env <vars> .venv python3 server.py --port 8250`) — **restart after any backend change**; kill by PORT, never `pkill` by name |
+| L1 disk cache | `$TMPDIR/wsh_l1_cache/*.pkl` — keyed on PARAMS, blind to data ⇒ **every distinct data root needs its own TMPDIR**; clear after any P/L-affecting change |
+
+---
+
+## 2. The data roots (exact paths)
+
+### 2.1 `~/Mulham/wsg-i` — the PRODUCTION engine root (what :8200 and every champion run read)
+
+| what | exact path | coverage | schema / notes |
+|---|---|---|---|
+| NQ candles (engine's own) | `Full_Canldes_Data/drive-download-20260602T124702Z-3-001/NQ_{1m,2m,5m,15m,1h,2h,4h}.csv` | 2025-01-01 → **2026-05-19** | `datetime,open,high,low,close,volume`; ET-naive; bars labeled by START; 4h grid 18/22/02/06/10/14 |
+| NQ candles, with20d variant | same dir, `NQ_<tf>_with20d.csv` | → 2026-06-09 | built by `build_plus20d_data.py`; NOT live |
+| NQ box (engine reads this) | `data/full_data/NQ_full_data.csv` | box days 2025-01-01 → **2026-05-22** | 53 cols; engine uses Date + 16 W* + 16 M* level columns; daily rows = CLOSING day; `hour>=18 ⇒ next day` mapping |
+| NQ box with20d | `data/full_data/NQ_full_data_with20d.csv` | → 2026-06-09 | real scraped rows, shifted by the proven script; adopted only in the extended root |
+| NQ per-year backend (dashboard 4h view) | `data/{2025_data,2026_data}/NQ_{4h,1m}_<yr>.csv`, `NQ_full_data_<yr>.csv` (+`_with20d`) | 2026 → 05-19 (with20d → 06-09) | the dashboard's second NQ backend; must stay consistent with the box above |
+| 2024 NQ history | `2024_data/NQ2024_Candles/NQ2024_Continuous_Data/NQ2024_<tf>.csv` + `2024_data/NQ2024-Boxs/NQ2024/NQ_{full,day,week,month}_data.csv` | 2024-01-01 → 2024-12-31 | pushed from local 2026-08-22; used by the NQ2024 signal delivery only |
+| NQ 20-day drop (raw) | `2026_last_20_days_data/NQ-2026-last-20-days-{candles,boxs}/NQ-5-6-2026*/` | 2026-05-18 → 06-09 | the source of the with20d files |
+| Non-NQ candles | `ALL_STOCKS/CANDLES/<EXCH>/<TOK>_Continuous_Data/<TOK>_<tf>.csv` — EXCH: CME{ES,RTY,YM} · COMEX{GC,SI,HG} · NYMEX{CL,NG} | ES → 05-19 · GC/SI → 07-02 · RTY/YM → 07-05 · HG → 07-07 · CL/NG → 07-08 | same schema as NQ |
+| ETF candles | `ALL_STOCKS/CANDLES/ETF/{QQQ,SQQQ}_Data/{ETH,RTH}/` | 2025-01-02 → 2026-05-19 | not in the 9-instrument engine; signal deliveries only |
+| Non-NQ boxes RAW (scraped) | `ALL_STOCKS/BOXS/<EXCH>/<TOK>/<TOK>_full_data.csv` (RTY/YM/ES/NQ/ETFs also have `_day/_week/_month`) | NQ/ES/ETF → 05-22 · GC/SI/HG/CL/NG/RTY/YM → **06-29** | raw = UNshifted; the engine never reads these directly |
+| Non-NQ boxes SHIFTED (engine reads) | **in the CODE checkout**: `subprojects/all-stocks-signals/shifted_boxes/<TOK>_full_data_shifted.csv` | → **2026-06-26** (= raw 06-29 shifted −1 business day) | produced by `subprojects/all-stocks-signals/onboard_stock.py`; travels with git, so `earn1`/`code` each carry a copy |
+| bundle data snapshots | `bundle_data_all/` (9 inst, → 07-08) · `bundle_data_clng/` | frozen inputs of the shareable backtester bundles | do not use as the engine root |
+| delivery bundles | `<TOK>_SIGNALS_DELIVERY/` + `.zip` for CL ES GC HG NG RTY SI YM; zips only for NQ NQ2024 NQ2026L20 QQQ-ETH QQQ-RTH SQQQ-ETH SQQQ-RTH (at `wsg-i/` root) | — | customer-facing signal exports (WS-AS) |
+| vendor drop archives | `vendor_drops_local/*.zip` (HG/RTY/YM July drops, drive-download-20260710 ×2, silver-gold candles/levels) | — | the raw files the onboarding SOP consumed; keep for provenance |
+| champion bundles | `BOX_STRATEGY_CHAMPIONS_2026-07-14/`, `BOX_STRATEGY_CHAMPIONS_EOD_2026-07-13/` (+zips) | — | ⚠️ built on the 4-dp-rounded champions — STALE, do not ship |
+
+### 2.2 `~/Mulham/wsg-i/FWD_EXTENDED` — the EXTENDED engine root (WS-FWD, #176)
+
+Mirror of 2.1 for the files the engine reads, **candles extended to 2026-08-07 16:59 ET for all
+9** under exact gates (Gate A splice parity 9/9 incl. volume; Gate B 54/54 resample proofs;
+Gate C audit; prod checksums untouched). NQ box = the with20d box (→ 06-09). Everything else
+symlinked to prod. Own `tmp/` for the L1 cache; `fwd_books/` = the 54 champion books +
+`fwd_run_summary.json` + `fwd_dashboard_gate.json`; `fwd_shots/` = 54 dashboard screenshots.
+Point a run here with the env line in §1. **Not yet swapped into production** (owner decision).
+
+### 2.3 `~/Mulham/data_2010_1s` — the 16-YEAR tape (the news / earnings / extension source)
+
+| what | exact path | coverage | notes |
+|---|---|---|---|
+| RAW vendor 1-second | `<TOK>.csv` (NQ ES GC SI HG CL NG RTY YM) | 2010-06-06 → 2026-08-07 | **UTC** Databento-style: `ts_event,rtype,publisher_id,instrument_id,open,high,low,close,volume,symbol`; per-contract symbols (roll-stitched) |
+| derived frames | `<TOK>_Continuous_Data/<TOK>_{1s,2s,5s,15s,30s,1m,2m,5m,15m,1h,2h,4h}.csv` | same (RTY from 2017-07-09) | ET-naive, engine schema; built by `main_futures_seconds.py` in this dir. ⚠️ pre-2016 rows are DST-broken (WS-NEWS2) — fine for ≥2016 studies |
+| sizes | 1s ≈ 1.7–6.8 GB per instrument; 1m ≈ 150–280 MB | ~130 GB total | |
+
+**Proven 2026-08-21:** the 1m frames here are tick-for-tick identical to the engine's vendor
+candles over their overlap (OHLC + volume, all 9). This is the legitimate source for every
+future candle extension (`optimize/fwd/fwd_extend_candles.py`).
+
+### 2.4 What is NOT on any server path and cannot be generated here
+
+**The box levels.** The W*/M* levels are scraped output of the owner's TradingView-side
+indicator; a derivability probe (ratio census, 4 instruments) showed per-period values, not
+fixed multiples; no generator/Pine source exists in any repo. A new box drop is an **owner
+action** (scrape → raw `<TOK>_full_data.csv` under `ALL_STOCKS/BOXS/...`, NQ under
+`data/full_data/` → run the onboarding shift → commit `shifted_boxes/`). Current box frontier:
+NQ 2026-06-09 (extended root) / 05-22 (prod) · ES 05-21 · all others 06-26.
+
+---
+
+## 3. Per-instrument coverage at a glance (2026-08-22)
+
+| inst | prod candles | extended candles | 16y tape | raw box | shifted box (engine) |
+|---|---|---|---|---|---|
+| NQ | 2026-05-19 | 2026-08-07 | 2010→2026-08-07 | 05-22 (with20d 06-09) | n/a — reads `data/full_data` directly |
+| ES | 05-19 | 08-07 | 2010→08-07 | 05-22 | 05-21 |
+| GC | 07-02 | 08-07 | 2010→08-07 | 06-29 | 06-26 |
+| SI | 07-02 | 08-07 | 2010→08-07 | 06-29 | 06-26 |
+| HG | 07-07 | 08-07 | 2010→08-07 | 06-29 | 06-26 |
+| CL | 07-08 | 08-07 | 2010→08-07 | 06-29 | 06-26 |
+| NG | 07-08 | 08-07 | 2010→08-07 | 06-29 | 06-26 |
+| RTY | 07-05 | 08-07 | 2017→08-07 | 06-29 | 06-26 |
+| YM | 07-05 | 08-07 | 2010→08-07 | 06-29 | 06-26 |
+
+Point values (engine): NQ 20 · ES 50 · GC 100 · SI 5,000 · HG 25,000 · CL 1,000 · NG 10,000 ·
+RTY 50 · YM 5 (`optimize/instruments.py`). The engine reads exactly three files per (inst, tf):
+decision-TF CSV, 1m CSV, box CSV (`optimize/data.py::load_inputs`).
+
+---
+
+## 4. Knowledge that lives in GIT (evidence, calendars, champions) — committed, not on a data root
+
+| what | path (repo) |
+|---|---|
+| deployed champion set `best` (+ `incumbent`/`eod`) | `subprojects/Parametric-Indicators/optimize/results/{best,cap1p,eod1p}_champions_full[_<TOK>].json` — ⚠️ `*.csv` there are gitignored |
+| golden gate (NQ 6/6 byte-identical anchors) | `subprojects/Parametric-Indicators/perf/check_golden.py` |
+| claims ledger (67/67) | `subprojects/Parametric-Indicators/optimize/verify/` (`run.py`, `claims_*.py`) |
+| news calendar + release stamps (WS-NEWS2+) | `subprojects/Parametric-Indicators/optimize/fundamentals/data/` (+ `DATA_REQUEST_release_timestamps_2010_2026.csv` at repo root) |
+| earnings acceptance stamps / E-S1 dataset | `subprojects/Parametric-Indicators/optimize/earnings/data/` |
+| XNI / fusion / forward evidence | `optimize/xni/data/`, `optimize/fundamentals/*_result*`, `optimize/fwd/data/` (54 books, gate JSON, 54 screenshots) |
+| deployed forecast layers + artifacts | `src/deploy/{power_forecast,two_calendar_forecast,regime_monitor}.py`; playbooks + bundles under `playbooks/` |
+| workstream records | `docs/NEWS-MASTER-EXPERIMENT-RECORD.md` (eras 0–12), `docs/PROGRAMME-COMPLETE-EXPERIMENT-REPORT.md`, `docs/PROGRESS-RECORD.md`, `docs/SYSTEM-LAYERS-ANALYSIS.md`, `docs/WS-*-FULL-RECORD.md`, pre-registrations `docs/*-PREREGISTRATION.md` |
+
+---
+
+## 5. Recipes (copy-paste)
+
+```bash
+# any engine/champion run on PRODUCTION data
+ssh amd-trading
+cd ~/Mulham/earn1/subprojects/Parametric-Indicators     # or ~/Mulham/code/... for the released code
+env WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data \
+    WSH_16Y_ROOT=/home/dev/Mulham/data_2010_1s /home/dev/Mulham/.venv/bin/python3 <script>
+
+# the same on the EXTENDED tape (own cache!)
+env WSH_DATA_BASE=/home/dev/Mulham/wsg-i/FWD_EXTENDED WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/FWD_EXTENDED/data \
+    TMPDIR=/home/dev/Mulham/wsg-i/FWD_EXTENDED/tmp /home/dev/Mulham/.venv/bin/python3 <script>
+
+# audit coverage (prints first/last stamp of every frame the engine would load)
+python3 optimize/fwd/phase0_data_audit.py
+# extend candles from the 16y tape into a parallel root (gated)
+WSH_FWD_ROOT=... python3 optimize/fwd/fwd_extend_candles.py
+# onboard a new vendor/box drop (shift −1 BDay, signals, registry)
+python3 subprojects/all-stocks-signals/onboard_stock.py --tokens <TOK> --jobs 16
+# dashboard visual gate — browser ON THE SERVER (the local box froze under it)
+env WSH_GATE_URL=http://127.0.0.1:8250/ WSH_GATE_CHROME=/home/dev/.cache/ms-playwright/chromium-1228/chrome-linux64/chrome \
+    python3 optimize/fwd/fwd_dashboard_gate.py --books <dir> --shots <dir> --out <json>
+# bring evidence home (git is the truth for evidence): scp → optimize/<ws>/data/ → gitignore `!` exception → commit
+```
+
+---
+
+## 6. Legacy server directories (campaign scratch — NOT sources of truth)
+
+`~/Mulham/{wsg-h, fa-m1, l2v2, gap2, gap3, gap4, q99, risk2, regime-edge, regime-hmm, chronos2,
+tfm-repro, meta-prophet, shared, runs}` and the `*.rsync-retired-2026-08-01` copies are the
+remains of closed workstreams (their verdicts live in the records). Read for archaeology only;
+never point an engine at them. `~/Mulham/wsg-i` itself still contains an old code checkout
+beside the data — use it for DATA paths only.
+
+## 7. Failure modes this page exists to prevent
+
+- *"FileNotFoundError: /mnt/data/projects/trading/Full_Canldes_Data/..."* → you ran locally; run on the server with the env line.
+- *"The dashboard shows different numbers than my run"* → different data root (prod vs extended) or a shared `TMPDIR` cache; pin both.
+- *"No entries after June"* → the box feed ends there (§2.4); candles are not the limit.
+- *"The with20d / bundle_data / BOX_STRATEGY dirs look newer"* → they are variants/snapshots, not the engine root; the engine root is §2.1 as listed.
+- *"Local test needs data"* → it must skip or run on the server; do not restore local trees.

--- a/docs/EXPANSION_ROUND_PLAYBOOK.md
+++ b/docs/EXPANSION_ROUND_PLAYBOOK.md
@@ -1,5 +1,7 @@
 # Expansion-Round Playbook
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 **Read this BEFORE adding indicators, instruments, timeframes, or layers — and again when you finish.**
 **Issue:** #57 · **Origin:** the `dfa` incident in #54 · **Status:** standing rules, not a one-off.
 

--- a/docs/PROGRESS-RECORD.md
+++ b/docs/PROGRESS-RECORD.md
@@ -99,6 +99,15 @@ committed file; `expect` values are never adjusted.
 
 ## 5 · Data & infra assets (and their sharp edges)
 
+- ⭐ **2026-08-22 — ONE source of truth for market data: the SERVER.** Local data trees and all
+  delivery/vendor zips were checksum-merged into `~/Mulham/wsg-i` (131 identical / 0 conflicts /
+  28 pushed / 22 archives verified) and deleted locally (+10 GB). Authoritative map with exact
+  paths, coverage per instrument, env recipes and failure modes: **`docs/DATA-AND-KNOWLEDGE-MAP.md`**.
+  Git stays the truth for code + evidence. Local data-backed runs now fail by design.
+- Engine candles: prod root → NQ/ES 05-19, others Jul 2–8; **extended root `wsg-i/FWD_EXTENDED` →
+  2026-08-07 all 9** (not yet swapped into prod). Box frontier: NQ 06-09 (ext) / ES 05-21 / others
+  06-26 — owner-scraped, not derivable; a fresh box export is the unlock for any forward test.
+
 - 1-second archive, 9 instruments, 2010→2026 (server `~/Mulham/data_2010_1s/`); **YM rebuilt
   from raw 2026-08-18** (was corrupt; its 0-byte 1m frame is fixed — YM fully studyable).
 - TradingView calendar (39,221 events, 649 series; usable ≥2016 — pre-2016 DST-broken).

--- a/docs/SYSTEM-LAYERS-ANALYSIS.md
+++ b/docs/SYSTEM-LAYERS-ANALYSIS.md
@@ -1,5 +1,7 @@
 # SYSTEM LAYERS — the Full Breakdown (FU-12; UPDATED to v5.5.0)
 
+> Data locations (server-only since 2026-08-22): `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 > **Update 2026-08-19 (v5.4.3):** since first publication the pipeline resolved both of §3's
 > open items — **3.7 (M2 power model) is now DEPLOYED** as the system's second forecast layer
 > (`src/deploy/power_forecast.py`, information-only), and **3.6 (the Exp2 sizing ramp) was

--- a/subprojects/Parametric-Indicators/SERVER_AGENT_MANUAL.md
+++ b/subprojects/Parametric-Indicators/SERVER_AGENT_MANUAL.md
@@ -1,5 +1,7 @@
 # Server Agent Manual — driving the Unified L1·L2·Combined backtest server
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 A complete, self-contained guide for **another agent** (or human) to operate `server.py` — the HTTP
 backend behind the unified dashboard. Everything an agent needs: how to start it, every endpoint, the
 exact request/response shapes, the parameter schema, ready-to-run `curl` examples, the known-good
@@ -54,8 +56,8 @@ NQ data on disk, via two environment variables:
 
 | Env var | Default | What it points at |
 |---|---|---|
-| `WSH_DATA_BASE` | `/mnt/data/projects/trading` | base dir holding `Full_Canldes_Data/<RAW_DIR>/NQ_<tf>.csv` + `NQ_1m.csv` |
-| `WSG_DATA_ROOT` | `/mnt/data/projects/trading/data` | holds `full_data/NQ_full_data.csv` (per-day box levels) |
+| `WSH_DATA_BASE` | `/mnt/data/projects/trading` (⚠️ EMPTY since 2026-08-22 — always set `/home/dev/Mulham/wsg-i`) | base dir holding `Full_Canldes_Data/<RAW_DIR>/NQ_<tf>.csv` + `NQ_1m.csv` |
+| `WSG_DATA_ROOT` | `/mnt/data/projects/trading/data` (⚠️ EMPTY — set `/home/dev/Mulham/wsg-i/data`) | holds `full_data/NQ_full_data.csv` (per-day box levels) |
 
 A template is shipped as **`.env.example`** (copy to `.env` and edit paths; the server reads the env,
 not a `.env` file directly — `export` them or use your shell/process manager).

--- a/subprojects/Parametric-Indicators/WORKSTREAMS.md
+++ b/subprojects/Parametric-Indicators/WORKSTREAMS.md
@@ -8,6 +8,8 @@ generated: 2026-06-30
 
 # WORKSTREAMS — Master Register & Progress Watcher
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 **This is the one file that lists every workstream we have, maps each to its git *work tree*
 (branch / worktree / tag), and tracks its progress.** It is a router + status board — the detailed
 canonical doc for each stream is linked from its dossier (§4+). Companion to `MASTER.md` (the code

--- a/subprojects/Parametric-Indicators/optimize/DATA_PROVENANCE.md
+++ b/subprojects/Parametric-Indicators/optimize/DATA_PROVENANCE.md
@@ -1,5 +1,7 @@
 # WS-I.10 data provenance — where everything lives
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 After the all-timeframe NSGA-III sweep, **everything has been pulled off the AMD server to local**.
 Nothing unique remains server-side (the server copy is left only as a redundant backup / resume point).
 

--- a/subprojects/Parametric-Indicators/roots.py
+++ b/subprojects/Parametric-Indicators/roots.py
@@ -43,6 +43,9 @@ REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 # Machine-specific. WSH_DATA_ROOT is the unambiguous name; WSH_DATA_BASE is the legacy one every
 # existing runner exports. Empty strings are treated as unset — `export WSH_ONLY=''` is a common shape
 # in the shell launchers and an empty root must not silently become Path('.').
+# ⚠️ 2026-08-22: market data lives ONLY on the server (docs/DATA-AND-KNOWLEDGE-MAP.md). The
+# REPO_ROOT fallback below resolves to an EMPTY tree locally — a FileNotFoundError there means
+# "run on the server with WSH_DATA_BASE/WSG_DATA_ROOT set", not a bug.
 DATA_ROOT: Path = Path(
     os.environ.get("WSH_DATA_ROOT") or os.environ.get("WSH_DATA_BASE") or REPO_ROOT
 )

--- a/subprojects/all-stocks-signals/NEW_STOCK_ONBOARDING_SOP.md
+++ b/subprojects/all-stocks-signals/NEW_STOCK_ONBOARDING_SOP.md
@@ -1,5 +1,7 @@
 # New-Stock Onboarding — Standard Operating Procedure (SOP)
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 The repeatable pipeline for adding any new instrument (a "stock": futures / ETF / equity) to the box-strategy
 system end-to-end. Encodes the process the user approved on 2026-07-06 while onboarding COMEX Gold (GC) + Silver
 (SI) and re-wiring E-mini S&P (ES).
@@ -26,8 +28,9 @@ Only after these three answers do you start.
 
 ## STEP 1 — Place the data
 
-Drop the vendor files into the canonical tree the registry anchors on
-(`<repo>/ALL_STOCKS`):
+Drop the vendor files into the canonical tree the registry anchors on — **on the SERVER only**
+(`/home/dev/Mulham/wsg-i/ALL_STOCKS`; since 2026-08-22 there is no local `ALL_STOCKS`, see
+`docs/DATA-AND-KNOWLEDGE-MAP.md`; keep the original zip in `wsg-i/vendor_drops_local/`):
 
 - Candles → `ALL_STOCKS/CANDLES/<EXCHANGE>/<PREFIX>_Continuous_Data/<PREFIX>_<TF>.csv`
   for `TF ∈ {1m,2m,5m,15m,1h,2h,4h}`. Schema: `datetime,open,high,low,close,volume`.

--- a/subprojects/all-stocks-signals/docs/DATA_MAP.md
+++ b/subprojects/all-stocks-signals/docs/DATA_MAP.md
@@ -9,7 +9,9 @@ workstream: WS-AS (all-stocks-signals)
 
 # WS-AS — Input → Output Data Map
 
-## 1. Source tree (`ALL_STOCKS/`)
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
+## 1. Source tree (`ALL_STOCKS/` — server path `/home/dev/Mulham/wsg-i/ALL_STOCKS/`, the ONLY copy since 2026-08-22)
 ```
 ALL_STOCKS/
 ├── CANDLES/

--- a/subprojects/signals/full_candles/README.md
+++ b/subprojects/signals/full_candles/README.md
@@ -1,5 +1,7 @@
 # Full-candles signals — all timeframes
 
+> ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
+
 This folder extends the Stage 1 / Stage 2 signal pipeline (previously run only on
 the **4h** candle file) to **all seven timeframes** shipped in the project-root
 `Full_Canldes_Data/` drop:


### PR DESCRIPTION
Owner decision 2026-08-22: market data lives only on the server; local trees deleted after a checksum-verified merge. Adds the authoritative map (exact paths, per-instrument coverage, env recipes, failure modes) and updates every live guidance doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)