### PR TITLE
Amendment 1: the frozen-replay track record (+ replay_window.py) — clock starts at the next box drop

### DIFF
--- a/docs/LIVE-PROTOCOL.md
+++ b/docs/LIVE-PROTOCOL.md
@@ -71,10 +71,14 @@ out" a drawdown short of a §3 halt · no reading of dashboard counts that #196 
 - **Executor** (owner/team leader): runs the bot per §1, keeps the journal, executes fixes from #200.
 - **Referee** (this repo's machinery): parity runs, monthly claims, the ledger; CI keeps every number
   re-derivable.
-- **Mode: PAPER ONLY (owner decision 2026-08-31).** The run executes in paper mode on the project's own
-  deployment layer — no broker, no external executor, no real money. Every claim and report is labelled
-  paper. A later upgrade to a real account would be a dated amendment and starts a separate, clearly
-  labelled segment of the record.
+- **Mode: PAPER ONLY, FROZEN-REPLAY (owner decisions 2026-08-31; Amendment 1).** No broker, no external
+  executor, no real money, no daemon. The record grows event-driven from the owner's box drops: each drop
+  passes the gate-E merge INCLUDING the repaint audit against the previous scrape (the honesty seal), then
+  the engine replays the new window with the HASH-FROZEN champion set and allowlist — out-of-sample by
+  construction, because the parameters were pinned before the data existed. Fill convention = the engine's
+  own (gap-at-open, stop-first), stated in every claim. Every claim and report is labelled paper/replay.
+  A forward-running executor remains the documented upgrade if real money ever enters (its unique value —
+  intra-day operational proof and pre-outcome timestamps — only matters there).
 
 ## 8. Prerequisites before signature (the #194 board)
 - [x] #195 allowlist frozen (`LIVE-ALLOWLIST-FROZEN`)
@@ -82,8 +86,8 @@ out" a drawdown short of a §3 halt · no reading of dashboard counts that #196 
 - [x] #196 UI single-engine (`UI-TRADES-SINGLE-ENGINE`)
 - [x] #197 ES adopt/retain outcomes folded in — RETAIN ×6 (`ES197-RETAIN-ALL-SIX`); the deployed set and the allowlist are unchanged
 - [x] external-executor compliance — OUT OF SCOPE by owner decision 2026-08-31 (the external live system is separate from this project)
-- [ ] the in-repo PAPER executor exists and passes its pre-registered shadow-window verification before the clock starts (#213)
-- [ ] paper fill model pre-registered (#213) and written into §4 — in paper mode the 'slippage allowance' becomes the declared fill convention (engine fills), stated in every claim
+- [x] execution mode settled: FROZEN-REPLAY per Amendment 1 (#213 rescoped to the replay tooling; the daemon executor deferred to a real-money upgrade)
+- [x] fill convention declared: the engine's own (gap-at-open, stop-first) — Amendment 1
 - [x] owner decisions: PAPER ONLY; boxes on demand with the 35-day auto-pause guard (§2) — 2026-08-31
 
 ## 9. Signature
@@ -91,4 +95,14 @@ Owner: **Mulham Fetna** · Date: **2026-08-31** · signed in session ("paper onl
 Allowlist sha256[:16]: **40bc5de2b94fa1a4** · Protocol file hash: pinned as this file's git blob via claim `LIVE-PROTOCOL-SIGNED`
 
 ## 10. Amendments (dated, append-only)
-*(none)*
+
+**Amendment 1 — 2026-08-31 (owner: "do the replay version").** Execution mode changed from a
+forward-running paper executor to the **frozen-replay track record**: (cause) under paper-only +
+on-demand boxes, the executor's unique value collapses — the parameter set and allowlist are hash-pinned
+before any future data exists, and the gate-E overlap diff between consecutive scrapes audits the one
+remaining hindsight channel (box repaint; measured in Aug-2026: core levels identical on all 31 overlapping
+days). The replay version keeps ~all of the evidentiary strength at near-zero cost. Mechanics: per box
+drop — gate-E merge + repaint audit → replay of the 9 allowlist slots with the frozen set on the new
+window (window = entries after the previous frontier) → a `LIVE-WINDOW-<date>` ledger claim + report,
+judged by §5's rules. The clock starts at the NEXT box drop. The daemon executor is deferred, documented,
+and would return via a dated amendment only with a real-money upgrade.

--- a/subprojects/Parametric-Indicators/optimize/live/live_record_state.json
+++ b/subprojects/Parametric-Indicators/optimize/live/live_record_state.json
@@ -1,0 +1,11 @@
+{
+ "created": "2026-08-31 (signature-time frontier = the corrected boxes of #179)",
+ "frontier": {
+  "NQ": "2026-08-06",
+  "ES": "2026-08-06",
+  "GC": "2026-08-06",
+  "HG": "2026-08-06",
+  "NG": "2026-08-06"
+ },
+ "windows": []
+}

--- a/subprojects/Parametric-Indicators/optimize/live/replay_window.py
+++ b/subprojects/Parametric-Indicators/optimize/live/replay_window.py
@@ -1,0 +1,101 @@
+"""LIVE-PROTOCOL Amendment 1 — the frozen-replay track record (#213). Server-side, per box drop.
+
+    python3 optimize/live/replay_window.py --out <dir>            # after the drop passed fwd_merge_boxes
+
+Sequence (per docs/LIVE-PROTOCOL.md §7/A1): the owner's drop has ALREADY passed the gate-E merge with the
+repaint audit; this script then (1) verifies the allowlist hash against the signed protocol §9, (2) replays
+the 9 allowlist slots with the FROZEN champion set through the same causal path as every book, (3) cuts the
+new window = entries on days strictly after the previous frontier DATE (the frontier day itself belongs
+to the prior record) recorded in live_record_state.json, (4) writes
+books + a summary with raw/$10/$25 views, and (5) advances the frontier. Everything it writes is committed;
+each drop becomes a LIVE-WINDOW-<date> ledger claim. One contract; engine fills; paper/replay labelled.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+HERE = Path(__file__).resolve()
+PI = HERE.parents[2]
+sys.path.insert(0, str(PI))
+
+AL = PI / "optimize" / "live" / "live_allowlist.json"
+STATE = PI / "optimize" / "live" / "live_record_state.json"
+PROTO = PI.parents[1] / "docs" / "LIVE-PROTOCOL.md"
+COST = 25.0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--label", default=date.today().isoformat())
+    a = ap.parse_args()
+    out = Path(a.out).expanduser() / a.label
+    out.mkdir(parents=True, exist_ok=True)
+
+    # 1) the universe the owner signed, byte-for-byte
+    alh = hashlib.sha256(AL.read_bytes()).hexdigest()[:16]
+    m = re.search(r"Allowlist sha256\[:16\]: \*\*([0-9a-f]{16})\*\*", PROTO.read_text())
+    if not m or m.group(1) != alh:
+        raise SystemExit(f"ALLOWLIST HASH MISMATCH: protocol §9 {m.group(1) if m else None} vs file {alh} — "
+                         "the signed universe changed without an amendment; refusing to run")
+    slots = json.load(open(AL))["allowed"]
+    state = json.load(open(STATE))
+    prev_frontier = state["frontier"]
+
+    from optimize.l2 import payload as P
+    rows = []
+    for slot in slots:
+        tok, tf = slot.split("_")
+        champs = json.loads(P._instrument_champions_path(tok, "best").read_text())
+        l1p = P._champion_layer_params(tf, champs[tf])
+        view = P.build_view_payload(l1p, P._scaled_permissive(tok), tf, "l1", instrument=tok)
+        tr = pd.DataFrame(view["trades"])
+        if len(tr):
+            tr["et"] = pd.to_datetime(pd.to_numeric(tr["entry_time"]), unit="s")
+            w = tr[tr["et"].dt.normalize() > pd.Timestamp(prev_frontier[tok])]   # frontier DAY inclusive to the prior record
+        else:
+            w = tr
+        with open(out / f"lw_book_{slot}.csv", "w", newline="") as f:
+            cw = csv.DictWriter(f, fieldnames=["layer", "entry_time", "exit_time", "direction",
+                                               "entry_price", "exit_price", "exit_reason", "pnl"],
+                                extrasaction="ignore")
+            cw.writeheader()
+            for t in (w.drop(columns=["et"]).to_dict("records") if len(w) else []):
+                cw.writerow(t)
+        pnl = float(w["pnl"].sum()) if len(w) else 0.0
+        rows.append({"slot": slot, "n": int(len(w)), "raw": round(pnl, 2),
+                     "net10": round(pnl - 10.0 * len(w), 2), "net25": round(pnl - COST * len(w), 2),
+                     "window_start": prev_frontier[tok],
+                     "last_entry": str(w["et"].max()) if len(w) else None})
+        print(f"{slot}: n={len(w)} raw={pnl:,.2f} net25={pnl - COST*len(w):,.2f}", flush=True)
+
+    # 3) advance the frontier to each instrument's current box end (the engine's decision frame end)
+    from optimize import data as D
+    new_frontier = dict(prev_frontier)
+    for tok in sorted({s.split("_")[0] for s in slots}):
+        df_dec, _, box, _, _ = D.load_inputs("4h", instrument=tok)
+        new_frontier[tok] = str(pd.to_datetime(box["Date"]).max().date())
+    summary = {"label": a.label, "mode": "paper/frozen-replay (LIVE-PROTOCOL A1)",
+               "allowlist_sha16": alh, "prev_frontier": prev_frontier, "new_frontier": new_frontier,
+               "cost_rt": COST, "slots": rows,
+               "fleet": {"n": sum(r["n"] for r in rows), "raw": round(sum(r["raw"] for r in rows), 2),
+                          "net10": round(sum(r["net10"] for r in rows), 2),
+                          "net25": round(sum(r["net25"] for r in rows), 2)}}
+    (out / "live_window_summary.json").write_text(json.dumps(summary, indent=1))
+    state["frontier"] = new_frontier
+    state["windows"] = state.get("windows", []) + [{"label": a.label, "fleet": summary["fleet"]}]
+    STATE.write_text(json.dumps(state, indent=1))
+    print(json.dumps(summary["fleet"]), "->", out / "live_window_summary.json", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/subprojects/Parametric-Indicators/optimize/verify/claims_protocol.py
+++ b/subprojects/Parametric-Indicators/optimize/verify/claims_protocol.py
@@ -31,26 +31,27 @@ def _v1() -> tuple[bool, str]:
 
 
 def _v2() -> tuple[bool, str]:
-    """V2 — EXACTLY ONE GATE LEFT: §8's prerequisite boxes are all checked except the paper executor
-    (#213) and its fill-model line — the clock is blocked by nothing else."""
+    """V2 — NO GATE LEFT: after Amendment 1 every §8 prerequisite box is checked; the track-record clock
+    starts at the next box drop (nothing blocks it but the owner's own scrape)."""
     s = _txt()
     sec = s.split("## 8.")[1].split("## 9.")[0]
     done = len(re.findall(r"- \[x\]", sec))
     open_ = re.findall(r"- \[ \] ([^\n]+)", sec)
-    ok = done >= 5 and len(open_) == 2 and all("#213" in o or "paper fill model" in o for o in open_)
-    return ok, f"{done} done; open: {[o[:50] for o in open_]}"
+    ok = done >= 7 and len(open_) == 0
+    return ok, f"{done} done; open: {len(open_)}"
 
 
 def _v3() -> tuple[bool, str]:
-    """V3 — FALSIFIER (the law is falsifiable): the amendments section is EMPTY at signature (any later
-    change must appear there or V1/V2 flip), the never-list is present with its seven prohibitions, and
-    the mode is PAPER ONLY with the on-demand box guard — the two owner decisions verbatim."""
+    """V3 — FALSIFIER (changes only through the amendment door): exactly ONE amendment exists, dated and
+    attributed (Amendment 1, the owner's replay decision), and the amended mode line cross-references it;
+    the never-list stands. A silent edit anywhere shows up as content without an amendment entry."""
     s = _txt()
     amend = s.split("## 10.")[1]
-    ok = ("*(none)*" in amend and "## 6. The never-list" in s
-          and "PAPER ONLY (owner decision 2026-08-31)" in s
+    n_amend = len(re.findall(r"\*\*Amendment \d+ — ", amend))
+    ok = (n_amend == 1 and '"do the replay version"' in amend and "## 6. The never-list" in s
+          and "FROZEN-REPLAY (owner decisions 2026-08-31; Amendment 1)" in s
           and "on demand** (owner decision 2026-08-31" in s)
-    return ok, "amendments empty; never-list present; paper-only + on-demand boxes recorded"
+    return ok, f"amendments {n_amend} (dated, attributed); mode cross-references A1; never-list present"
 
 
 def _n_signed() -> float:
@@ -64,8 +65,8 @@ register(Claim(
               "deployment layer; the 9-slot allowlist bound by hash; 1 contract; engine exits; frozen "
               "gates; boxes scraped on demand with a 35-day auto-pause guard carrying the staleness risk; "
               "mechanical kill rules; monthly reconciliation with failed months flagged; no verdict before "
-              "6 months; a seven-item never-list. One gate remains before the track-record clock: the "
-              "paper executor and its pre-registered shadow-window verification (#213).",
+              "6 months; a seven-item never-list. The clock starts at the "
+              "next box drop (Amendment 1: frozen-replay mode; no executor, no gate remains).",
     source="docs/LIVE-PROTOCOL.md + optimize/live/live_allowlist.json",
     value_fn=_n_signed,
     expect=1.0,


### PR DESCRIPTION
Owner decision in session ('do the replay version'). Protocol §7/§8/§10 amended (dated, attributed); LIVE-PROTOCOL-SIGNED claim now pins: zero gates left, exactly one dated amendment, mode cross-referenced. `replay_window.py`: refuses to run on an allowlist-hash mismatch with §9, replays the 9 frozen slots per drop, cuts strictly after the frontier day, advances the committed state. Smoke on the server: mechanics green, fleet n=0 (no data beyond the signature-time frontier 2026-08-06) — the record starts with the owner's next scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)