### PR TITLE
#218: JOSS 2026-format paper + compile action + CONTRIBUTING

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,0 +1,25 @@
+name: JOSS draft PDF
+on:
+  push:
+    paths:
+      - paper/**
+      - .github/workflows/draft-pdf.yml
+  workflow_dispatch:
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          paper-path: paper/paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          path: paper/paper.pdf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Contributions are welcome — issues and pull requests both. This project has an unusual operating
+contract, so please read two documents before writing code:
+
+1. **[`AGENTS.md`](AGENTS.md)** — the working rules of this repository (branch/PR flow, worktree
+   discipline, verification duties). They apply to human and AI contributors alike.
+2. **The verification standard:** every published number in this project is a claim in the ledger
+   (`subprojects/Parametric-Indicators/optimize/verify/`). If your change alters a published
+   number, the corresponding claim and its committed evidence must change in the same PR — CI
+   replays the full ledger and will reject silent divergence.
+
+## The short version
+
+- **Open an issue first** describing what you intend to change; work happens on a
+  `feat/<issue>-<slug>` branch and lands via PR into `dev` (integration), then `main`.
+- **Tests must pass without market data.** The engine suite runs green on a fresh clone
+  (`cd subprojects/Parametric-Indicators && pytest`); data-dependent tests skip themselves. Price
+  data are never committed — the pipeline runs against a user-supplied feed.
+- **CI is the gate:** byte-compile, import smoke, engine-parity (fast vs exact engines must agree
+  trade-for-trade), and the claims-ledger replay are required checks on `dev` and `main`.
+- **Research contributions** (new studies, strategy families, instruments) additionally follow the
+  pre-registration discipline: design filed before results are computed, negatives carry power
+  analyses, positives carry dumb controls and noise checks. See `docs/` for filed examples.
+
+## License
+
+By contributing you agree that your contributions are licensed under
+[AGPL-3.0-or-later](LICENSE).

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -30,3 +30,44 @@
   year    = {2000},
   doi     = {10.1111/1468-0262.00152}
 }
+
+@misc{backtrader,
+  author = {Rodr{\'i}guez, Daniel},
+  title  = {backtrader: Python backtesting library for trading strategies},
+  year   = {2015},
+  url    = {https://github.com/mementum/backtrader}
+}
+
+@misc{zipline,
+  author = {{Quantopian, Inc. and contributors}},
+  title  = {Zipline: a Pythonic algorithmic trading library},
+  year   = {2012},
+  url    = {https://github.com/quantopian/zipline}
+}
+
+@misc{vectorbt,
+  author = {Polakow, Oleg},
+  title  = {vectorbt: getting into the vectorized backtesting},
+  year   = {2019},
+  url    = {https://github.com/polakowo/vectorbt}
+}
+
+@inproceedings{optuna,
+  author    = {Akiba, Takuya and Sano, Shotaro and Yanase, Toshihiko and Ohta, Takeru and Koyama, Masanori},
+  title     = {Optuna: A Next-generation Hyperparameter Optimization Framework},
+  booktitle = {Proceedings of the 25th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining},
+  year      = {2019},
+  pages     = {2623--2631},
+  doi       = {10.1145/3292500.3330701}
+}
+
+@article{nosek2018preregistration,
+  author  = {Nosek, Brian A. and Ebersole, Charles R. and DeHaven, Alexander C. and Mellor, David T.},
+  title   = {The preregistration revolution},
+  journal = {Proceedings of the National Academy of Sciences},
+  volume  = {115},
+  number  = {11},
+  pages   = {2600--2606},
+  year    = {2018},
+  doi     = {10.1073/pnas.1708274114}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,4 +1,3 @@
-
 ---
 title: 'Trading Strategy Finder: a machine-verified, pre-registered research framework for futures trading strategies'
 tags:
@@ -18,72 +17,111 @@ authors:
 affiliations:
   - name: BeInMedia (Nmo AI), Kuwait City, Kuwait
     index: 1
-date: 2026-09-01
+date: 1 September 2026
 bibliography: paper.bib
 ---
 
 # Summary
 
-Trading Strategy Finder is a Python research framework for discovering and — more importantly —
-*honestly validating* futures trading strategies. It combines a parity-locked pair of backtest
-engines (a fast vectorized engine and an exact reference engine that must agree trade-for-trade),
-a multi-objective optimizer (NSGA-III via Optuna) over a 165-indicator signal registry,
-walk-forward fold evaluation, stressed transaction-cost reporting, and a governance layer that is
-the project's distinctive contribution: a **machine-verified claims ledger**. Every number the
-project publishes is a claim with three independent verifications that must fail for different
-reasons, a declared blind spot, and committed evidence files; `optimize/verify/run.py` re-derives
-all 79 current claims offline, with no market data, and continuous integration blocks any change
-that breaks one. Studies are pre-registered before they run; negative results carry mandatory power
-analyses; positive results require dumb controls and noise checks; and the live track record is
-out-of-sample by construction, because the deployed parameter set and trading universe are
-hash-frozen under a signed, amendment-only protocol before new data exists.
+Trading Strategy Finder is a Python framework for researching trading strategies on futures
+markets — and, centrally, for making the *claims* that come out of that research trustworthy. It
+provides backtesting engines, a multi-objective strategy optimizer, and walk-forward evaluation,
+like other backtesting tools. Its distinctive contribution is a governance layer: a
+**machine-verified claims ledger** in which every number the project publishes exists as an
+executable claim — the number is re-derived live from the committed evidence files that produced
+it, checked by three independent verifications that must fail for different reasons (one of them a
+falsification test), and accompanied by a mandatory declared blind spot. All 79 current claims
+replay offline in minutes with no market data, continuous integration blocks any change that breaks
+one, and a self-test replays five real historical defects and requires the harness to reject each
+one for the right reason. Around the ledger, the framework operationalizes pre-registration with
+append-only amendments, mandatory power analysis for negative results, dumb controls and noise
+checks for positive ones, stressed transaction-cost reporting, and a live track record whose
+parameters are hash-frozen under a signed protocol before evaluation data exists — making it
+out-of-sample by construction.
 
 # Statement of need
 
-Backtest research has a well-documented false-positive problem: selection among many implicit
-trials, small per-trade effects, and cost assumptions that decide the sign of a result
-[@bailey2014pseudo; @harvey2016cross; @white2000reality]. General scientific tooling for
-pre-registration does not integrate with trading research pipelines, and popular open-source
-backtesters (e.g., Backtrader, Zipline, vectorbt) provide simulation but no *verification
-governance*: nothing in them prevents the researcher from silently re-running until something
-works. Trading Strategy Finder addresses that gap. The framework's studies of opening-range
-breakout (a pre-registered 225-cell, 16-year null), scheduled macroeconomic news, and forward
-out-of-sample decay are all replayable by third parties from committed evidence, and the full
-pipeline re-runs against any user-supplied one-minute data feed — market data are deliberately
-external to the repository, so the software is data-vendor-neutral. The intended audience is
-quantitative-finance researchers, reproducibility researchers, and practitioners who need an
-auditable standard of evidence for strategy claims.
+Trading-strategy research has a structural false-positive problem: the researcher controls the
+number of trials, the cost assumptions, and the stopping rule, and effects are small relative to
+per-trade noise. The methodology literature has quantified the damage — data-snooping reversals
+[@white2000reality], the probability of backtest overfitting [@bailey2014pseudo], and
+multiple-testing haircuts across published anomalies [@harvey2016cross] — but the remedies remain
+conventions enforced by the same person they constrain. Researchers who want to hold themselves to
+a pre-registration standard in this domain currently have no tooling that *binds* their published
+numbers to the artifacts that produced them, forces negatives to state their statistical power, or
+mechanically prevents the quiet edit of an evidence file. Trading Strategy Finder exists to close
+that gap. Its target audience is quantitative-finance researchers, reproducibility researchers, and
+practitioners who need an auditable standard of evidence for strategy claims. Market data are
+deliberately external to the repository: the pipeline runs against any user-supplied one-minute
+data feed, so the framework is data-vendor-neutral, and no data at all are needed to verify any
+published claim.
 
-# Functionality
+# State of the field
 
-- **Engines:** causal box-strategy backtester with conservative fill conventions (gap-through fills
-  at the bar open, stop-first within a bar), an accelerated engine parity-locked to it, and golden
-  regression gates.
-- **Optimization:** multi-objective search (Optuna/NSGA-III) with walk-forward folds, feasibility
-  constraints, and budget conventions; PostgreSQL-backed studies.
-- **Verification:** the claims ledger (79 claims, three verifications + blind spot each, evidence
-  required to be git-tracked), a self-test that replays five historical defects, and data-free CI
-  (byte-compile, import smoke, engine parity, full ledger) required on protected branches.
-- **Protocolized live record:** a signed protocol with a rule-derived instrument allowlist, frozen
-  parameters, repaint audits between data drops, and append-only amendments.
-- **Reporting:** dashboards and full-book reports with raw/\$10/\$25 stressed-cost views.
+Mature open-source backtesting frameworks — Backtrader [@backtrader], Zipline
+[@zipline], and vectorbt [@vectorbt], among others — provide event-driven or vectorized
+simulation, portfolio accounting, and performance metrics, and QuantConnect's LEAN provides the
+same as a hosted platform. All of them answer "what would this strategy have earned?"; none of them
+constrain *how the researcher reports the answer*. Nothing in these tools prevents silent re-runs
+until something works, headline results at zero cost assumptions, or negatives discarded without a
+power analysis. On the governance side, general pre-registration infrastructure (e.g., the Open
+Science Framework [@nosek2018preregistration]) records intent but does not integrate with a
+computational pipeline: it cannot re-derive a published number from evidence or fail a build when a
+claim breaks. Trading Strategy Finder occupies the intersection: simulation *plus* enforced
+verification governance. We know of no other public trading-research codebase in which every
+published number is a CI-enforced, falsifier-carrying, machine-replayable claim.
 
-The engine test suite runs green on a fresh clone with no market data (data-dependent tests skip
-themselves), which is also how the JOSS reviewer can exercise the software.
+# Software design
 
-# Author contributions
+Three design decisions carry the framework. **First, verification is a data structure, not a
+document.** A claim is an object binding a statement, its evidence-file paths, an executable
+`value_fn` re-deriving the headline number within an explicit tolerance, three verifications
+required to fail for different reasons, and a non-empty blind-spot declaration; structural rules
+reject claims whose evidence is not version-controlled. This makes "the paper says X" a testable
+proposition forever, at the cost of authorship overhead per claim — a trade-off we accept because
+exploratory work may run unregistered but is unpublishable until registered. **Second, the engines
+are redundant on purpose.** A fast vectorized engine and an exact reference engine are
+parity-locked (they must agree trade-for-trade in CI) so that speed optimizations can never
+silently change results — the parity suite runs data-free on synthetic sessions. **Third, the
+framework distrusts its own gates.** A self-test replays five real historical defects from the
+project's past — including a claim verified against notes rather than its producing artifact, and a
+unit-drift defect — and requires each to be rejected *for the matching reason*, treating
+rejection-by-crash as failure; this exists because the gate once passed for the wrong reason.
+Optimization (NSGA-III via Optuna [@optuna]) writes to PostgreSQL studies with never-reused
+prefixes, so failed campaigns remain on the record.
 
-M.F.: conceptualization, methodology, software, validation, formal analysis, investigation, data
-curation, visualization, project administration, writing. A.U.E.: conceptualization, data curation,
-supervision.
+# Research impact statement
 
-# Acknowledgments
+The framework is the instrument of an active 18-month research programme whose outputs are public
+and re-derivable: two companion research papers submitted in 2026 — a pre-registered 225-cell,
+16-year null result on opening-range breakout, and a methodology paper on the claims ledger itself
+— draw every number from this repository's evidence files via the ledger, and both are reproducible
+by third parties without any market data (`python3 optimize/verify/run.py`, 79/79 claims). The
+software is versioned and archived with DOIs on Zenodo (concept DOI 10.5281/zenodo.21473312, eight
+released versions to date), is deployed in production research use at BeInMedia, and operates a
+signed, hash-frozen live evaluation protocol whose windows accumulate as new ledger claims —
+a public, out-of-sample-by-construction track record that external researchers can audit
+continuously. The verification pattern (claims with falsifiers and blind spots, defect-replay
+self-tests, evidence-tracking rules) is domain-portable and documented for reuse beyond finance.
 
-This software was developed at **BeInMedia (Nmo AI)** (Kuwait • Dubai • Doha,
-https://www.beinmedia.com/), which provided the research infrastructure, computing resources, and
-data licensing. Substantial portions of the codebase were developed with the assistance of AI
-coding agents operating under the authors' direction; all results are gated by the pre-registered
-claims ledger and CI described above.
+# AI usage disclosure
+
+Generative AI was used substantially in this project, under human direction, and the framework's
+governance was designed with that in mind. AI coding agents (Anthropic Claude-family models,
+operated through the Claude Code environment) wrote large portions of the codebase, documentation,
+and analysis pipeline, and assisted in drafting this paper. The human authors set the research
+questions, made all core design decisions (the claim schema, engine parity, pre-registration and
+verdict rules, the live protocol), reviewed the agents' outputs, and signed every pre-registration
+and protocol decision. Independently of that review, correctness is enforced mechanically rather
+than assumed: all AI-produced changes pass the same CI gates as any contribution — byte-compilation,
+import smoke tests, engine-parity checks, and the full claims-ledger replay — and no result is
+publishable except as a ledger claim with its falsifier. The defect-replay self-test described
+above guards the verification layer itself.
+
+# Acknowledgements
+
+This software was developed at BeInMedia (Nmo AI) — Kuwait, Dubai, and Doha
+(https://www.beinmedia.com/) — which provided the research infrastructure, computing resources,
+and data licensing that made the project possible.
 
 # References
-


### PR DESCRIPTION
JOSS updated its scope/requirements (2026): paper.md now requires Summary / Statement of need / State of the field / Software design / Research impact statement / AI usage disclosure / Acknowledgements / References, 750–1750 words — rewritten accordingly (1,136 words), bib extended (backtrader/zipline/vectorbt/optuna/OSF-prereg). Adds the official openjournals draft-PDF action (their recommended compile check) and a CONTRIBUTING.md (on JOSS's pre-review screening list). NOTE: JOSS submission itself WAITS until 2026-11-13 — the repo (created 2026-05-13) must show a 6-month public history at pre-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)