### PR TITLE
Close research/legacy-18-baseline → single root (docs + CITATION 5.6.0)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
     given-names: Mulham
     orcid: "https://orcid.org/0009-0006-4432-798X"
     email: contact@mulhamfetna.com
-version: 5.2.0
-date-released: "2026-07-27"
+version: 5.6.0
+date-released: "2026-08-23"
 license: AGPL-3.0-or-later
 doi: "10.5281/zenodo.21473312"
 identifiers:

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,19 +1,21 @@
 ---
-name: legacy-18-baseline-start-here
-description: "Onboarding for the agent operating the legacy-18-baseline workstream — what this project is, what is already known, what is isolated and why, and the rules that are not negotiable. Read this completely before touching anything."
+name: project-start-here
+description: "Onboarding for any agent on this project (single root since 2026-08-23) — what this project is, what is already known, what is isolated and why, and the rules that are not negotiable. Read this completely before touching anything."
 type: onboarding
 date: 2026-08-03
-workstream: legacy-18-baseline
-branch: research/legacy-18-baseline
+workstream: legacy-18-baseline (CLOSED 2026-08-23 — merged to main, single root)
+branch: dev (feature branches → dev → main)
 ---
 
-# START HERE — `legacy-18-baseline` workstream
+# START HERE — the project onboarding (single root since 2026-08-23)
 
 > ⚠️ **Data location changed 2026-08-22:** market data lives ONLY on the server (`~/Mulham/wsg-i`, `~/Mulham/data_2010_1s`); the local checkout has NO data trees. Authoritative map: `docs/DATA-AND-KNOWLEDGE-MAP.md`.
 
-**You are one of two agents working on this project on this device, at the same time.** The other
-agent works in `/mnt/data/projects/trading` on branch `dev`. You work **only** here, in
-`/mnt/data/projects/trading/legacy18`, on branch `research/legacy-18-baseline`.
+> ✅ **One united root since 2026-08-23.** The `research/legacy-18-baseline` branch (eras 12–13: WS-FWD, data
+> unification, WS-LIVE-PARITY, WS-ORB) was merged `dev → main` as **v5.6.0** and deleted; the `legacy18`
+> worktree is retired. **All work now happens in `/mnt/data/projects/trading` on `dev`** (short-lived feature
+> branches off `dev`, PR → `dev` → `main`). Passages below that describe "this worktree" or "the other agent"
+> are kept as history of the isolation design; the isolation itself no longer exists.
 
 Read this whole file before running anything. It is short on purpose; the deep material is linked.
 
@@ -72,7 +74,7 @@ source .wsenv/env.sh
 
 | resource | isolated? | how |
 |---|---|---|
-| code checkout | ✅ | separate git worktree, branch `research/legacy-18-baseline` |
+| code checkout | (retired 2026-08-23) | was a separate worktree on `research/legacy-18-baseline`; now the single root `/mnt/data/projects/trading` on `dev` |
 | Python env | ✅ | `.venv/` here — use `$WS_PY`, never bare `python3` |
 | **L1 disk cache** | ✅ | `TMPDIR` → `/tmp/ws-legacy18` (sibling uses `/tmp/wsh_l1_cache`). **This is the one that would silently corrupt both workstreams.** See §4. |
 | Optuna studies | ✅ | `optimize/studies/` resolves from `__file__`, so the worktree separates it. `WSH_STORAGE_URL` is force-unset. |
@@ -128,7 +130,7 @@ by code.
    must be `scp`'d back and committed. **MARKET DATA is the exception since 2026-08-22: it lives ONLY
    on the server** (`docs/DATA-AND-KNOWLEDGE-MAP.md`); the local checkout has no data trees and must
    never grow them back.
-8. **Stay in this worktree.** Never switch branches or worktrees unless told to out loud.
+8. **Stay in the single root** (`/mnt/data/projects/trading`, branch `dev`). Never switch branches or create worktrees unless told to out loud.
 9. **Verify, don't assume.** Never conclude from truncated output. ⚠️ `| head -N` on a long run
    **SIGPIPEs the process**, and a filter that misses stderr hides the reason.
 10. **Everything you generate is a LOCAL FILE by default.** Do not publish, upload, email, or post
