### PR TITLE
#226 phase 2: codebase labelling — every top-level dir explained, era-marked in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ modelling, and a discipline of pre-registered, power-analysed, cross-instrument-
 | `subprojects/Parametric-Indicators/docs/superpowers/` | The research reports — every verdict, discovery, and honest retraction (news "priced in", gap-aware fills, the Asia-cell fluke, …). |
 | `subprojects/Parametric-Indicators/DAILY_REPORTS.md` | The running standup. |
 | `docs/` | Workflow proposals and long-form references. Era-expired documents are kept under era-labelled names (e.g. `START-HERE-2026-08-legacy18-onboarding.md`) and `docs/archive/` — historical record, not current instructions. **`docs/POSITIONING.md`** — where this work sits in the field, rung by rung, each cell linked to its evidence; `docs/POSITIONING-AUDIT-2026-08-29.md` — the measured audit behind it. |
-
 | `src/deploy/` | **The live deployment layer** — the news-release executor (`release_executor.py`, v5.3.0–v5.4.2), the deployed power-forecast model (`power_forecast.py`, v5.4.3), the regime monitor and its schedule. The only code that touches an account. Covered by the 157-test root suite. |
+| `deploy_out_d3/`, `deploy_out_d4/` | **Live output directories** of the deployment layer (events/results per instrument). Written by `src/deploy/` — do not move or rename. |
+| `src/api|data|optimization|strategy/`, `scripts/`, `templates/` | **The frozen v1-era stack** (May 2026): the original API, data pipeline, optimizer and strategy code plus its two prep scripts and dashboard template. Frozen — no new work lands here — but still wired together and covered by the root test suite, so it stays runnable. |
+| `frontend/` | **The v1-era dashboard UI** (Vue + Vite, frozen May 2026; `npm install && npm run dev`, backend = `src/api`). The current research dashboard lives in the engine, not here. |
+| `tests/` | The root suite (157 tests): `src/` incl. the live deploy layer + workflow guards. Green without market data. |
+| `playbooks/` | The champion playbooks (37 PDFs) + the portable backtest bundle that reproduces them. |
+| `paper/` | The JOSS software paper (`paper.md` + `paper.bib`); compiled by the "JOSS draft PDF" action. |
 | `subprojects/Parametric-Indicators/shareable/`, `server-audit/` | **Snapshots, not live code** — hand-off bundles and the harvested server archive (#94). Each carries its own README saying so. |
 
-The frozen **v1.x** era (`src/main/`) is preserved under the `v1.0.0` / `v1.0-working` tags.
+The **v1.x era** is preserved two ways: the tagged releases `v1.0.0` / `v1.0-working`, and the frozen
+v1 stack above (kept importable and test-covered rather than deleted).
 
 ## Two tiers of reproducibility (read this before judging the numbers)
 

--- a/deploy_out_d3/README.md
+++ b/deploy_out_d3/README.md
@@ -1,0 +1,4 @@
+# deploy_out_d3/ — LIVE output directory (do not move or rename)
+
+Written by the deployed layer in `src/deploy/` (per-instrument events + results). The path is
+referenced by deployed code; contents are runtime artifacts of the live/paper deployment.

--- a/deploy_out_d4/README.md
+++ b/deploy_out_d4/README.md
@@ -1,0 +1,4 @@
+# deploy_out_d4/ — LIVE output directory (do not move or rename)
+
+Written by the deployed layer in `src/deploy/` (per-instrument events + results). The path is
+referenced by deployed code; contents are runtime artifacts of the live/paper deployment.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,6 @@
+# frontend/ — v1-era dashboard UI (FROZEN, May 2026)
+
+The original Vue 3 + Vite dashboard of the v1 stack (`npm install && npm run dev`; backend =
+`src/api/app.py`). Frozen since 2026-05-26 — no new work lands here; kept runnable as part of the
+preserved v1 era (see the root README's "What's here"). The **current** research dashboard lives in
+`subprojects/Parametric-Indicators/` and is served from the compute server.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,5 @@
+# scripts/ — v1-era data-prep scripts (FROZEN, May 2026)
+
+`preprocess_boxes.py` and `split_data_by_year.py` belong to the frozen v1 stack (referenced by
+`src/api` / `src/strategy`, covered by the root test suite). Not used by the current engine — its
+tooling lives under `subprojects/Parametric-Indicators/`. Kept so the v1 era stays runnable.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,4 @@
+# templates/ — v1-era dashboard template (FROZEN, May 2026)
+
+`ultimate_dashboard.html.tpl` is rendered by the frozen v1 stack (`src/api/app.py`). Not used by
+the current engine dashboard. Kept so the v1 era stays runnable.


### PR DESCRIPTION
Owner-approved approach: LABEL, DON'T MOVE (the v1 stack is frozen but wired + test-covered; deploy_out_* are live I/O). README 'What's here' now covers every tracked top-level dir, fixes the broken table split, and corrects the stale 'src/main' claim (no such dir — the v1 stack is src/{api,data,optimization,strategy}+scripts+templates+frontend, kept importable and test-covered). Five in-dir READMEs state era/status. Zero code changes; root suite verified after: 131 passed / 26 skipped (data-absent) / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)