### PR TITLE
#217: v5.7.0 version DOI into CITATION.cff + README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,9 @@ identifiers:
     value: "10.5281/zenodo.22161256"
     description: "The v5.6.0 version DOI (2026-08-29)."
   - type: doi
+    value: "10.5281/zenodo.22212233"
+    description: "The v5.7.0 version DOI (2026-08-31)."
+  - type: doi
     value: "10.5281/zenodo.21473313"
     description: "The v5.0.0 version DOI."
   - type: doi

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ per release via Zenodo (badge above).
 
 ```
 Fetna, M. (2026). Trading Strategy Finder: a reproducible quantitative-analysis framework for futures
-trading-strategy discovery and validation (Version 5.6.0) [Software]. Zenodo.
-https://doi.org/10.5281/zenodo.22161256
+trading-strategy discovery and validation (Version 5.7.0) [Software]. Zenodo.
+https://doi.org/10.5281/zenodo.22212233
 ```
 
-Cite the **version you actually used** (the DOI above is v5.6.0). To cite the project in general — always
+Cite the **version you actually used** (the DOI above is v5.7.0). To cite the project in general — always
 resolving to the newest release — use the concept DOI **`10.5281/zenodo.21473312`**. Every version DOI is
 listed in [`CITATION.cff`](CITATION.cff).


### PR DESCRIPTION
Zenodo minted 10.5281/zenodo.22212233 for release v5.7.0 (concept DOI unchanged). Closes the Tier-1 loop (#217, board #216; #201 executed by the release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)