@@ -145,8 +147,9 @@ ssh amd-trading                      # 78.89.209.212 port 33362, user dev, key ~
 ```
 
 - 32 cores, 123 GB RAM, has numba. **Your local venv also has numba** (the sibling's does not) — see §8b.
-- Server checkout: `~/Mulham/code` — currently tracks `dev`. **You must not repoint it.** Create your
-  own checkout or worktree for this workstream.
+- Server checkout: `~/Mulham/code` — tracks `dev` (serves :8200 and, with the extended-root env, :8250).
+  `~/Mulham/earn1` (the research-branch worktree) was retired 2026-08-23. Do not create new server checkouts
+  without the owner's word.
 - Data root on the server (required, or ~32 tests fail as fake regressions):
   `WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data`
 - Server venv: `/home/dev/Mulham/.venv/bin/python3`

--- a/docs/DATA-AND-KNOWLEDGE-MAP.md
+++ b/docs/DATA-AND-KNOWLEDGE-MAP.md
@@ -10,7 +10,7 @@ internalize:
    must never grow them back. `roots.py` still *defaults* the data root to the checkout, so a
    local data-backed run fails with `FileNotFoundError` **by design** (the no-local-compute
    rule). That failure is not a bug in the code; it is the rule working.
-2. **Code, evidence and records live in git** (branches `research/legacy-18-baseline` →
+2. **Code, evidence and records live in git** (feature branches →
    `dev` → `main`) and are mirrored into server worktrees. "Local = source of truth" means
    *git*; "server = source of truth" means *data*. Never confuse the two.
 
@@ -26,11 +26,11 @@ archives verified) recorded on issue #176.
 |---|---|
 | host | `ssh amd-trading` (78.89.209.212 / LAN 192.168.50.62), user `dev`, 32 cores / 123 GB RAM, **no GPU** |
 | python | `/home/dev/Mulham/.venv/bin/python3` (numpy 2.4 · pandas 3.0 · optuna 4.9 · numba 0.65 · playwright + chromium-1228 in `~/.cache/ms-playwright`) |
-| code worktrees | `~/Mulham/code` = production checkout (serves dashboard **:8200**) · `~/Mulham/earn1` = `research/legacy-18-baseline` (branch dashboard **:8250**) · `~/Mulham/wsg-i` = the **data root** (also an old rsync checkout — ⚠️ its code is STALE, never run from it) |
+| code worktrees | `~/Mulham/code` = the ONE code checkout (tracks `dev`; serves **:8200** on the prod root and **:8250** on the extended root) · `~/Mulham/earn1` RETIRED 2026-08-23 (research branch merged to main v5.6.0) · `~/Mulham/wsg-i` = the **data root** (also an old rsync checkout — ⚠️ its code is STALE, never run from it) |
 | env for ANY data-backed run | `WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data WSH_16Y_ROOT=/home/dev/Mulham/data_2010_1s` |
 | env for the EXTENDED tape | `WSH_DATA_BASE=/home/dev/Mulham/wsg-i/FWD_EXTENDED WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/FWD_EXTENDED/data TMPDIR=/home/dev/Mulham/wsg-i/FWD_EXTENDED/tmp` |
 | optimizer storage | Postgres container `wsh-pg` at `127.0.0.1:55432`, creds `~/Mulham/wsg-i/pg.env` (⚠️ `get_all_study_summaries()` hangs — use `docker exec wsh-pg psql`) |
-| dashboards | :8200 prod (`~/Mulham/wsg-i/dash.sh refresh` / supervisor), :8250 branch (`cd ~/Mulham/earn1/subprojects/Parametric-Indicators && nohup env <vars> .venv python3 server.py --port 8250`) — **restart after any backend change**; kill by PORT, never `pkill` by name |
+| dashboards | :8200 prod (`~/Mulham/wsg-i/dash.sh refresh` / supervisor), :8250 extended-root (`cd ~/Mulham/code/subprojects/Parametric-Indicators && nohup env <extended-root vars> .venv python3 server.py --port 8250`) — **restart after any backend change**; kill by PORT, never `pkill` by name |
 | L1 disk cache | `$TMPDIR/wsh_l1_cache/*.pkl` — keyed on PARAMS, blind to data ⇒ **every distinct data root needs its own TMPDIR**; clear after any P/L-affecting change |
 
 ---
@@ -53,7 +53,7 @@ archives verified) recorded on issue #176.
 | ETF candles | `ALL_STOCKS/CANDLES/ETF/{QQQ,SQQQ}_Data/{ETH,RTH}/` | 2025-01-02 → 2026-05-19 | not in the 9-instrument engine; signal deliveries only |
 | Non-NQ boxes RAW (scraped) | `ALL_STOCKS/BOXS/<EXCH>/<TOK>/<TOK>_full_data.csv` (RTY/YM/ES/NQ/ETFs also have `_day/_week/_month`) | all 9 → **2026-08-07** (raw dates; ETF → 05-22) | raw = UNshifted (row D = levels built from session D−1). ⚠️ NQ's file is stored in the SHIFTED convention (never re-shifted). ⚠️ ES's file WAS delivered shifted and got shifted twice (#179) — corrected 2026-08-23 to raw convention (`.pre179` backup). NQ/ES `_day/_week/_month` keep old convention; the Aug export sits alongside as `*_aug2026.csv`. Pre-merge copies: `*.csv.pre179` |
 | Box export archive (2026-08-22 scrape) | `vendor_drops_local/last levels-20260823T103031Z-1-001.zip` (+ unzipped `last levels/FUTURES/<EXCH>/<TOK>/`) | 2026-05-18 → 08-07 raw, 60 rows × 9 | the drop merged by `optimize/fwd/fwd_merge_boxes.py` (gate E report in `optimize/fwd/data/fwd_box_merge_report.json`) |
-| Non-NQ boxes SHIFTED (engine reads) | **in the CODE checkout**: `subprojects/all-stocks-signals/shifted_boxes/<TOK>_full_data_shifted.csv` | → **2026-08-06** (= raw 08-07 shifted −1 business day) | produced by `subprojects/all-stocks-signals/onboard_stock.py`; travels with git, so `earn1`/`code` each carry a copy |
+| Non-NQ boxes SHIFTED (engine reads) | **in the CODE checkout**: `subprojects/all-stocks-signals/shifted_boxes/<TOK>_full_data_shifted.csv` | → **2026-08-06** (= raw 08-07 shifted −1 business day) | produced by `subprojects/all-stocks-signals/onboard_stock.py`; travels with git (the `code` checkout) |
 | bundle data snapshots | `bundle_data_all/` (9 inst, → 07-08) · `bundle_data_clng/` | frozen inputs of the shareable backtester bundles | do not use as the engine root |
 | delivery bundles | `<TOK>_SIGNALS_DELIVERY/` + `.zip` for CL ES GC HG NG RTY SI YM; zips only for NQ NQ2024 NQ2026L20 QQQ-ETH QQQ-RTH SQQQ-ETH SQQQ-RTH (at `wsg-i/` root) | — | customer-facing signal exports (WS-AS) |
 | vendor drop archives | `vendor_drops_local/*.zip` (HG/RTY/YM July drops, drive-download-20260710 ×2, silver-gold candles/levels) | — | the raw files the onboarding SOP consumed; keep for provenance |
@@ -143,7 +143,7 @@ decision-TF CSV, 1m CSV, box CSV (`optimize/data.py::load_inputs`).
 ```bash
 # any engine/champion run on PRODUCTION data
 ssh amd-trading
-cd ~/Mulham/earn1/subprojects/Parametric-Indicators     # or ~/Mulham/code/... for the released code
+cd ~/Mulham/code/subprojects/Parametric-Indicators      # the single code checkout (tracks dev)
 env WSH_DATA_BASE=/home/dev/Mulham/wsg-i WSG_DATA_ROOT=/home/dev/Mulham/wsg-i/data \
     WSH_16Y_ROOT=/home/dev/Mulham/data_2010_1s /home/dev/Mulham/.venv/bin/python3 <script>
 

--- a/docs/PROGRESS-RECORD.md
+++ b/docs/PROGRESS-RECORD.md
@@ -70,7 +70,7 @@ per-workstream full records. The one-line-each version:
 
 ## 3 · ACTIVE + QUEUED (the live board)
 
-**The board is QUIET AND GREEN (2026-08-23, post-WS-ORB)**: no active workstream, no
+**The board is QUIET AND GREEN (2026-08-23, post-WS-ORB; research branch merged to main as v5.6.0 and closed — ONE ROOT: `/mnt/data/projects/trading` on `dev`)**: no active workstream, no
 unverdicted study, no stale doc. Everything open is deliberate:
 
 - **Owner-side items (the only movers of new profit)**: the LIVE GATEWAY (all income is
@@ -115,7 +115,7 @@ committed file; `expect` values are never adjusted.
 - 1-second archive, 9 instruments, 2010→2026 (server `~/Mulham/data_2010_1s/`); **YM rebuilt
   from raw 2026-08-18** (was corrupt; its 0-byte 1m frame is fixed — YM fully studyable).
 - TradingView calendar (39,221 events, 649 series; usable ≥2016 — pre-2016 DST-broken).
-- Server: AMD box (123 GB), worktrees `~/Mulham/code`=dev · `~/Mulham/earn1`=legacy18;
+- Server: AMD box (123 GB), single checkout `~/Mulham/code`=dev (`earn1` retired 2026-08-23);
   dashboard :8200 production, :8250 branch; venv `data_2010_1s/venv` (scipy via `python3 -m
   pip`; its pip binary is broken).
 - Known traps live in the memory index and the full records (gitignore blanket rules,


### PR DESCRIPTION
Final PR from the research branch: guidance rewritten to the single-root state (START-HERE, DATA-AND-KNOWLEDGE-MAP, PROGRESS-RECORD), server `earn1` checkout retired, CITATION.cff → 5.6.0 / 2026-08-23. Next: dev → main as v5.6.0, branch deleted, worktree removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)